### PR TITLE
fix: refactored tests dependant on float assertion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 *.a
 *.so
 
+#vim
+*.swp
+*.swo
+
 # Folders
 _obj
 _test

--- a/README.md
+++ b/README.md
@@ -207,6 +207,36 @@ func (a A) FieldMap() map[string]string {
 }
 ```
 
+## Benchmarks
+
+Everyone wants their project's benchmarks to be speedy. And while we know that rethinkDb and the gorethink driver are quite fast, our primary goal is for our benchmarks to be correct. They are designed to give you, the user, an accurate picture of writes per second (w/s). If you come up with a accurate test that meets this aim, submit a pull request please. 
+
+| Type    |  Value   |
+| --- | --- |
+| **Model Name** | MacBook Pro |
+| **Model Identifier** | MacBookPro11,3 |
+| **Processor Name** | Intel Core i7 | 
+| **Processor Speed** | 2.3 GHz | 
+| **Number of Processors** | 1 |
+| **Total Number of Cores** | 4 |
+| **L2 Cache (per Core)** | 256 KB | 
+| **L3 Cache** | 6 MB | 
+| **Memory** | 16 GB |
+
+```bash
+BenchmarkBatch200RandomWrites                20                              557227775                     ns/op
+BenchmarkBatch200RandomWritesParallel10      30                              354465417                     ns/op
+BenchmarkBatch200SoftRandomWritesParallel10  100                             761639276                     ns/op
+BenchmarkRandomWrites                        100                             10456580                      ns/op
+BenchmarkRandomWritesParallel10              1000                            1614175                       ns/op
+BenchmarkRandomSoftWrites                    3000                            589660                        ns/op
+BenchmarkRandomSoftWritesParallel10          10000                           247588                        ns/op
+BenchmarkSequentialWrites                    50                              24408285                      ns/op
+BenchmarkSequentialWritesParallel10          1000                            1755373                       ns/op
+BenchmarkSequentialSoftWrites                3000                            631211                        ns/op
+BenchmarkSequentialSoftWritesParallel10      10000                           263481                        ns/op
+```
+
 ## Examples
 
 View other examples on the [wiki](https://github.com/dancannon/gorethink/wiki/Examples).

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,288 @@
+package gorethink
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+var bSess *Session
+var bDbName string
+var bTableName string
+
+func BenchmarkBatch200RandomWrites(b *testing.B) {
+
+	var term Term
+	var data []map[string]interface{}
+
+	for i := 0; i < b.N; i++ {
+
+		for is := 0; is < 200; is++ {
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			cid := map[string]interface{}{
+				"customer_id": strconv.FormatInt(r.Int63(), 10),
+			}
+			data = append(data, cid)
+		}
+
+		// Insert the new item into the database
+		term = Table(bTableName).Insert(data)
+
+		// Insert the new item into the database
+		_, err := term.RunWrite(bSess, RunOpts{
+			MinBatchRows: 200,
+			MaxBatchRows: 200,
+		})
+		if err != nil {
+			b.Errorf("insert failed [%s] ", err)
+		}
+	}
+
+}
+
+func BenchmarkBatch200RandomWritesParallel10(b *testing.B) {
+
+	var term Term
+	var data []map[string]interface{}
+
+	b.SetParallelism(10)
+
+	b.RunParallel(func(pb *testing.PB) {
+
+		for pb.Next() {
+			for is := 0; is < 200; is++ {
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				cid := map[string]interface{}{
+					"customer_id": strconv.FormatInt(r.Int63(), 10),
+				}
+				data = append(data, cid)
+			}
+
+			// Insert the new item into the database
+			term = Table(bTableName).Insert(data)
+
+			// Insert the new item into the database
+			_, err := term.RunWrite(bSess, RunOpts{
+				MinBatchRows: 200,
+				MaxBatchRows: 200,
+			})
+			if err != nil {
+				b.Errorf("insert failed [%s] ", err)
+			}
+		}
+	})
+
+}
+
+func BenchmarkBatch200SoftRandomWritesParallel10(b *testing.B) {
+
+	var term Term
+	var data []map[string]interface{}
+
+	b.SetParallelism(10)
+
+	b.RunParallel(func(pb *testing.PB) {
+
+		for pb.Next() {
+
+			opts := InsertOpts{Durability: "soft"}
+
+			for is := 0; is < 200; is++ {
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				cid := map[string]interface{}{
+					"customer_id": strconv.FormatInt(r.Int63(), 10),
+				}
+				data = append(data, cid)
+			}
+
+			// Insert the new item into the database
+			term = Table(bTableName).Insert(data, opts)
+
+			// Insert the new item into the database
+			_, err := term.RunWrite(bSess, RunOpts{
+				MinBatchRows: 200,
+				MaxBatchRows: 200,
+			})
+			if err != nil {
+				b.Errorf("insert failed [%s] ", err)
+			}
+		}
+	})
+
+}
+
+func BenchmarkRandomWrites(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		data := map[string]interface{}{
+			"customer_id": strconv.FormatInt(r.Int63(), 10),
+		}
+		// Insert the new item into the database
+		_, err := Table(bTableName).Insert(data).RunWrite(bSess)
+		if err != nil {
+			b.Errorf("insert failed [%s] ", err)
+		}
+	}
+
+}
+
+func BenchmarkRandomWritesParallel10(b *testing.B) {
+
+	// p*GOMAXPROCS
+	b.SetParallelism(10)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			data := map[string]interface{}{
+				"customer_id": strconv.FormatInt(r.Int63(), 10),
+			}
+			// Insert the new item into the database
+			_, err := Table(bTableName).Insert(data).RunWrite(bSess)
+			if err != nil {
+				b.Errorf("insert failed [%s] ", err)
+			}
+		}
+	})
+
+}
+
+func BenchmarkRandomSoftWrites(b *testing.B) {
+
+	for i := 0; i < b.N; i++ {
+		data := map[string]interface{}{
+			"customer_id": strconv.FormatInt(rand.Int63(), 10),
+		}
+		// Insert the new item into the database
+		opts := InsertOpts{Durability: "soft"}
+		_, err := Table(bTableName).Insert(data, opts).RunWrite(bSess)
+		if err != nil {
+			b.Errorf("insert failed [%s] ", err)
+		}
+	}
+
+}
+
+func BenchmarkRandomSoftWritesParallel10(b *testing.B) {
+
+	// p*GOMAXPROCS
+	b.SetParallelism(10)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			data := map[string]interface{}{
+				"customer_id": strconv.FormatInt(r.Int63(), 10),
+			}
+
+			// Insert the new item into the database
+			opts := InsertOpts{Durability: "soft"}
+			_, err := Table(bTableName).Insert(data, opts).RunWrite(bSess)
+			if err != nil {
+				b.Errorf("insert failed [%s] ", err)
+			}
+		}
+	})
+
+}
+
+func BenchmarkSequentialWrites(b *testing.B) {
+
+	si := 0
+	for i := 0; i < b.N; i++ {
+		si++
+		data := map[string]interface{}{
+			"customer_id": si,
+		}
+
+		// Insert the new item into the database
+		_, err := Table(bTableName).Insert(data).RunWrite(bSess)
+		if err != nil {
+			b.Errorf("insert failed [%s] ", err)
+			return
+		}
+	}
+}
+
+func BenchmarkSequentialWritesParallel10(b *testing.B) {
+
+	var mu sync.Mutex
+	si := 0
+
+	// p*GOMAXPROCS
+	b.SetParallelism(10)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			mu.Lock()
+			si++
+			mu.Unlock()
+
+			data := map[string]interface{}{
+				"customer_id": si,
+			}
+
+			// Insert the new item into the database
+			_, err := Table(bTableName).Insert(data).RunWrite(bSess)
+			if err != nil {
+				b.Errorf("insert failed [%s] ", err)
+				return
+			}
+		}
+	})
+
+}
+
+func BenchmarkSequentialSoftWrites(b *testing.B) {
+
+	opts := InsertOpts{Durability: "soft"}
+	si := 0
+
+	for i := 0; i < b.N; i++ {
+		si++
+		data := map[string]interface{}{
+			"customer_id": si,
+		}
+
+		// Insert the new item into the database
+		_, err := Table(bTableName).Insert(data, opts).RunWrite(bSess)
+		if err != nil {
+			b.Errorf("insert failed [%s] ", err)
+			return
+		}
+	}
+}
+
+func BenchmarkSequentialSoftWritesParallel10(b *testing.B) {
+
+	var mu sync.Mutex
+	si := 0
+
+	// p*GOMAXPROCS
+	b.SetParallelism(10)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			mu.Lock()
+			si++
+			mu.Unlock()
+
+			data := map[string]interface{}{
+				"customer_id": si,
+			}
+
+			opts := InsertOpts{Durability: "soft"}
+
+			// Insert the new item into the database
+			_, err := Table(bTableName).Insert(data, opts).RunWrite(bSess)
+			if err != nil {
+				b.Errorf("insert failed [%s] ", err)
+				return
+			}
+		}
+	})
+
+}

--- a/gorethink_test.go
+++ b/gorethink_test.go
@@ -3,6 +3,7 @@ package gorethink
 import (
 	"encoding/json"
 	"flag"
+	"log"
 	"math/rand"
 	"os"
 	"runtime"
@@ -34,6 +35,59 @@ func init() {
 	// Needed for running tests for RethinkDB with a non-empty authkey
 	authKey = os.Getenv("RETHINKDB_AUTHKEY")
 }
+
+//
+// Begin TestMain(), Setup, Teardown
+//
+func testBenchmarkSetup() {
+
+	var err error
+
+	bDbName = "benchmark"
+	bTableName = "benchmarks"
+
+	bSess, err = Connect(ConnectOpts{
+		Address:  "localhost:28015",
+		Database: bDbName,
+		MaxIdle:  50,
+		MaxOpen:  50,
+	})
+
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
+	DbDrop(bDbName).Exec(bSess)
+	DbCreate(bDbName).Exec(bSess)
+
+	Db(bDbName).TableDrop(bTableName).Run(bSess)
+	Db(bDbName).TableCreate(bTableName).Run(bSess)
+
+}
+
+func testBenchmarkTeardown() {
+	Db(bDbName).TableDrop(bTableName).Run(bSess)
+	bSess.Close()
+}
+
+// stubs
+func testSetup()    {}
+func testTeardown() {}
+
+func TestMain(m *testing.M) {
+	// seed randomness for use with tests
+	rand.Seed(time.Now().UTC().UnixNano())
+	testSetup()
+	testBenchmarkSetup()
+	res := m.Run()
+	testTeardown()
+	testBenchmarkTeardown()
+	os.Exit(res)
+}
+
+//
+// End TestMain(), Setup, Teardown
+//
 
 // Hook up gocheck into the gotest runner.
 func Test(t *testing.T) { test.TestingT(t) }

--- a/query_geospatial_test.go
+++ b/query_geospatial_test.go
@@ -1,42 +1,89 @@
 package gorethink
 
 import (
+	"reflect"
+
 	"github.com/dancannon/gorethink/types"
 
 	test "gopkg.in/check.v1"
 )
 
+/* BEGIN FLOAT HELPERS */
+
+// totally ripped off from math/all_test.go
+// https://github.com/golang/go/blob/master/src/math/all_test.go#L1723-L1749
+func tolerance(a, b, e float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+
+	}
+
+	if a != 0 {
+		e = e * a
+		if e < 0 {
+			e = -e
+
+		}
+
+	}
+	return d < e
+}
+
+func mehclose(a, b float64) bool    { return tolerance(a, b, 1e-2) }
+func kindaclose(a, b float64) bool  { return tolerance(a, b, 1e-8) }
+func prettyclose(a, b float64) bool { return tolerance(a, b, 1e-14) }
+func veryclose(a, b float64) bool   { return tolerance(a, b, 4e-16) }
+func soclose(a, b, e float64) bool  { return tolerance(a, b, e) }
+
+func compareCoordinates(co [][]float64, lines types.Lines, c *test.C) {
+	for _, points := range lines {
+		for ip, point := range points {
+			v := reflect.ValueOf(point)
+			for i := 0; i < v.NumField(); i++ {
+				lc := co[ip][i]
+				f := v.Field(i).Float()
+				if !kindaclose(lc, f) {
+					c.Errorf("the deviation between the compared floats is too great [%v:%v]", lc, f)
+				}
+			}
+		}
+	}
+}
+
+/* END FLOAT HELPERS */
+
 func (s *RethinkSuite) TestGeospatialDecodeGeometryPseudoType(c *test.C) {
+
 	var response types.Geometry
+
+	// setup coordinates
+	co := [][]float64{
+		{-122.423246, 37.779388},
+		{-122.423246, 37.329898},
+		{-121.88642, 37.329898},
+		{-121.88642, 37.329898},
+		{-122.423246, 37.779388},
+	}
+
+	gt := "Polygon"
 	res, err := Expr(map[string]interface{}{
 		"$reql_type$": "GEOMETRY",
-		"type":        "Polygon",
-		"coordinates": []interface{}{
-			[]interface{}{
-				[]interface{}{-122.423246, 37.779388},
-				[]interface{}{-122.423246, 37.329898},
-				[]interface{}{-121.88642, 37.329898},
-				[]interface{}{-121.88642, 37.779388},
-				[]interface{}{-122.423246, 37.779388},
-			},
-		},
+		"type":        gt,
+		"coordinates": []interface{}{co},
 	}).Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response, test.DeepEquals, types.Geometry{
-		Type: "Polygon",
-		Lines: types.Lines{
-			types.Line{
-				types.Point{Lon: -122.423246, Lat: 37.779388},
-				types.Point{Lon: -122.423246, Lat: 37.329898},
-				types.Point{Lon: -121.88642, Lat: 37.329898},
-				types.Point{Lon: -121.88642, Lat: 37.779388},
-				types.Point{Lon: -122.423246, Lat: 37.779388},
-			},
-		},
-	})
+
+	// test shape
+	if response.Type != gt {
+		c.Errorf("expected [%v], instead [%v]", gt, response.Type)
+	}
+
+	// assert points are within threshold
+	compareCoordinates(co, response.Lines, c)
 }
 
 func (s *RethinkSuite) TestGeospatialEncodeGeometryPseudoType(c *test.C) {
@@ -75,46 +122,44 @@ func (s *RethinkSuite) TestGeospatialCircle(c *test.C) {
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response, test.DeepEquals, types.Geometry{
-		Type: "Polygon",
-		Lines: types.Lines{
-			types.Line{
-				types.Point{Lon: -122.423246, Lat: 37.77929790366427},
-				types.Point{Lon: -122.42326814543915, Lat: 37.77929963483801},
-				types.Point{Lon: -122.4232894398445, Lat: 37.779304761831504},
-				types.Point{Lon: -122.42330906488651, Lat: 37.77931308761787},
-				types.Point{Lon: -122.42332626638755, Lat: 37.77932429224285},
-				types.Point{Lon: -122.42334038330416, Lat: 37.77933794512014},
-				types.Point{Lon: -122.42335087313059, Lat: 37.77935352157849},
-				types.Point{Lon: -122.42335733274696, Lat: 37.77937042302436},
-				types.Point{Lon: -122.4233595139113, Lat: 37.77938799994533},
-				types.Point{Lon: -122.42335733279968, Lat: 37.7794055768704},
-				types.Point{Lon: -122.42335087322802, Lat: 37.779422478327966},
-				types.Point{Lon: -122.42334038343147, Lat: 37.77943805480385},
-				types.Point{Lon: -122.42332626652532, Lat: 37.779451707701796},
-				types.Point{Lon: -122.42330906501378, Lat: 37.77946291234741},
-				types.Point{Lon: -122.42328943994191, Lat: 37.77947123815131},
-				types.Point{Lon: -122.42326814549187, Lat: 37.77947636515649},
-				types.Point{Lon: -122.423246, Lat: 37.779478096334365},
-				types.Point{Lon: -122.42322385450814, Lat: 37.77947636515649},
-				types.Point{Lon: -122.4232025600581, Lat: 37.77947123815131},
-				types.Point{Lon: -122.42318293498623, Lat: 37.77946291234741},
-				types.Point{Lon: -122.42316573347469, Lat: 37.779451707701796},
-				types.Point{Lon: -122.42315161656855, Lat: 37.77943805480385},
-				types.Point{Lon: -122.423141126772, Lat: 37.779422478327966},
-				types.Point{Lon: -122.42313466720033, Lat: 37.7794055768704},
-				types.Point{Lon: -122.42313248608872, Lat: 37.77938799994533},
-				types.Point{Lon: -122.42313466725305, Lat: 37.77937042302436},
-				types.Point{Lon: -122.42314112686942, Lat: 37.77935352157849},
-				types.Point{Lon: -122.42315161669585, Lat: 37.77933794512014},
-				types.Point{Lon: -122.42316573361246, Lat: 37.77932429224285},
-				types.Point{Lon: -122.4231829351135, Lat: 37.77931308761787},
-				types.Point{Lon: -122.42320256015552, Lat: 37.779304761831504},
-				types.Point{Lon: -122.42322385456086, Lat: 37.77929963483801},
-				types.Point{Lon: -122.423246, Lat: 37.77929790366427},
-			},
-		},
-	})
+
+	co := [][]float64{
+		{-122.423246, 37.77929790366427},
+		{-122.42326814543915, 37.77929963483801},
+		{-122.4232894398445, 37.779304761831504},
+		{-122.42330906488651, 37.77931308761787},
+		{-122.42332626638755, 37.77932429224285},
+		{-122.42334038330416, 37.77933794512014},
+		{-122.42335087313059, 37.77935352157849},
+		{-122.42335733274696, 37.77937042302436},
+		{-122.4233595139113, 37.77938799994533},
+		{-122.42335733279968, 37.7794055768704},
+		{-122.42335087322802, 37.779422478327966},
+		{-122.42334038343147, 37.77943805480385},
+		{-122.42332626652532, 37.779451707701796},
+		{-122.42330906501378, 37.77946291234741},
+		{-122.42328943994191, 37.77947123815131},
+		{-122.42326814549187, 37.77947636515649},
+		{-122.423246, 37.779478096334365},
+		{-122.42322385450814, 37.77947636515649},
+		{-122.4232025600581, 37.77947123815131},
+		{-122.42318293498623, 37.77946291234741},
+		{-122.42316573347469, 37.779451707701796},
+		{-122.42315161656855, 37.77943805480385},
+		{-122.423141126772, 37.779422478327966},
+		{-122.42313466720033, 37.7794055768704},
+		{-122.42313248608872, 37.77938799994533},
+		{-122.42313466725305, 37.77937042302436},
+		{-122.42314112686942, 37.77935352157849},
+		{-122.42315161669585, 37.77933794512014},
+		{-122.42316573361246, 37.77932429224285},
+		{-122.4231829351135, 37.77931308761787},
+		{-122.42320256015552, 37.779304761831504},
+		{-122.42322385456086, 37.77929963483801},
+		{-122.423246, 37.77929790366427},
+	}
+
+	compareCoordinates(co, response.Lines, c)
 }
 
 func (s *RethinkSuite) TestGeospatialCirclePoint(c *test.C) {
@@ -124,46 +169,43 @@ func (s *RethinkSuite) TestGeospatialCirclePoint(c *test.C) {
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response, test.DeepEquals, types.Geometry{
-		Type: "Polygon",
-		Lines: types.Lines{
-			types.Line{
-				types.Point{Lon: -122.423246, Lat: 37.77929790366427},
-				types.Point{Lon: -122.42326814543915, Lat: 37.77929963483801},
-				types.Point{Lon: -122.4232894398445, Lat: 37.779304761831504},
-				types.Point{Lon: -122.42330906488651, Lat: 37.77931308761787},
-				types.Point{Lon: -122.42332626638755, Lat: 37.77932429224285},
-				types.Point{Lon: -122.42334038330416, Lat: 37.77933794512014},
-				types.Point{Lon: -122.42335087313059, Lat: 37.77935352157849},
-				types.Point{Lon: -122.42335733274696, Lat: 37.77937042302436},
-				types.Point{Lon: -122.4233595139113, Lat: 37.77938799994533},
-				types.Point{Lon: -122.42335733279968, Lat: 37.7794055768704},
-				types.Point{Lon: -122.42335087322802, Lat: 37.779422478327966},
-				types.Point{Lon: -122.42334038343147, Lat: 37.77943805480385},
-				types.Point{Lon: -122.42332626652532, Lat: 37.779451707701796},
-				types.Point{Lon: -122.42330906501378, Lat: 37.77946291234741},
-				types.Point{Lon: -122.42328943994191, Lat: 37.77947123815131},
-				types.Point{Lon: -122.42326814549187, Lat: 37.77947636515649},
-				types.Point{Lon: -122.423246, Lat: 37.779478096334365},
-				types.Point{Lon: -122.42322385450814, Lat: 37.77947636515649},
-				types.Point{Lon: -122.4232025600581, Lat: 37.77947123815131},
-				types.Point{Lon: -122.42318293498623, Lat: 37.77946291234741},
-				types.Point{Lon: -122.42316573347469, Lat: 37.779451707701796},
-				types.Point{Lon: -122.42315161656855, Lat: 37.77943805480385},
-				types.Point{Lon: -122.423141126772, Lat: 37.779422478327966},
-				types.Point{Lon: -122.42313466720033, Lat: 37.7794055768704},
-				types.Point{Lon: -122.42313248608872, Lat: 37.77938799994533},
-				types.Point{Lon: -122.42313466725305, Lat: 37.77937042302436},
-				types.Point{Lon: -122.42314112686942, Lat: 37.77935352157849},
-				types.Point{Lon: -122.42315161669585, Lat: 37.77933794512014},
-				types.Point{Lon: -122.42316573361246, Lat: 37.77932429224285},
-				types.Point{Lon: -122.4231829351135, Lat: 37.77931308761787},
-				types.Point{Lon: -122.42320256015552, Lat: 37.779304761831504},
-				types.Point{Lon: -122.42322385456086, Lat: 37.77929963483801},
-				types.Point{Lon: -122.423246, Lat: 37.77929790366427},
-			},
-		},
-	})
+	co := [][]float64{
+		{-122.423246, 37.77929790366427},
+		{-122.42326814543915, 37.77929963483801},
+		{-122.4232894398445, 37.779304761831504},
+		{-122.42330906488651, 37.77931308761787},
+		{-122.42332626638755, 37.77932429224285},
+		{-122.42334038330416, 37.77933794512014},
+		{-122.42335087313059, 37.77935352157849},
+		{-122.42335733274696, 37.77937042302436},
+		{-122.4233595139113, 37.77938799994533},
+		{-122.42335733279968, 37.7794055768704},
+		{-122.42335087322802, 37.779422478327966},
+		{-122.42334038343147, 37.77943805480385},
+		{-122.42332626652532, 37.779451707701796},
+		{-122.42330906501378, 37.77946291234741},
+		{-122.42328943994191, 37.77947123815131},
+		{-122.42326814549187, 37.77947636515649},
+		{-122.423246, 37.779478096334365},
+		{-122.42322385450814, 37.77947636515649},
+		{-122.4232025600581, 37.77947123815131},
+		{-122.42318293498623, 37.77946291234741},
+		{-122.42316573347469, 37.779451707701796},
+		{-122.42315161656855, 37.77943805480385},
+		{-122.423141126772, 37.779422478327966},
+		{-122.42313466720033, 37.7794055768704},
+		{-122.42313248608872, 37.77938799994533},
+		{-122.42313466725305, 37.77937042302436},
+		{-122.42314112686942, 37.77935352157849},
+		{-122.42315161669585, 37.77933794512014},
+		{-122.42316573361246, 37.77932429224285},
+		{-122.4231829351135, 37.77931308761787},
+		{-122.42320256015552, 37.779304761831504},
+		{-122.42322385456086, 37.77929963483801},
+		{-122.423246, 37.77929790366427},
+	}
+
+	compareCoordinates(co, response.Lines, c)
 }
 
 func (s *RethinkSuite) TestGeospatialCirclePointFill(c *test.C) {
@@ -173,76 +215,83 @@ func (s *RethinkSuite) TestGeospatialCirclePointFill(c *test.C) {
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response, test.DeepEquals, types.Geometry{
-		Type: "Polygon",
-		Lines: types.Lines{
-			types.Line{
-				types.Point{Lon: -122.423246, Lat: 37.77929790366427},
-				types.Point{Lon: -122.42326814543915, Lat: 37.77929963483801},
-				types.Point{Lon: -122.4232894398445, Lat: 37.779304761831504},
-				types.Point{Lon: -122.42330906488651, Lat: 37.77931308761787},
-				types.Point{Lon: -122.42332626638755, Lat: 37.77932429224285},
-				types.Point{Lon: -122.42334038330416, Lat: 37.77933794512014},
-				types.Point{Lon: -122.42335087313059, Lat: 37.77935352157849},
-				types.Point{Lon: -122.42335733274696, Lat: 37.77937042302436},
-				types.Point{Lon: -122.4233595139113, Lat: 37.77938799994533},
-				types.Point{Lon: -122.42335733279968, Lat: 37.7794055768704},
-				types.Point{Lon: -122.42335087322802, Lat: 37.779422478327966},
-				types.Point{Lon: -122.42334038343147, Lat: 37.77943805480385},
-				types.Point{Lon: -122.42332626652532, Lat: 37.779451707701796},
-				types.Point{Lon: -122.42330906501378, Lat: 37.77946291234741},
-				types.Point{Lon: -122.42328943994191, Lat: 37.77947123815131},
-				types.Point{Lon: -122.42326814549187, Lat: 37.77947636515649},
-				types.Point{Lon: -122.423246, Lat: 37.779478096334365},
-				types.Point{Lon: -122.42322385450814, Lat: 37.77947636515649},
-				types.Point{Lon: -122.4232025600581, Lat: 37.77947123815131},
-				types.Point{Lon: -122.42318293498623, Lat: 37.77946291234741},
-				types.Point{Lon: -122.42316573347469, Lat: 37.779451707701796},
-				types.Point{Lon: -122.42315161656855, Lat: 37.77943805480385},
-				types.Point{Lon: -122.423141126772, Lat: 37.779422478327966},
-				types.Point{Lon: -122.42313466720033, Lat: 37.7794055768704},
-				types.Point{Lon: -122.42313248608872, Lat: 37.77938799994533},
-				types.Point{Lon: -122.42313466725305, Lat: 37.77937042302436},
-				types.Point{Lon: -122.42314112686942, Lat: 37.77935352157849},
-				types.Point{Lon: -122.42315161669585, Lat: 37.77933794512014},
-				types.Point{Lon: -122.42316573361246, Lat: 37.77932429224285},
-				types.Point{Lon: -122.4231829351135, Lat: 37.77931308761787},
-				types.Point{Lon: -122.42320256015552, Lat: 37.779304761831504},
-				types.Point{Lon: -122.42322385456086, Lat: 37.77929963483801},
-				types.Point{Lon: -122.423246, Lat: 37.77929790366427},
-			},
-		},
-	})
+	co := [][]float64{
+		{-122.423246, 37.77929790366427},
+		{-122.42326814543915, 37.77929963483801},
+		{-122.4232894398445, 37.779304761831504},
+		{-122.42330906488651, 37.77931308761787},
+		{-122.42332626638755, 37.77932429224285},
+		{-122.42334038330416, 37.77933794512014},
+		{-122.42335087313059, 37.77935352157849},
+		{-122.42335733274696, 37.77937042302436},
+		{-122.4233595139113, 37.77938799994533},
+		{-122.42335733279968, 37.7794055768704},
+		{-122.42335087322802, 37.779422478327966},
+		{-122.42334038343147, 37.77943805480385},
+		{-122.42332626652532, 37.779451707701796},
+		{-122.42330906501378, 37.77946291234741},
+		{-122.42328943994191, 37.77947123815131},
+		{-122.42326814549187, 37.77947636515649},
+		{-122.423246, 37.779478096334365},
+		{-122.42322385450814, 37.77947636515649},
+		{-122.4232025600581, 37.77947123815131},
+		{-122.42318293498623, 37.77946291234741},
+		{-122.42316573347469, 37.779451707701796},
+		{-122.42315161656855, 37.77943805480385},
+		{-122.423141126772, 37.779422478327966},
+		{-122.42313466720033, 37.7794055768704},
+		{-122.42313248608872, 37.77938799994533},
+		{-122.42313466725305, 37.77937042302436},
+		{-122.42314112686942, 37.77935352157849},
+		{-122.42315161669585, 37.77933794512014},
+		{-122.42316573361246, 37.77932429224285},
+		{-122.4231829351135, 37.77931308761787},
+		{-122.42320256015552, 37.779304761831504},
+		{-122.42322385456086, 37.77929963483801},
+		{-122.423246, 37.77929790366427},
+	}
+
+	compareCoordinates(co, response.Lines, c)
+
 }
 
 func (s *RethinkSuite) TestGeospatialPointDistanceMethod(c *test.C) {
 	var response float64
+	f := 734125.249602186
 	res, err := Point(-122.423246, 37.779388).Distance(Point(-117.220406, 32.719464)).Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response, test.Equals, 734125.249602186)
+	if !kindaclose(response, f) {
+		c.Errorf("the deviation between the compared floats is too great [%v:%v]", response, f)
+	}
 }
 
 func (s *RethinkSuite) TestGeospatialPointDistanceRoot(c *test.C) {
 	var response float64
+	f := 734125.249602186
 	res, err := Distance(Point(-122.423246, 37.779388), Point(-117.220406, 32.719464)).Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response, test.Equals, 734125.249602186)
+	if !kindaclose(response, f) {
+		c.Errorf("the deviation between the compared floats is too great [%v:%v]", response, f)
+	}
 }
 
 func (s *RethinkSuite) TestGeospatialPointDistanceRootKm(c *test.C) {
 	var response float64
+	f := 734.125249602186
 	res, err := Distance(Point(-122.423246, 37.779388), Point(-117.220406, 32.719464), DistanceOpts{Unit: "km"}).Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response, test.Equals, 734.125249602186)
+	if !kindaclose(response, f) {
+		c.Errorf("the deviation between the compared floats is too great [%v:%v]", response, f)
+	}
 }
 
 func (s *RethinkSuite) TestGeospatialFill(c *test.C) {


### PR DESCRIPTION
Hi Dan,

As promised, here are the fixes for the tests. 

I created some helper methods which essentially ripoff Go's stdlib.

From there I refactored the coordinates into float64 vertices. 

I then used a helper method I created to compare the coordinates instantiated to the Lines and Points returned, throwing an error if the deviation is too great.

I think this is readable but am open to feedback.

Jared
