### PR TITLE
Cursor.IsNil(): removed duplicate if block

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -279,10 +279,6 @@ func (c *Cursor) IsNil() bool {
 			return true
 		}
 
-		if bufferedItem == nil {
-			return true
-		}
-
 		return false
 	}
 


### PR DESCRIPTION
Removed a duplicate if block in the Cursor.IsNil() method.
