### PR TITLE
v0.7.0 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ gobuild_args: -tags='cluster'
 
 go:
   - 1.4
-  # - tip
+  - tip
 
 before_install:
   - wget http://download.rethinkdb.com/dev/2.0.0-0RC1/rethinkdb_2.0.0%2b0RC1~0precise_amd64.deb
@@ -14,6 +14,6 @@ before_script:
 #   - sudo add-apt-repository ppa:rethinkdb/ppa -y
 #   - sudo apt-get update -q
 #   - sudo apt-get install rethinkdb
-  - rethinkdb --bind all &
-  - rethinkdb --port-offset 1 --directory rethinkdb_data1 --join localhost:29015 --bind all &
-  - rethinkdb --port-offset 2 --directory rethinkdb_data2 --join localhost:29015 --bind all &
+  - rethinkdb --bind all > /dev/null 2>&1 &
+  - rethinkdb --port-offset 1 --directory rethinkdb_data1 --join localhost:29015 --bind all > /dev/null 2>&1 &
+  - rethinkdb --port-offset 2 --directory rethinkdb_data2 --join localhost:29015 --bind all > /dev/null 2>&1 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+gobuild_args: -tags='cluster'
+
 go:
   - 1.4
   # - tip
@@ -13,3 +15,5 @@ before_script:
 #   - sudo apt-get update -q
 #   - sudo apt-get install rethinkdb
   - rethinkdb --bind all &
+  - rethinkdb --port-offset 1 --directory rethinkdb_data1 --join localhost:29015 --bind all &
+  - rethinkdb --port-offset 2 --directory rethinkdb_data2 --join localhost:29015 --bind all &

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_script:
 #   - sudo add-apt-repository ppa:rethinkdb/ppa -y
 #   - sudo apt-get update -q
 #   - sudo apt-get install rethinkdb
-  - rethinkdb --bind all > /dev/null 2>&1 &
-  - rethinkdb --port-offset 1 --directory rethinkdb_data1 --join localhost:29015 --bind all > /dev/null 2>&1 &
-  - rethinkdb --port-offset 2 --directory rethinkdb_data2 --join localhost:29015 --bind all > /dev/null 2>&1 &
+  - rethinkdb > /dev/null 2>&1 &
+  - rethinkdb --port-offset 1 --directory rethinkdb_data1 --join localhost:29015 > /dev/null 2>&1 &
+  - rethinkdb --port-offset 2 --directory rethinkdb_data2 --join localhost:29015 > /dev/null 2>&1 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ before_script:
 #   - sudo apt-get update -q
 #   - sudo apt-get install rethinkdb
   - rethinkdb > /dev/null 2>&1 &
-  - rethinkdb --port-offset 1 --directory rethinkdb_data1 --join localhost:29015 > /dev/null 2>&1 &
-  - rethinkdb --port-offset 2 --directory rethinkdb_data2 --join localhost:29015 > /dev/null 2>&1 &
+  - rethinkdb --port-offset 1 --directory rethinkdb_data1 --join localhost:29016 > /dev/null 2>&1 &
+  - rethinkdb --port-offset 2 --directory rethinkdb_data2 --join localhost:29016 > /dev/null 2>&1 &
+  - rethinkdb --port-offset 3 --directory rethinkdb_data3 --join localhost:29016 > /dev/null 2>&1 &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.7.0 - 2015-03-30
 
