### PR TITLE
Set maxOpen at pool init time

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -61,6 +61,7 @@ func NewPool(opts *ConnectOpts) (*Pool, error) {
 		openerCh: make(chan struct{}, connectionRequestQueueSize),
 		lastPut:  make(map[*poolConn]string),
 		maxIdle:  opts.MaxIdle,
+		maxOpen:  opts.MaxOpen,
 	}
 	go p.connectionOpener()
 	return p, nil


### PR DESCRIPTION
Currently, maxOpen isn't set during pool init (it's always zero aka unlimited). As a result, gorethink continues to open connections until it runs out of file descriptors. 
This PR should address the issue.
