### PR TITLE
Add WaitOpts

### DIFF
--- a/query_admin.go
+++ b/query_admin.go
@@ -37,16 +37,33 @@ func (t Term) Status() Term {
 	return constructMethodTerm(t, "Status", p.Term_STATUS, []interface{}{}, map[string]interface{}{})
 }
 
-// Wait for a table or all the tables in a database to be ready. A table may be
-// temporarily unavailable after creation, rebalancing or reconfiguring. The
-// wait command blocks until the given table (or database) is fully up to date.
-func Wait() Term {
-	return constructRootTerm("Wait", p.Term_WAIT, []interface{}{}, map[string]interface{}{})
+type WaitOpts struct {
+	WaitFor interface{} `gorethink:"wait_for,omitempty"`
+	Timeout interface{} `gorethink:"timeout,omitempty"`
+}
+
+func (o *WaitOpts) toMap() map[string]interface{} {
+	return optArgsToMap(o)
 }
 
 // Wait for a table or all the tables in a database to be ready. A table may be
 // temporarily unavailable after creation, rebalancing or reconfiguring. The
 // wait command blocks until the given table (or database) is fully up to date.
-func (t Term) Wait() Term {
-	return constructMethodTerm(t, "Wait", p.Term_WAIT, []interface{}{}, map[string]interface{}{})
+func Wait(optArgs ...WaitOpts) Term {
+	opts := map[string]interface{}{}
+	if len(optArgs) >= 1 {
+		opts = optArgs[0].toMap()
+	}
+	return constructRootTerm("Wait", p.Term_WAIT, []interface{}{}, opts)
+}
+
+// Wait for a table or all the tables in a database to be ready. A table may be
+// temporarily unavailable after creation, rebalancing or reconfiguring. The
+// wait command blocks until the given table (or database) is fully up to date.
+func (t Term) Wait(optArgs ...WaitOpts) Term {
+	opts := map[string]interface{}{}
+	if len(optArgs) >= 1 {
+		opts = optArgs[0].toMap()
+	}
+	return constructMethodTerm(t, "Wait", p.Term_WAIT, []interface{}{}, opts)
 }

--- a/query_admin_test.go
+++ b/query_admin_test.go
@@ -73,6 +73,25 @@ func (s *RethinkSuite) TestAdminWait(c *test.C) {
 	c.Assert(response["ready"].(float64) > 0, test.Equals, true)
 }
 
+func (s *RethinkSuite) TestAdminWaitOpts(c *test.C) {
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+
+	query := Db("test").Table("test").Wait(WaitOpts{
+		WaitFor: "all_replicas_ready",
+		Timeout: 10,
+	})
+
+	res, err := query.Run(sess)
+	c.Assert(err, test.IsNil)
+
+	var response map[string]interface{}
+	err = res.One(&response)
+	c.Assert(err, test.IsNil)
+
+	c.Assert(response["ready"].(float64) > 0, test.Equals, true)
+}
+
 func (s *RethinkSuite) TestAdminStatus(c *test.C) {
 	Db("test").TableDrop("test").Exec(sess)
 	Db("test").TableCreate("test").Exec(sess)


### PR DESCRIPTION
Allow optional arguments `wait_for` and `timeout` in Wait() calls.
