### PR TITLE
Encode Time with milliseconds. From Rethinkdb docs: Times are stored on ...

### DIFF
--- a/encoding/encoder_types.go
+++ b/encoding/encoder_types.go
@@ -264,7 +264,7 @@ func timePseudoTypeEncoder(v reflect.Value) interface{} {
 
 	return map[string]interface{}{
 		"$reql_type$": "TIME",
-		"epoch_time":  t.Unix(),
+		"epoch_time":  float64(t.UnixNano())/1000/1000/1000, //milliseconds
 		"timezone":    "+00:00",
 	}
 }


### PR DESCRIPTION
...the server as seconds since epoch (UTC) with millisecond precision plus a time zone.