-This release includes support for RethinkDB 2.0 and connecting to clusters. All sessions will now attempt to connect to a cluster even if only one node was specified, because of this the way of connecting to a database has slightly changed (hopefully it now also slightly easier), the new method of connecting to a database is as follows:
+This release includes support for RethinkDB 2.0 and connecting to clusters. To connect to a cluster you should use the new `Addresses` field in `ConnectOpts`, for example:
 
 ```go
-session, err := Connect("localhost:28015")
-if err != nil {
-    log.Fatalln(err.Error())
-}
-```
-
-If you wish to specify any of the optional arguments you can now use `ConnectWithOpts`
-
-```go
-session, err := ConnectWithOpts("localhost:28015")
+session, err := r.Connect(r.ConnectOpts{
+    Addresses: []string{"localhost:28015", "localhost:28016"},
+})
 if err != nil {
     log.Fatalln(err.Error())
 }
@@ -34,6 +27,7 @@ For more details checkout the [README](https://github.com/dancannon/gorethink/bl
 
 - Added the ability to connect to multiple nodes, queries are then distributed between these nodes. If a node stops responding then queries stop being sent to this node.
 - Added the `DiscoverHosts` optional argument to `ConnectOpts`, when this value is `true` the driver will listen for new nodes added to the cluster.
+- Added the `Addresses` optional argument to `ConnectOpts`, this allows the driver to connect to multiple nodes in a cluster.
 - Added the `IncludeStates` optional argument to `Changes`.
 - Added `MinVal` and `MaxVal` which represent the smallest and largest possible values.
 - Added the `Listen` cursor helper function which publishes database results to a channel.
@@ -41,7 +35,6 @@ For more details checkout the [README](https://github.com/dancannon/gorethink/bl
 - Added the `Type` function to the `Cursor`, by default this value will be "Cursor" unless using a changefeed.
 - Changed the `IndexesOf` function to `OffsetsOf` .
 - Changed driver to use the v0.4 protocol (used to use v0.3).
-- Changed the arguments for`Connect` and added the `ConnectWithOpts` function.
 - Fixed geometry tests not properly checking the expected results.
 - Fixed bug causing nil pointer panics when using an `Unmarshaler`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.7.0 - 2015-03-30
+
+This release includes support for RethinkDB 2.0 and connecting to clusters. All sessions will now attempt to connect to a cluster even if only one node was specified, because of this the way of connecting to a database has slightly changed (hopefully it now also slightly easier), the new method of connecting to a database is as follows:
+
+```go
+session, err := Connect("localhost:28015")
+if err != nil {
+    log.Fatalln(err.Error())
+}
+```
+
+If you wish to specify any of the optional arguments you can now use `ConnectWithOpts`
+
+```go
+session, err := ConnectWithOpts("localhost:28015")
+if err != nil {
+    log.Fatalln(err.Error())
+}
+```
+
+Also added was the ability to read from a cursor using a channel, this is especially useful when using changefeeds. For more information see this [gist](https://gist.github.com/dancannon/2865686d163ed78bbc3c)
+
+```go
+cursor, err := r.Table("items").Changes()
+ch := make(chan map[string]interface{})
+cursor.Listen(ch)
+```
+
+For more details checkout the [README](https://github.com/dancannon/gorethink/blob/master/README.md) and [godoc](https://godoc.org/github.com/dancannon/gorethink). As always if you have any further questions send me a message on [Gitter](https://gitter.im/dancannon/gorethink).
+
+- Added the ability to connect to multiple nodes, queries are then distributed between these nodes. If a node stops responding then queries stop being sent to this node.
+- Added the `DiscoverHosts` optional argument to `ConnectOpts`, when this value is `true` the driver will listen for new nodes added to the cluster.
+- Added the `IncludeStates` optional argument to `Changes`.
+- Added `MinVal` and `MaxVal` which represent the smallest and largest possible values.
+- Added the `Listen` cursor helper function which publishes database results to a channel.
+- Added support for optional  arguments for the `Wait` function.
+- Added the `Type` function to the `Cursor`, by default this value will be "Cursor" unless using a changefeed.
+- Changed the `IndexesOf` function to `OffsetsOf` .
+- Changed driver to use the v0.4 protocol (used to use v0.3).
+- Changed the arguments for`Connect` and added the `ConnectWithOpts` function.
+- Fixed geometry tests not properly checking the expected results.
+- Fixed bug causing nil pointer panics when using an `Unmarshaler`
 
 ## v0.6.3 - 2015-03-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 [Go](http://golang.org/) driver for [RethinkDB](http://www.rethinkdb.com/) 
 
 
-Current version: v0.6.3 (RethinkDB v1.16) 
-
-**Version 0.6 introduced some small API changes and some significant internal changes, for more information check the [change log](CHANGELOG.md) and please be aware the driver is not yet stable**
+Current version: v0.7.0 (RethinkDB v2.0) 
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dancannon/gorethink?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -47,10 +45,6 @@ The driver uses a connection pool at all times, by default it creates and frees 
 To configure the connection pool `MaxIdle`, `MaxOpen` and `IdleTimeout` can be specified during connection. If you wish to change the value of `MaxIdle` or `MaxOpen` during runtime then the functions `SetMaxIdleConns` and `SetMaxOpenConns` can be used.
 
 ```go
