### PR TITLE
add basic support for SSL connections with CA cert validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For more details checkout the [README](https://github.com/dancannon/gorethink/bl
 - Changed driver to use the v0.4 protocol (used to use v0.3).
 - Fixed geometry tests not properly checking the expected results.
 - Fixed bug causing nil pointer panics when using an `Unmarshaler`
+- Fixed dropped millisecond precision if given value is too old
 
 ## v0.6.3 - 2015-03-04
 ### Added

--- a/connection.go
+++ b/connection.go
@@ -4,10 +4,8 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"io"
 	"net"
-	"strings"
 	"sync/atomic"
 	"time"
 

--- a/connection.go
+++ b/connection.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"strings"
@@ -56,9 +57,9 @@ func NewConnection(address string, opts *ConnectOpts) (*Connection, error) {
 		c.conn, err = nd.Dial("tcp", address)
 	} else {
 		roots := x509.NewCertPool()
-		ok := roots.AppendCertsFromPEM([]byte(c.opts.CaCert))
+		ok := roots.AppendCertsFromPEM([]byte(c.opts.CACert))
 		if !ok {
-			panic("failed to parse root certificate")
+			return nil, errors.New("failed to parse root certificate")
 		}
 		c.conn, err = tls.DialWithDialer(&nd, "tcp", address, &tls.Config{
 			RootCAs:    roots,

--- a/session.go
+++ b/session.go
@@ -23,7 +23,7 @@ type ConnectOpts struct {
 	AuthKey   string        `gorethink:"authkey,omitempty"`
 	Timeout   time.Duration `gorethink:"timeout,omitempty"`
 	SSL       bool          `gorethink:"ssl",omitempty"`
-	CaCert    string        `gorethink:"cacert",omitempty"`
+	CACert    string        `gorethink:"cacert",omitempty"`
 
 	MaxIdle int `gorethink:"max_idle,omitempty"`
 	MaxOpen int `gorethink:"max_open,omitempty"`

--- a/session.go
+++ b/session.go
@@ -22,6 +22,8 @@ type ConnectOpts struct {
 	Database  string        `gorethink:"database,omitempty"`
 	AuthKey   string        `gorethink:"authkey,omitempty"`
 	Timeout   time.Duration `gorethink:"timeout,omitempty"`
+	SSL       bool          `gorethink:"ssl",omitempty"`
+	CaCert    string        `gorethink:"cacert",omitempty"`
 
 	MaxIdle int `gorethink:"max_idle,omitempty"`
 	MaxOpen int `gorethink:"max_open,omitempty"`

--- a/session.go
+++ b/session.go
@@ -1,6 +1,7 @@
 package gorethink
 
 import (
+	"crypto/tls"
 	"time"
 
 	p "github.com/dancannon/gorethink/ql2"
@@ -22,8 +23,7 @@ type ConnectOpts struct {
 	Database  string        `gorethink:"database,omitempty"`
 	AuthKey   string        `gorethink:"authkey,omitempty"`
 	Timeout   time.Duration `gorethink:"timeout,omitempty"`
-	SSL       bool          `gorethink:"ssl",omitempty"`
-	CACert    string        `gorethink:"cacert",omitempty"`
+	TLSConfig *tls.Config   `gorethink:"tlsconfig,omitempty"`
 
 	MaxIdle int `gorethink:"max_idle,omitempty"`
 	MaxOpen int `gorethink:"max_open,omitempty"`


### PR DESCRIPTION
adds an ssl flag to the connectopts and a cacerts option. In the connection class, it now checks for the SSL flag and build the necessary cert info and calls tls.DialWithDialer.

For now, the SSL support is only good for encrypting traffic and verifying the CA certification to prevent MITM attacks.
