### PR TITLE
Fix documentation on func (Term) Exec

### DIFF
--- a/query.go
+++ b/query.go
@@ -240,7 +240,7 @@ func (o *ExecOpts) toMap() map[string]interface{} {
 // Exec runs the query but does not return the result. Exec will still wait for
 // the response to be received unless the NoReply field is true.
 //
-//	res, err := r.Db("database").Table("table").Insert(doc).Exec(sess, r.ExecOpts{
+//	err := r.Db("database").Table("table").Insert(doc).Exec(sess, r.ExecOpts{
 //		NoReply: true,
 //	})
 func (t Term) Exec(s *Session, optArgs ...ExecOpts) error {


### PR DESCRIPTION
The documentation's example expects a result to be returned. Exec only responds with an error.