-import (
-    r "github.com/dancannon/gorethink"
-)
-
 var session *r.Session
 
 session, err := r.ConnectWithOpts(r.ConnectOpts{
@@ -66,6 +60,24 @@ session.SetMaxOpenConns(5)
 ```
 
 A pre-configured [Pool](http://godoc.org/github.com/dancannon/gorethink#Pool) instance can also be passed to Connect().
+
+### Connect to a cluster
+
+To connect to a RethinkDB cluster which has multiple nodes you can use the following syntax. 
+
+```go
+var session *r.Session
+
+session, err := r.ConnectWithOpts(r.ConnectOpts{
+    Database: "test",
+    AuthKey:  "14daak1cad13dj",
+}, "localhost:28015")
+if err != nil {
+    log.Fatalln(err.Error())
+}
+```
+
+When using `ConnectCluster` host discovery is automatically enabled, this means that if any nodes are added to the cluster after the initial connection then the new node will be added to the pool of available nodes used by GoRethink.
 
 
 ## Query Functions

--- a/README.md
+++ b/README.md
@@ -47,19 +47,18 @@ To configure the connection pool `MaxIdle`, `MaxOpen` and `IdleTimeout` can be s
 ```go
 var session *r.Session
 
-session, err := r.ConnectWithOpts(r.ConnectOpts{
+session, err := r.Connect(r.ConnectOpts{
+    Address: "localhost:28015",
     Database: "test",
     MaxIdle: 10,
     MaxOpen: 10,
-}, "localhost:28015")
+})
 if err != nil {
     log.Fatalln(err.Error())
 }
 
 session.SetMaxOpenConns(5)
 ```
-
-A pre-configured [Pool](http://godoc.org/github.com/dancannon/gorethink#Pool) instance can also be passed to Connect().
 
 ### Connect to a cluster
 
@@ -68,16 +67,18 @@ To connect to a RethinkDB cluster which has multiple nodes you can use the follo
 ```go
 var session *r.Session
 
-session, err := r.ConnectWithOpts(r.ConnectOpts{
+session, err := r.Conenct(r.ConnectOpts{
+    Addresses: []string{"localhost:28015", "localhost:28016"},
     Database: "test",
     AuthKey:  "14daak1cad13dj",
+    DiscoverHosts: true,
 }, "localhost:28015")
 if err != nil {
     log.Fatalln(err.Error())
 }
 ```
 
-When using `ConnectCluster` host discovery is automatically enabled, this means that if any nodes are added to the cluster after the initial connection then the new node will be added to the pool of available nodes used by GoRethink.
+When `DiscoverHosts` is true any nodes are added to the cluster after the initial connection then the new node will be added to the pool of available nodes used by GoRethink.
 
 
 ## Query Functions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub tag](https://img.shields.io/github/tag/dancannon/gorethink.svg?style=flat)]()
 [![GoDoc](https://godoc.org/github.com/dancannon/gorethink?status.png)](https://godoc.org/github.com/dancannon/gorethink)
-[![wercker status](https://app.wercker.com/status/e315e764041af8e80f0c68280d4b4de2/s/master "wercker status")](https://app.wercker.com/project/bykey/e315e764041af8e80f0c68280d4b4de2) 
+[![build status](https://img.shields.io/travis/dancannon/gorethink/master.svg "build status")](https://travis-ci.org/dancannon/gorethink) 
 
 [Go](http://golang.org/) driver for [RethinkDB](http://www.rethinkdb.com/) 
 

--- a/cluster_integration_test.go
+++ b/cluster_integration_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *RethinkSuite) TestClusterDetectNewNode(c *test.C) {
-	session, err := ConnectClusterWithOpts(ConnectOpts{
+	session, err := Connect(ConnectOpts{
 		DiscoverHosts:       true,
 		NodeRefreshInterval: time.Second,
 	}, url, url2)
@@ -32,7 +32,7 @@ func (s *RethinkSuite) TestClusterDetectNewNode(c *test.C) {
 }
 
 func (s *RethinkSuite) TestClusterNodeHealth(c *test.C) {
-	session, err := ConnectClusterWithOpts(ConnectOpts{
+	session, err := Connect(ConnectOpts{
 		DiscoverHosts:       true,
 		NodeRefreshInterval: time.Second,
 		MaxIdle:             50,

--- a/cluster_integration_test.go
+++ b/cluster_integration_test.go
@@ -31,28 +31,6 @@ func (s *RethinkSuite) TestClusterDetectNewNode(c *test.C) {
 	}
 }
 
-func (s *RethinkSuite) TestClusterDetectRemovedNode(c *test.C) {
-	session, err := ConnectClusterWithOpts(ConnectOpts{
-		DiscoverHosts:       true,
-		NodeRefreshInterval: time.Second,
-	}, url, url2, url3)
-	c.Assert(err, test.IsNil)
-
-	t := time.NewTimer(time.Minute * 5)
-	for {
-		select {
-		// Fail if deadline has passed
-		case <-t.C:
-			c.Fatal("No node was removed from the cluster")
-		default:
-			// Pass if another node was added
-			if len(session.cluster.GetNodes()) < 3 {
-				return
-			}
-		}
-	}
-}
-
 func (s *RethinkSuite) TestClusterNodeHealth(c *test.C) {
 	session, err := ConnectClusterWithOpts(ConnectOpts{
 		DiscoverHosts:       true,

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func (s *RethinkSuite) TestClusterConnect(c *test.C) {
-	cluster, err := ConnectCluster(url, url2, url3)
+	session, err := Connect(ConnectOpts{
+		Addresses: []string{url, url2, url3},
+	})
 	c.Assert(err, test.IsNil)
 
-	row, err := Expr("Hello World").Run(cluster)
+	row, err := Expr("Hello World").Run(session)
 	c.Assert(err, test.IsNil)
 
 	var response string
@@ -23,11 +25,13 @@ func (s *RethinkSuite) TestClusterConnect(c *test.C) {
 }
 
 func (s *RethinkSuite) TestClusterMultipleQueries(c *test.C) {
-	cluster, err := ConnectCluster(url, url2, url3)
+	session, err := Connect(ConnectOpts{
+		Addresses: []string{url, url2, url3},
+	})
 	c.Assert(err, test.IsNil)
 
 	for i := 0; i < 1000; i++ {
-		row, err := Expr(fmt.Sprintf("Hello World", i)).Run(cluster)
+		row, err := Expr(fmt.Sprintf("Hello World", i)).Run(session)
 		c.Assert(err, test.IsNil)
 
 		var response string
@@ -39,16 +43,18 @@ func (s *RethinkSuite) TestClusterMultipleQueries(c *test.C) {
 
 func (s *RethinkSuite) TestClusterConnectError(c *test.C) {
 	var err error
-	_, err = ConnectClusterWithOpts(ConnectOpts{
-		Timeout: time.Second,
-	}, "nonexistanturl")
+	_, err = Connect(ConnectOpts{
+		Addresses: []string{"nonexistanturl"},
+		Timeout:   time.Second,
+	})
 	c.Assert(err, test.NotNil)
 }
 
 func (s *RethinkSuite) TestClusterConnectDatabase(c *test.C) {
-	session, err := ConnectClusterWithOpts(ConnectOpts{
-		Database: "test2",
-	}, url, url2, url3)
+	session, err := Connect(ConnectOpts{
+		Addresses: []string{url, url2, url3},
+		Database:  "test2",
+	})
 	c.Assert(err, test.IsNil)
 
 	_, err = Table("test2").Run(session)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -11,7 +11,7 @@ import (
 
 func (s *RethinkSuite) TestClusterConnect(c *test.C) {
 	session, err := Connect(ConnectOpts{
-		Addresses: []string{url, url2, url3},
+		Addresses: []string{url1, url2, url3},
 	})
 	c.Assert(err, test.IsNil)
 
@@ -26,7 +26,7 @@ func (s *RethinkSuite) TestClusterConnect(c *test.C) {
 
 func (s *RethinkSuite) TestClusterMultipleQueries(c *test.C) {
 	session, err := Connect(ConnectOpts{
-		Addresses: []string{url, url2, url3},
+		Addresses: []string{url1, url2, url3},
 	})
 	c.Assert(err, test.IsNil)
 
@@ -52,7 +52,7 @@ func (s *RethinkSuite) TestClusterConnectError(c *test.C) {
 
 func (s *RethinkSuite) TestClusterConnectDatabase(c *test.C) {
 	session, err := Connect(ConnectOpts{
-		Addresses: []string{url, url2, url3},
+		Addresses: []string{url1, url2, url3},
 		Database:  "test2",
 	})
 	c.Assert(err, test.IsNil)

--- a/cursor.go
+++ b/cursor.go
@@ -412,6 +412,10 @@ type queue struct {
 }
 
 func (q *queue) Len() int {
+	if len(q.elems) == 0 {
+		return 0
+	}
+
 	return q.nelems
 }
 func (q *queue) Push(elem interface{}) {

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
-// Go driver for RethinkDB
+// Package gorethink implements a Go driver for RethinkDB
 //
-// Current version: v0.6.3 (RethinkDB v1.16)
+// Current version: v0.7.0 (RethinkDB v2.0)
 // For more in depth information on how to use RethinkDB check out the API docs
 // at http://rethinkdb.com/api
 package gorethink

--- a/example_query_select_test.go
+++ b/example_query_select_test.go
@@ -15,9 +15,10 @@ func Example_Get() {
 		Gender    string `gorethink:"gender"`
 	}
 
-	sess, err := r.ConnectWithOpts(r.ConnectOpts{
+	sess, err := r.Connect(r.ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
-	}, url)
+	})
 	if err != nil {
 		log.Fatalf("Error connecting to DB: %s", err)
 	}
@@ -57,9 +58,10 @@ func Example_GetAll_Compound() {
 		Gender    string `gorethink:"gender"`
 	}
 
-	sess, err := r.ConnectWithOpts(r.ConnectOpts{
+	sess, err := r.Connect(r.ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
-	}, url)
+	})
 	if err != nil {
 		log.Fatalf("Error connecting to DB: %s", err)
 	}

--- a/example_query_table_test.go
+++ b/example_query_table_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func Example_TableCreate() {
-	sess, err := r.ConnectWithOpts(r.ConnectOpts{
+	sess, err := r.Connect(r.ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
-	}, url)
+	})
 	if err != nil {
 		log.Fatalf("Error connecting to DB: %s", err)
 	}
@@ -30,9 +31,10 @@ func Example_TableCreate() {
 }
 
 func Example_IndexCreate() {
-	sess, err := r.ConnectWithOpts(r.ConnectOpts{
+	sess, err := r.Connect(r.ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
-	}, url)
+	})
 	if err != nil {
 		log.Fatalf("Error connecting to DB: %s", err)
 	}
@@ -53,9 +55,10 @@ func Example_IndexCreate() {
 }
 
 func Example_IndexCreate_compound() {
-	sess, err := r.ConnectWithOpts(r.ConnectOpts{
+	sess, err := r.Connect(r.ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
-	}, url)
+	})
 	if err != nil {
 		log.Fatalf("Error connecting to DB: %s", err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -23,9 +23,10 @@ func init() {
 }
 
 func Example() {
-	session, err := r.ConnectWithOpts(r.ConnectOpts{
+	session, err := r.Connect(r.ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
-	}, url)
+	})
 	if err != nil {
 		log.Fatalf("Error connecting to DB: %s", err)
 	}

--- a/gorethink_test.go
+++ b/gorethink_test.go
@@ -14,7 +14,7 @@ import (
 
 var sess *Session
 var debug = flag.Bool("gorethink.debug", false, "print query trees")
-var url, url2, url3, db, authKey string
+var url, url1, url2, url3, db, authKey string
 
 func init() {
 	flag.Parse()
@@ -26,14 +26,19 @@ func init() {
 		url = "localhost:28015"
 	}
 
-	url2 = os.Getenv("RETHINKDB_URL_2")
+	url2 = os.Getenv("RETHINKDB_URL_1")
 	if url2 == "" {
 		url2 = "localhost:28016"
 	}
 
+	url2 = os.Getenv("RETHINKDB_URL_2")
+	if url2 == "" {
+		url2 = "localhost:28017"
+	}
+
 	url3 = os.Getenv("RETHINKDB_URL_3")
 	if url3 == "" {
-		url3 = "localhost:28017"
+		url3 = "localhost:28018"
 	}
 
 	db = os.Getenv("RETHINKDB_DB")

--- a/gorethink_test.go
+++ b/gorethink_test.go
@@ -55,11 +55,12 @@ func testBenchmarkSetup() {
 	bDbName = "benchmark"
 	bTableName = "benchmarks"
 
-	bSess, err = ConnectWithOpts(ConnectOpts{
+	bSess, err = Connect(ConnectOpts{
+		Address:  url,
 		Database: bDbName,
 		MaxIdle:  50,
 		MaxOpen:  50,
-	}, url)
+	})
 
 	if err != nil {
 		log.Fatalln(err.Error())
@@ -106,9 +107,10 @@ var _ = test.Suite(&RethinkSuite{})
 
 func (s *RethinkSuite) SetUpSuite(c *test.C) {
 	var err error
-	sess, err = ConnectWithOpts(ConnectOpts{
+	sess, err = Connect(ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
-	}, url)
+	})
 	c.Assert(err, test.IsNil)
 }
 

--- a/query_select_test.go
+++ b/query_select_test.go
@@ -338,11 +338,12 @@ func (s *RethinkSuite) TestConcurrentSelectManyWorkers(c *test.C) {
 	}
 
 	rand.Seed(time.Now().UnixNano())
-	sess, _ := ConnectWithOpts(ConnectOpts{
+	sess, _ := Connect(ConnectOpts{
+		Address: url,
 		AuthKey: authKey,
 		MaxOpen: 200,
 		MaxIdle: 200,
-	}, url)
+	})
 
 	// Ensure table + database exist
 	DbCreate("test").RunWrite(sess)

--- a/session_test.go
+++ b/session_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func (s *RethinkSuite) TestSessionConnect(c *test.C) {
-	session, err := ConnectWithOpts(ConnectOpts{
+	session, err := Connect(ConnectOpts{
+		Address: url,
 		AuthKey: os.Getenv("RETHINKDB_AUTHKEY"),
-	}, url)
+	})
 	c.Assert(err, test.IsNil)
 
 	row, err := Expr("Hello World").Run(session)
@@ -23,9 +24,10 @@ func (s *RethinkSuite) TestSessionConnect(c *test.C) {
 }
 
 func (s *RethinkSuite) TestSessionReconnect(c *test.C) {
-	session, err := ConnectWithOpts(ConnectOpts{
+	session, err := Connect(ConnectOpts{
+		Address: url,
 		AuthKey: os.Getenv("RETHINKDB_AUTHKEY"),
-	}, url)
+	})
 	c.Assert(err, test.IsNil)
 
 	row, err := Expr("Hello World").Run(session)
@@ -49,17 +51,19 @@ func (s *RethinkSuite) TestSessionReconnect(c *test.C) {
 
 func (s *RethinkSuite) TestSessionConnectError(c *test.C) {
 	var err error
-	_, err = ConnectWithOpts(ConnectOpts{
+	_, err = Connect(ConnectOpts{
+		Address: "nonexistanturl",
 		Timeout: time.Second,
-	}, "nonexistanturl")
+	})
 	c.Assert(err, test.NotNil)
 }
 
 func (s *RethinkSuite) TestSessionConnectDatabase(c *test.C) {
-	session, err := ConnectWithOpts(ConnectOpts{
+	session, err := Connect(ConnectOpts{
+		Address:  url,
 		AuthKey:  os.Getenv("RETHINKDB_AUTHKEY"),
 		Database: "test2",
-	}, url)
+	})
 	c.Assert(err, test.IsNil)
 
 	_, err = Table("test2").Run(session)


### PR DESCRIPTION
This release includes support for RethinkDB 2.0 and connecting to clusters. To connect to a cluster you should use the new `Addresses` field in `ConnectOpts`, for example:

``` go
session, err := r.Connect(r.ConnectOpts{
    Addresses: []string{"localhost:28015", "localhost:28016"},
})
if err != nil {
    log.Fatalln(err.Error())
}
```

Also added was the ability to read from a cursor using a channel, this is especially useful when using changefeeds. For more information see this [gist](https://gist.github.com/dancannon/2865686d163ed78bbc3c)

``` go
cursor, err := r.Table("items").Changes()
ch := make(chan map[string]interface{})
cursor.Listen(ch)
```

For more details checkout the [README](https://github.com/dancannon/gorethink/blob/master/README.md) and [godoc](https://godoc.org/github.com/dancannon/gorethink). As always if you have any further questions send me a message on [Gitter](https://gitter.im/dancannon/gorethink).
- Added the ability to connect to multiple nodes, queries are then distributed between these nodes. If a node stops responding then queries stop being sent to this node.
- Added the `DiscoverHosts` optional argument to `ConnectOpts`, when this value is `true` the driver will listen for new nodes added to the cluster.
- Added the `Addresses` optional argument to `ConnectOpts`, this allows the driver to connect to multiple nodes in a cluster.
- Added the `IncludeStates` optional argument to `Changes`.
- Added `MinVal` and `MaxVal` which represent the smallest and largest possible values.
- Added the `Listen` cursor helper function which publishes database results to a channel.
- Added support for optional  arguments for the `Wait` function.
- Added the `Type` function to the `Cursor`, by default this value will be "Cursor" unless using a changefeed.
- Changed the `IndexesOf` function to `OffsetsOf` .
- Changed driver to use the v0.4 protocol (used to use v0.3).
- Fixed geometry tests not properly checking the expected results.
- Fixed bug causing nil pointer panics when using an `Unmarshaler`
