### PR TITLE
Can't connect to server with http admin turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ session, err := r.Connect(r.ConnectOpts{
     Database: "test",
     AuthKey:  "14daak1cad13dj",
     DiscoverHosts: true,
-}, "localhost:28015")
+})
 if err != nil {
     log.Fatalln(err.Error())
 }

--- a/node.go
+++ b/node.go
@@ -191,7 +191,6 @@ type nodeStatus struct {
 	Status  string `gorethink:"status"`
 	Network struct {
 		Hostname           string `gorethink:"hostname"`
-		HTTPAdminPort      int64  `gorethink:"http_admin_port"`
 		ClusterPort        int64  `gorethink:"cluster_port"`
 		ReqlPort           int64  `gorethink:"reql_port"`
 		CanonicalAddresses []struct {


### PR DESCRIPTION
When the http admin interface is disabled for a server the driver fails to connect. Reason is that the `server_status` table returns `"http_admin_port": "<no http admin>" ,` but the driver expects the port to be a number. As a result, no connection can be made.

This PR changes the data type for HTTPAdminPort to string. Another way to fix this would be to remove the field, it's not used anyway.

This also fixes a bug in the example in the README.
