### PR TITLE
Fix struct alignment for ARM and x86-32 builds

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -28,6 +28,7 @@ type Response struct {
 type Connection struct {
 	conn    net.Conn
 	opts    *ConnectOpts
+	_       [4]byte
 	token   int64
 	cursors map[int64]*Cursor
 	bad     bool
@@ -164,6 +165,7 @@ func (c *Connection) sendQuery(q Query) error {
 // getToken generates the next query token, used to number requests and match
 // responses with requests.
 func (c *Connection) nextToken() int64 {
+	// requires c.token to be 64-bit aligned on ARM
 	return atomic.AddInt64(&c.token, 1)
 }
 


### PR DESCRIPTION
atomic.AddInt64 requires struct fields to be 64-bit aligned on x86-32 and ARM architectures. The token field of the Connection struct was not aligned and thus resulted in a nil pointer dereference. See the documentation on the Atomic package for reference: https://golang.org/src/sync/atomic/doc.go#L50
