### PR TITLE
Drop millisecond precision if given value is too old

### DIFF
--- a/cursor_test.go
+++ b/cursor_test.go
@@ -145,10 +145,12 @@ func (s *RethinkSuite) TestCursorStruct(c *test.C) {
 }
 
 func (s *RethinkSuite) TestCursorStructPseudoTypes(c *test.C) {
+	var zeroTime time.Time
 	t := time.Now()
 
 	res, err := Expr(map[string]interface{}{
 		"T": time.Unix(t.Unix(), 0).In(time.UTC),
+		"Z": zeroTime,
 		"B": []byte("hello"),
 	}).Run(sess)
 	c.Assert(err, test.IsNil)
@@ -159,6 +161,7 @@ func (s *RethinkSuite) TestCursorStructPseudoTypes(c *test.C) {
 	c.Assert(res.Type(), test.Equals, "Cursor")
 
 	c.Assert(response.T.Equal(time.Unix(t.Unix(), 0)), test.Equals, true)
+	c.Assert(response.Z.Equal(zeroTime), test.Equals, true)
 	c.Assert(response.B, jsonEquals, []byte("hello"))
 }
 

--- a/gorethink_test.go
+++ b/gorethink_test.go
@@ -211,6 +211,7 @@ type Y struct {
 
 type PseudoTypes struct {
 	T time.Time
+	Z time.Time
 	B []byte
 }
 


### PR DESCRIPTION
It's an edge case but the result of `UnixNano()` '...is undefined if the Unix
time in nanoseconds cannot be represented by an `int64`' (from docs), which
means it won't work for dates older than 1677-09-21, which includes the
zero Time (`var t time.Time`).

I ran into this issue trying to retrieve a previously saved zero Time
but was instead getting a date in 1754
