### PR TITLE
minor fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ import (
     r "github.com/dancannon/gorethink"
 )
 
+address := "localhost:28015"
 var session *r.Session
 
-session, err := Connect(address)
+session, err := r.Connect(address)
 if err != nil {
     log.Fatalln(err.Error())
 }


### PR DESCRIPTION
Since the sample code does not run from within the package, the Connect func needs to be called off of the session (r)
Also, added the default address (localhost:28015) to make it a little bit clearer.
