### PR TITLE
Renamed functions + improved some documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ In an attempt to make this library more "idiomatic" some functions have been ren
  - Renamed `Js` to `JS`
  - Renamed `Json` to `JSON`
  - Renamed `Http` to `HTTP`
+ - Renamed `GeoJson` to `GeoJSON`
+ - Renamed `ToGeoJson` to `ToGeoJSON`
 
 ## v0.7.2 - 2015-05-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+In an attempt to make this library more "idiomatic" some functions have been renamed, for the full list of changes see below.
+
+### Changed 
+ - Renamed `Db` to `DB`
+ - Renamed `DbCreate` to `DBCreate`
+ - Renamed `DbDrop` to `DBDrop`
+ - Renamed `RqlConnectionError` to `RQLConnectionError`
+ - Renamed `RqlDriverError` to `RQLDriverError`
+ - Renamed `RqlClientError` to `RQLClientError`
+ - Renamed `RqlRuntimeError` to `RQLRuntimeError`
+ - Renamed `RqlCompileError` to `RQLCompileError`
+
 ## v0.7.2 - 2015-05-05
 ### Added
  - Added support for connecting to a server using TLS (#179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,28 @@ In an attempt to make this library more "idiomatic" some functions have been ren
 
 ## Added
  - Added more documentation.
+ - Added `Shards`, `Replicas` and `PrimaryReplicaTag` optional arguments in `TableCreateOpts`.
+ - Added `MultiGroup` and `MultiGroupByIndex` which are equivalent to the running `group` with the `multi` optional argument set to true.
 
 ### Changed 
- - Renamed `Db` to `DB`
- - Renamed `DbCreate` to `DBCreate`
- - Renamed `DbDrop` to `DBDrop`
- - Renamed `RqlConnectionError` to `RQLConnectionError`
- - Renamed `RqlDriverError` to `RQLDriverError`
- - Renamed `RqlClientError` to `RQLClientError`
- - Renamed `RqlRuntimeError` to `RQLRuntimeError`
- - Renamed `RqlCompileError` to `RQLCompileError`
- - Renamed `Js` to `JS`
- - Renamed `Json` to `JSON`
- - Renamed `Http` to `HTTP`
- - Renamed `GeoJson` to `GeoJSON`
- - Renamed `ToGeoJson` to `ToGeoJSON`
+ - Renamed `Db` to `DB`.
+ - Renamed `DbCreate` to `DBCreate`.
+ - Renamed `DbDrop` to `DBDrop`.
+ - Renamed `RqlConnectionError` to `RQLConnectionError`.
+ - Renamed `RqlDriverError` to `RQLDriverError`.
+ - Renamed `RqlClientError` to `RQLClientError`.
+ - Renamed `RqlRuntimeError` to `RQLRuntimeError`.
+ - Renamed `RqlCompileError` to `RQLCompileError`.
+ - Renamed `Js` to `JS`.
+ - Renamed `Json` to `JSON`.
+ - Renamed `Http` to `HTTP`.
+ - Renamed `GeoJson` to `GeoJSON`.
+ - Renamed `ToGeoJson` to `ToGeoJSON`.
+
+### Removed
+
+ - Removed `CacheSize` and `DataCenter` optional arguments in `TableCreateOpts`.
+ - Removed `CacheSize` optional argument from `InsertOpts`
 
 ## v0.7.2 - 2015-05-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ In an attempt to make this library more "idiomatic" some functions have been ren
  - Renamed `Http` to `HTTP`.
  - Renamed `GeoJson` to `GeoJSON`.
  - Renamed `ToGeoJson` to `ToGeoJSON`.
+ - Renamed `WriteChanges` to `ChangeResponse`, this is now a general type and can be used when dealing with changefeeds.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 In an attempt to make this library more "idiomatic" some functions have been renamed, for the full list of changes see below.
 
+## Added
+ - Added more documentation.
+
 ### Changed 
  - Renamed `Db` to `DB`
  - Renamed `DbCreate` to `DBCreate`
@@ -15,6 +18,9 @@ In an attempt to make this library more "idiomatic" some functions have been ren
  - Renamed `RqlClientError` to `RQLClientError`
  - Renamed `RqlRuntimeError` to `RQLRuntimeError`
  - Renamed `RqlCompileError` to `RQLCompileError`
+ - Renamed `Js` to `JS`
+ - Renamed `Json` to `JSON`
+ - Renamed `Http` to `HTTP`
 
 ## v0.7.2 - 2015-05-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ When `DiscoverHosts` is true any nodes are added to the cluster after the initia
 
 This library is based on the official drivers so the code on the [API](http://www.rethinkdb.com/api/) page should require very few changes to work.
 
-To view full documentation for the query functions check the [GoDoc](http://godoc.org/github.com/dancannon/gorethink#Term)
+To view full documentation for the query functions check the [API reference](https://github.com/dancannon/gorethink/wiki/Go-ReQL-command-reference) or [GoDoc](http://godoc.org/github.com/dancannon/gorethink#Term)
 
 Slice Expr Example
 ```go
@@ -129,7 +129,7 @@ As shown above in the Between example optional arguments are passed to the funct
 
 Different result types are returned depending on what function is used to execute the query.
 
-- `Run` returns a cursor which can be used to view all rows returned.
+- `Run` returns a cugrsor which can be used to view all rows returned.
 - `RunWrite` returns a WriteResponse and should be used for queries such as Insert, Update, etc...
 - `Exec` sends a query to the server and closes the connection immediately after reading the response from the database. If you do not wish to wait for the response then you can set the `NoReply` flag.
 
@@ -239,7 +239,7 @@ BenchmarkSequentialSoftWritesParallel10      10000                           263
 
 ## Examples
 
-View other examples on the [wiki](https://github.com/dancannon/gorethink/wiki/Examples).
+Many functions have examples and are viewable in the godoc, alternatively view some more full features examples on the [wiki](https://github.com/dancannon/gorethink/wiki/Examples).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -205,20 +205,6 @@ Field int `gorethink:"myName,omitempty"`
 Field int `gorethink:",omitempty"`
 ```
 
-Alternatively you can implement the FieldMapper interface  by providing the FieldMap function which returns a map of strings in the form of `"FieldName": "NewName"`. For example:
-
-```go
-type A struct {
-    Field int
-}
-
-func (a A) FieldMap() map[string]string {
-    return map[string]string{
-        "Field": "myName",
-    }
-}
-```
-
 ## Benchmarks
 
 Everyone wants their project's benchmarks to be speedy. And while we know that rethinkDb and the gorethink driver are quite fast, our primary goal is for our benchmarks to be correct. They are designed to give you, the user, an accurate picture of writes per second (w/s). If you come up with a accurate test that meets this aim, submit a pull request please. 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ As shown above in the Between example optional arguments are passed to the funct
 
 Different result types are returned depending on what function is used to execute the query.
 
-- `Run` returns a cugrsor which can be used to view all rows returned.
+- `Run` returns a cursor which can be used to view all rows returned.
 - `RunWrite` returns a WriteResponse and should be used for queries such as Insert, Update, etc...
 - `Exec` sends a query to the server and closes the connection immediately after reading the response from the database. If you do not wish to wait for the response then you can set the `NoReply` flag.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [documentation](http://godoc.org/github.com/dancannon/gorethink#Connect)
 
 The driver uses a connection pool at all times, by default it creates and frees connections automatically. It's safe for concurrent use by multiple goroutines.
 
-To configure the connection pool `MaxIdle`, `MaxOpen` and `IdleTimeout` can be specified during connection. If you wish to change the value of `MaxIdle` or `MaxOpen` during runtime then the functions `SetMaxIdleConns` and `SetMaxOpenConns` can be used.
+To configure the connection pool `MaxIdle`, `MaxOpen` and `Timeout` can be specified during connection. If you wish to change the value of `MaxIdle` or `MaxOpen` during runtime then the functions `SetMaxIdleConns` and `SetMaxOpenConns` can be used.
 
 ```go
 var session *r.Session

--- a/cluster.go
+++ b/cluster.go
@@ -135,7 +135,7 @@ func (c *Cluster) listenForNodeChanges() error {
 	}
 
 	cursor, err := node.Query(newQuery(
-		Db("rethinkdb").Table("server_status").Changes(),
+		DB("rethinkdb").Table("server_status").Changes(),
 		map[string]interface{}{},
 		c.opts,
 	))
@@ -196,7 +196,7 @@ func (c *Cluster) connectNodes(hosts []Host) {
 		defer conn.Close()
 
 		_, cursor, err := conn.Query(newQuery(
-			Db("rethinkdb").Table("server_status"),
+			DB("rethinkdb").Table("server_status"),
 			map[string]interface{}{},
 			c.opts,
 		))

--- a/cluster.go
+++ b/cluster.go
@@ -135,7 +135,7 @@ func (c *Cluster) listenForNodeChanges() error {
 	}
 
 	cursor, err := node.Query(newQuery(
-		DB("rethinkdb").Table("server_status").Changes(),
+		Db("rethinkdb").Table("server_status").Changes(),
 		map[string]interface{}{},
 		c.opts,
 	))
@@ -196,7 +196,7 @@ func (c *Cluster) connectNodes(hosts []Host) {
 		defer conn.Close()
 
 		_, cursor, err := conn.Query(newQuery(
-			DB("rethinkdb").Table("server_status"),
+			Db("rethinkdb").Table("server_status"),
 			map[string]interface{}{},
 			c.opts,
 		))

--- a/connection.go
+++ b/connection.go
@@ -103,7 +103,7 @@ func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 	if q.Type == p.Query_START || q.Type == p.Query_NOREPLY_WAIT {
 		q.Token = c.nextToken()
 		if c.opts.Database != "" {
-			q.Opts["db"] = Db(c.opts.Database).build()
+			q.Opts["db"] = DB(c.opts.Database).build()
 		}
 	}
 
@@ -138,7 +138,7 @@ func (c *Connection) sendQuery(q Query) error {
 	// Build query
 	b, err := json.Marshal(q.build())
 	if err != nil {
-		return RqlDriverError{"Error building query"}
+		return ErrRQLDriver{"Error building query"}
 	}
 
 	// Set timeout
@@ -151,7 +151,7 @@ func (c *Connection) sendQuery(q Query) error {
 	// Send the JSON encoding of the query itself.
 	if err = c.writeQuery(q.Token, b); err != nil {
 		c.bad = true
-		return RqlConnectionError{err.Error()}
+		return ErrRQLConnection{err.Error()}
 	}
 
 	return nil
@@ -178,14 +178,14 @@ func (c *Connection) readResponse() (*Response, error) {
 	b := c.buf.takeBuffer(int(messageLength))
 	if _, err := io.ReadFull(c.conn, b[:]); err != nil {
 		c.bad = true
-		return nil, RqlConnectionError{err.Error()}
+		return nil, ErrRQLConnection{err.Error()}
 	}
 
 	// Decode the response
 	var response = newCachedResponse()
 	if err := json.Unmarshal(b, response); err != nil {
 		c.bad = true
-		return nil, RqlDriverError{err.Error()}
+		return nil, ErrRQLDriver{err.Error()}
 	}
 	response.Token = responseToken
 
@@ -195,11 +195,11 @@ func (c *Connection) readResponse() (*Response, error) {
 func (c *Connection) processResponse(q Query, response *Response) (*Response, *Cursor, error) {
 	switch response.Type {
 	case p.Response_CLIENT_ERROR:
-		return c.processErrorResponse(q, response, RqlClientError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, ErrRQLClient{rqlResponseError{response, q.Term}})
 	case p.Response_COMPILE_ERROR:
-		return c.processErrorResponse(q, response, RqlCompileError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, ErrRQLCompile{rqlResponseError{response, q.Term}})
 	case p.Response_RUNTIME_ERROR:
-		return c.processErrorResponse(q, response, RqlRuntimeError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, ErrRQLRuntime{rqlResponseError{response, q.Term}})
 	case p.Response_SUCCESS_ATOM:
 		return c.processAtomResponse(q, response)
 	case p.Response_SUCCESS_PARTIAL:
@@ -210,7 +210,7 @@ func (c *Connection) processResponse(q Query, response *Response) (*Response, *C
 		return c.processWaitResponse(q, response)
 	default:
 		putResponse(response)
-		return nil, nil, RqlDriverError{"Unexpected response type"}
+		return nil, nil, ErrRQLDriver{"Unexpected response type"}
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -103,7 +103,7 @@ func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 	if q.Type == p.Query_START || q.Type == p.Query_NOREPLY_WAIT {
 		q.Token = c.nextToken()
 		if c.opts.Database != "" {
-			q.Opts["db"] = DB(c.opts.Database).build()
+			q.Opts["db"] = Db(c.opts.Database).build()
 		}
 	}
 
@@ -138,7 +138,7 @@ func (c *Connection) sendQuery(q Query) error {
 	// Build query
 	b, err := json.Marshal(q.build())
 	if err != nil {
-		return RQLDriverError{"Error building query"}
+		return RqlDriverError{"Error building query"}
 	}
 
 	// Set timeout
@@ -151,7 +151,7 @@ func (c *Connection) sendQuery(q Query) error {
 	// Send the JSON encoding of the query itself.
 	if err = c.writeQuery(q.Token, b); err != nil {
 		c.bad = true
-		return RQLConnectionError{err.Error()}
+		return RqlConnectionError{err.Error()}
 	}
 
 	return nil
@@ -178,14 +178,14 @@ func (c *Connection) readResponse() (*Response, error) {
 	b := c.buf.takeBuffer(int(messageLength))
 	if _, err := io.ReadFull(c.conn, b[:]); err != nil {
 		c.bad = true
-		return nil, RQLConnectionError{err.Error()}
+		return nil, RqlConnectionError{err.Error()}
 	}
 
 	// Decode the response
 	var response = newCachedResponse()
 	if err := json.Unmarshal(b, response); err != nil {
 		c.bad = true
-		return nil, RQLDriverError{err.Error()}
+		return nil, RqlDriverError{err.Error()}
 	}
 	response.Token = responseToken
 
@@ -195,11 +195,11 @@ func (c *Connection) readResponse() (*Response, error) {
 func (c *Connection) processResponse(q Query, response *Response) (*Response, *Cursor, error) {
 	switch response.Type {
 	case p.Response_CLIENT_ERROR:
-		return c.processErrorResponse(q, response, RQLClientError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, RqlClientError{rqlResponseError{response, q.Term}})
 	case p.Response_COMPILE_ERROR:
-		return c.processErrorResponse(q, response, RQLCompileError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, RqlCompileError{rqlResponseError{response, q.Term}})
 	case p.Response_RUNTIME_ERROR:
-		return c.processErrorResponse(q, response, RQLRuntimeError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, RqlRuntimeError{rqlResponseError{response, q.Term}})
 	case p.Response_SUCCESS_ATOM:
 		return c.processAtomResponse(q, response)
 	case p.Response_SUCCESS_PARTIAL:
@@ -210,7 +210,7 @@ func (c *Connection) processResponse(q Query, response *Response) (*Response, *C
 		return c.processWaitResponse(q, response)
 	default:
 		putResponse(response)
-		return nil, nil, RQLDriverError{"Unexpected response type"}
+		return nil, nil, RqlDriverError{"Unexpected response type"}
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -16,6 +16,8 @@ const (
 	respHeaderLen = 12
 )
 
+// Response represents the raw response from a query, most of the time you
+// should instead use a Cursor when reading from the database.
 type Response struct {
 	Token     int64
 	Type      p.Response_ResponseType   `json:"t"`
@@ -95,6 +97,10 @@ func (c *Connection) Close() error {
 	return nil
 }
 
+// Query sends a Query to the database, returning both the raw Response and a
+// Cursor which should be used to view the query's response.
+//
+// This function is used internally by Run which should be used for most queries.
 func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 	if c == nil {
 		return nil, nil, nil
@@ -139,6 +145,7 @@ func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 	}
 }
 
+// sendQuery marshals the Query and sends the JSON to the server.
 func (c *Connection) sendQuery(q Query) error {
 	// Build query
 	b, err := json.Marshal(q.build())
@@ -169,6 +176,8 @@ func (c *Connection) nextToken() int64 {
 	return atomic.AddInt64(&c.token, 1)
 }
 
+// readResponse attempts to read a Response from the server, if no response
+// could be read then an error is returned.
 func (c *Connection) readResponse() (*Response, error) {
 	// Set timeout
 	if c.opts.Timeout == 0 {

--- a/connection.go
+++ b/connection.go
@@ -103,7 +103,7 @@ func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 	if q.Type == p.Query_START || q.Type == p.Query_NOREPLY_WAIT {
 		q.Token = c.nextToken()
 		if c.opts.Database != "" {
-			q.Opts["db"] = Db(c.opts.Database).build()
+			q.Opts["db"] = DB(c.opts.Database).build()
 		}
 	}
 
@@ -138,7 +138,7 @@ func (c *Connection) sendQuery(q Query) error {
 	// Build query
 	b, err := json.Marshal(q.build())
 	if err != nil {
-		return RqlDriverError{"Error building query"}
+		return RQLDriverError{"Error building query"}
 	}
 
 	// Set timeout
@@ -151,7 +151,7 @@ func (c *Connection) sendQuery(q Query) error {
 	// Send the JSON encoding of the query itself.
 	if err = c.writeQuery(q.Token, b); err != nil {
 		c.bad = true
-		return RqlConnectionError{err.Error()}
+		return RQLConnectionError{err.Error()}
 	}
 
 	return nil
@@ -178,14 +178,14 @@ func (c *Connection) readResponse() (*Response, error) {
 	b := c.buf.takeBuffer(int(messageLength))
 	if _, err := io.ReadFull(c.conn, b[:]); err != nil {
 		c.bad = true
-		return nil, RqlConnectionError{err.Error()}
+		return nil, RQLConnectionError{err.Error()}
 	}
 
 	// Decode the response
 	var response = newCachedResponse()
 	if err := json.Unmarshal(b, response); err != nil {
 		c.bad = true
-		return nil, RqlDriverError{err.Error()}
+		return nil, RQLDriverError{err.Error()}
 	}
 	response.Token = responseToken
 
@@ -195,11 +195,11 @@ func (c *Connection) readResponse() (*Response, error) {
 func (c *Connection) processResponse(q Query, response *Response) (*Response, *Cursor, error) {
 	switch response.Type {
 	case p.Response_CLIENT_ERROR:
-		return c.processErrorResponse(q, response, RqlClientError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, RQLClientError{rqlResponseError{response, q.Term}})
 	case p.Response_COMPILE_ERROR:
-		return c.processErrorResponse(q, response, RqlCompileError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, RQLCompileError{rqlResponseError{response, q.Term}})
 	case p.Response_RUNTIME_ERROR:
-		return c.processErrorResponse(q, response, RqlRuntimeError{rqlResponseError{response, q.Term}})
+		return c.processErrorResponse(q, response, RQLRuntimeError{rqlResponseError{response, q.Term}})
 	case p.Response_SUCCESS_ATOM:
 		return c.processAtomResponse(q, response)
 	case p.Response_SUCCESS_PARTIAL:
@@ -210,7 +210,7 @@ func (c *Connection) processResponse(q Query, response *Response) (*Response, *C
 		return c.processWaitResponse(q, response)
 	default:
 		putResponse(response)
-		return nil, nil, RqlDriverError{"Unexpected response type"}
+		return nil, nil, RQLDriverError{"Unexpected response type"}
 	}
 }
 

--- a/connection_helper.go
+++ b/connection_helper.go
@@ -14,7 +14,7 @@ import (
 func (c *Connection) writeData(data []byte) error {
 	_, err := c.conn.Write(data[:])
 	if err != nil {
-		return ErrRQLConnection{err.Error()}
+		return RQLConnectionError{err.Error()}
 	}
 
 	return nil
@@ -26,7 +26,7 @@ func (c *Connection) writeHandshakeReq() error {
 
 	data := c.buf.takeSmallBuffer(dataLen)
 	if data == nil {
-		return ErrRQLDriver{ErrBusyBuffer.Error()}
+		return RQLDriverError{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer
@@ -56,14 +56,14 @@ func (c *Connection) readHandshakeSuccess() error {
 		if err == io.EOF {
 			return fmt.Errorf("Unexpected EOF: %s", string(line))
 		}
-		return ErrRQLConnection{err.Error()}
+		return RQLConnectionError{err.Error()}
 	}
 	// convert to string and remove trailing NUL byte
 	response := string(line[:len(line)-1])
 	if response != "SUCCESS" {
 		response = strings.TrimSpace(response)
 		// we failed authorization or something else terrible happened
-		return ErrRQLDriver{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
+		return RQLDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
 	}
 
 	return nil
@@ -75,7 +75,7 @@ func (c *Connection) writeQuery(token int64, q []byte) error {
 
 	data := c.buf.takeBuffer(dataLen)
 	if data == nil {
-		return ErrRQLDriver{ErrBusyBuffer.Error()}
+		return RQLDriverError{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer

--- a/connection_helper.go
+++ b/connection_helper.go
@@ -26,7 +26,7 @@ func (c *Connection) writeHandshakeReq() error {
 
 	data := c.buf.takeSmallBuffer(dataLen)
 	if data == nil {
-		return RQLDriverError{ErrBusyBuffer.Error()}
+		return RQLDriverError{"Busy buffer"}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer
@@ -75,7 +75,7 @@ func (c *Connection) writeQuery(token int64, q []byte) error {
 
 	data := c.buf.takeBuffer(dataLen)
 	if data == nil {
-		return RQLDriverError{ErrBusyBuffer.Error()}
+		return RQLDriverError{"Busy Buffer"}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer

--- a/connection_helper.go
+++ b/connection_helper.go
@@ -13,7 +13,7 @@ import (
 func (c *Connection) writeData(data []byte) error {
 	_, err := c.conn.Write(data[:])
 	if err != nil {
-		return RqlConnectionError{err.Error()}
+		return ErrRQLConnection{err.Error()}
 	}
 
 	return nil
@@ -25,7 +25,7 @@ func (c *Connection) writeHandshakeReq() error {
 
 	data := c.buf.takeSmallBuffer(dataLen)
 	if data == nil {
-		return RqlDriverError{ErrBusyBuffer.Error()}
+		return ErrRQLDriver{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer
@@ -55,13 +55,13 @@ func (c *Connection) readHandshakeSuccess() error {
 		if err == io.EOF {
 			return fmt.Errorf("Unexpected EOF: %s", string(line))
 		}
-		return RqlConnectionError{err.Error()}
+		return ErrRQLConnection{err.Error()}
 	}
 	// convert to string and remove trailing NUL byte
 	response := string(line[:len(line)-1])
 	if response != "SUCCESS" {
 		// we failed authorization or something else terrible happened
-		return RqlDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
+		return ErrRQLDriver{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
 	}
 
 	return nil
@@ -73,7 +73,7 @@ func (c *Connection) writeQuery(token int64, q []byte) error {
 
 	data := c.buf.takeBuffer(dataLen)
 	if data == nil {
-		return RqlDriverError{ErrBusyBuffer.Error()}
+		return ErrRQLDriver{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer

--- a/connection_helper.go
+++ b/connection_helper.go
@@ -13,7 +13,7 @@ import (
 func (c *Connection) writeData(data []byte) error {
 	_, err := c.conn.Write(data[:])
 	if err != nil {
-		return RqlConnectionError{err.Error()}
+		return RQLConnectionError{err.Error()}
 	}
 
 	return nil
@@ -25,7 +25,7 @@ func (c *Connection) writeHandshakeReq() error {
 
 	data := c.buf.takeSmallBuffer(dataLen)
 	if data == nil {
-		return RqlDriverError{ErrBusyBuffer.Error()}
+		return RQLDriverError{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer
@@ -55,13 +55,13 @@ func (c *Connection) readHandshakeSuccess() error {
 		if err == io.EOF {
 			return fmt.Errorf("Unexpected EOF: %s", string(line))
 		}
-		return RqlConnectionError{err.Error()}
+		return RQLConnectionError{err.Error()}
 	}
 	// convert to string and remove trailing NUL byte
 	response := string(line[:len(line)-1])
 	if response != "SUCCESS" {
 		// we failed authorization or something else terrible happened
-		return RqlDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
+		return RQLDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
 	}
 
 	return nil
@@ -73,7 +73,7 @@ func (c *Connection) writeQuery(token int64, q []byte) error {
 
 	data := c.buf.takeBuffer(dataLen)
 	if data == nil {
-		return RqlDriverError{ErrBusyBuffer.Error()}
+		return RQLDriverError{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer

--- a/connection_helper.go
+++ b/connection_helper.go
@@ -13,7 +13,7 @@ import (
 func (c *Connection) writeData(data []byte) error {
 	_, err := c.conn.Write(data[:])
 	if err != nil {
-		return RQLConnectionError{err.Error()}
+		return RqlConnectionError{err.Error()}
 	}
 
 	return nil
@@ -25,7 +25,7 @@ func (c *Connection) writeHandshakeReq() error {
 
 	data := c.buf.takeSmallBuffer(dataLen)
 	if data == nil {
-		return RQLDriverError{ErrBusyBuffer.Error()}
+		return RqlDriverError{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer
@@ -55,13 +55,13 @@ func (c *Connection) readHandshakeSuccess() error {
 		if err == io.EOF {
 			return fmt.Errorf("Unexpected EOF: %s", string(line))
 		}
-		return RQLConnectionError{err.Error()}
+		return RqlConnectionError{err.Error()}
 	}
 	// convert to string and remove trailing NUL byte
 	response := string(line[:len(line)-1])
 	if response != "SUCCESS" {
 		// we failed authorization or something else terrible happened
-		return RQLDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
+		return RqlDriverError{fmt.Sprintf("Server dropped connection with message: \"%s\"", response)}
 	}
 
 	return nil
@@ -73,7 +73,7 @@ func (c *Connection) writeQuery(token int64, q []byte) error {
 
 	data := c.buf.takeBuffer(dataLen)
 	if data == nil {
-		return RQLDriverError{ErrBusyBuffer.Error()}
+		return RqlDriverError{ErrBusyBuffer.Error()}
 	}
 
 	// Send the protocol version to the server as a 4-byte little-endian-encoded integer

--- a/cursor.go
+++ b/cursor.go
@@ -45,13 +45,11 @@ func newCursor(conn *Connection, cursorType string, token int64, term *Term, opt
 //     err = cursor.Err() // get any error encountered during iteration
 //     ...
 type Cursor struct {
-	pc          *poolConn
 	releaseConn func(error)
 
 	conn       *Connection
 	token      int64
 	cursorType string
-	query      Query
 	term       *Term
 	opts       map[string]interface{}
 

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -188,13 +188,13 @@ func (s *RethinkSuite) TestCursorAtomArray(c *test.C) {
 }
 
 func (s *RethinkSuite) TestEmptyResults(c *test.C) {
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
-	res, err := Db("test").Table("test").Get("missing value").Run(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
+	res, err := DB("test").Table("test").Get("missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 
-	res, err = Db("test").Table("test").Get("missing value").Run(sess)
+	res, err = DB("test").Table("test").Get("missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	var response interface{}
 	err = res.One(&response)
@@ -205,30 +205,30 @@ func (s *RethinkSuite) TestEmptyResults(c *test.C) {
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 
-	res, err = Db("test").Table("test").Get("missing value").Run(sess)
+	res, err = DB("test").Table("test").Get("missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 
-	res, err = Db("test").Table("test").GetAll("missing value", "another missing value").Run(sess)
+	res, err = DB("test").Table("test").GetAll("missing value", "another missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.Next(&response), test.Equals, false)
 
 	var obj object
 	obj.Name = "missing value"
-	res, err = Db("test").Table("test").Filter(obj).Run(sess)
+	res, err = DB("test").Table("test").Filter(obj).Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 }
 
 func (s *RethinkSuite) TestCursorAll(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableDrop("Table3").Exec(sess)
-	Db("test").TableCreate("Table3").Exec(sess)
-	Db("test").Table("Table3").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableDrop("Table3").Exec(sess)
+	DB("test").TableCreate("Table3").Exec(sess)
+	DB("test").Table("Table3").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table3").Insert([]interface{}{
+	DB("test").Table("Table3").Insert([]interface{}{
 		map[string]interface{}{
 			"id":   2,
 			"name": "Object 1",
@@ -248,7 +248,7 @@ func (s *RethinkSuite) TestCursorAll(c *test.C) {
 	}).Exec(sess)
 
 	// Test query
-	query := Db("test").Table("Table3").OrderBy("id")
+	query := DB("test").Table("Table3").OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -278,13 +278,13 @@ func (s *RethinkSuite) TestCursorAll(c *test.C) {
 
 func (s *RethinkSuite) TestCursorListen(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableDrop("Table3").Exec(sess)
-	Db("test").TableCreate("Table3").Exec(sess)
-	Db("test").Table("Table3").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableDrop("Table3").Exec(sess)
+	DB("test").TableCreate("Table3").Exec(sess)
+	DB("test").Table("Table3").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table3").Insert([]interface{}{
+	DB("test").Table("Table3").Insert([]interface{}{
 		map[string]interface{}{
 			"id":   2,
 			"name": "Object 1",
@@ -304,7 +304,7 @@ func (s *RethinkSuite) TestCursorListen(c *test.C) {
 	}).Exec(sess)
 
 	// Test query
-	query := Db("test").Table("Table3").OrderBy("id")
+	query := DB("test").Table("Table3").OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -188,13 +188,13 @@ func (s *RethinkSuite) TestCursorAtomArray(c *test.C) {
 }
 
 func (s *RethinkSuite) TestEmptyResults(c *test.C) {
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
-	res, err := DB("test").Table("test").Get("missing value").Run(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+	res, err := Db("test").Table("test").Get("missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 
-	res, err = DB("test").Table("test").Get("missing value").Run(sess)
+	res, err = Db("test").Table("test").Get("missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	var response interface{}
 	err = res.One(&response)
@@ -205,30 +205,30 @@ func (s *RethinkSuite) TestEmptyResults(c *test.C) {
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 
-	res, err = DB("test").Table("test").Get("missing value").Run(sess)
+	res, err = Db("test").Table("test").Get("missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 
-	res, err = DB("test").Table("test").GetAll("missing value", "another missing value").Run(sess)
+	res, err = Db("test").Table("test").GetAll("missing value", "another missing value").Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.Next(&response), test.Equals, false)
 
 	var obj object
 	obj.Name = "missing value"
-	res, err = DB("test").Table("test").Filter(obj).Run(sess)
+	res, err = Db("test").Table("test").Filter(obj).Run(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(res.IsNil(), test.Equals, true)
 }
 
 func (s *RethinkSuite) TestCursorAll(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableDrop("Table3").Exec(sess)
-	DB("test").TableCreate("Table3").Exec(sess)
-	DB("test").Table("Table3").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableDrop("Table3").Exec(sess)
+	Db("test").TableCreate("Table3").Exec(sess)
+	Db("test").Table("Table3").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table3").Insert([]interface{}{
+	Db("test").Table("Table3").Insert([]interface{}{
 		map[string]interface{}{
 			"id":   2,
 			"name": "Object 1",
@@ -248,7 +248,7 @@ func (s *RethinkSuite) TestCursorAll(c *test.C) {
 	}).Exec(sess)
 
 	// Test query
-	query := DB("test").Table("Table3").OrderBy("id")
+	query := Db("test").Table("Table3").OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -278,13 +278,13 @@ func (s *RethinkSuite) TestCursorAll(c *test.C) {
 
 func (s *RethinkSuite) TestCursorListen(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableDrop("Table3").Exec(sess)
-	DB("test").TableCreate("Table3").Exec(sess)
-	DB("test").Table("Table3").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableDrop("Table3").Exec(sess)
+	Db("test").TableCreate("Table3").Exec(sess)
+	Db("test").Table("Table3").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table3").Insert([]interface{}{
+	Db("test").Table("Table3").Insert([]interface{}{
 		map[string]interface{}{
 			"id":   2,
 			"name": "Object 1",
@@ -304,7 +304,7 @@ func (s *RethinkSuite) TestCursorListen(c *test.C) {
 	}).Exec(sess)
 
 	// Test query
-	query := DB("test").Table("Table3").OrderBy("id")
+	query := Db("test").Table("Table3").OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type object struct {
-	Id    int64  `gorethink:"id,omitempty"`
+	ID    int64  `gorethink:"id,omitempty"`
 	Name  string `gorethink:"name"`
 	Attrs []attr
 }
@@ -135,7 +135,7 @@ func (s *RethinkSuite) TestCursorStruct(c *test.C) {
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
 	c.Assert(response, test.DeepEquals, object{
-		Id:   2,
+		ID:   2,
 		Name: "Object 1",
 		Attrs: []attr{attr{
 			Name:  "attr 1",
@@ -258,7 +258,7 @@ func (s *RethinkSuite) TestCursorAll(c *test.C) {
 	c.Assert(response, test.HasLen, 2)
 	c.Assert(response, test.DeepEquals, []object{
 		object{
-			Id:   2,
+			ID:   2,
 			Name: "Object 1",
 			Attrs: []attr{attr{
 				Name:  "attr 1",
@@ -266,7 +266,7 @@ func (s *RethinkSuite) TestCursorAll(c *test.C) {
 			}},
 		},
 		object{
-			Id:   3,
+			ID:   3,
 			Name: "Object 2",
 			Attrs: []attr{attr{
 				Name:  "attr 1",
@@ -318,7 +318,7 @@ func (s *RethinkSuite) TestCursorListen(c *test.C) {
 	c.Assert(response, test.HasLen, 2)
 	c.Assert(response, test.DeepEquals, []object{
 		object{
-			Id:   2,
+			ID:   2,
 			Name: "Object 1",
 			Attrs: []attr{attr{
 				Name:  "attr 1",
@@ -326,7 +326,7 @@ func (s *RethinkSuite) TestCursorListen(c *test.C) {
 			}},
 		},
 		object{
-			Id:   3,
+			ID:   3,
 			Name: "Object 2",
 			Attrs: []attr{attr{
 				Name:  "attr 1",

--- a/errors.go
+++ b/errors.go
@@ -88,38 +88,38 @@ func (e rqlResponseError) String() string {
 	return e.Error()
 }
 
-type ErrRQLCompile struct {
+type RQLCompileError struct {
 	rqlResponseError
 }
 
-type ErrRQLRuntime struct {
+type RQLRuntimeError struct {
 	rqlResponseError
 }
 
-type ErrRQLClient struct {
+type RQLClientError struct {
 	rqlResponseError
 }
 
-type ErrRQLDriver struct {
+type RQLDriverError struct {
 	message string
 }
 
-func (e ErrRQLDriver) Error() string {
+func (e RQLDriverError) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e ErrRQLDriver) String() string {
+func (e RQLDriverError) String() string {
 	return e.Error()
 }
 
-type ErrRQLConnection struct {
+type RQLConnectionError struct {
 	message string
 }
 
-func (e ErrRQLConnection) Error() string {
+func (e RQLConnectionError) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e ErrRQLConnection) String() string {
+func (e RQLConnectionError) String() string {
 	return e.Error()
 }

--- a/errors.go
+++ b/errors.go
@@ -10,16 +10,23 @@ import (
 )
 
 var (
-	ErrNoHosts              = errors.New("no hosts provided")
+	// ErrNoHosts is returned when no hosts to the Connect method.
+	ErrNoHosts = errors.New("no hosts provided")
+	// ErrNoConnectionsStarted is returned when the driver couldn't to any of
+	// the provided hosts.
 	ErrNoConnectionsStarted = errors.New("no connections were made when creating the session")
-	ErrHostQueryFailed      = errors.New("unable to populate hosts")
-	ErrInvalidNode          = errors.New("invalid node")
-	ErrClusterClosed        = errors.New("cluster closed")
-
-	ErrNoConnections    = errors.New("gorethink: no connections were available")
+	// ErrInvalidNode is returned when attempting to connect to a node which
+	// returns an invalid response.
+	ErrInvalidNode = errors.New("invalid node")
+	// ErrClusterClosed is returned when a query is executed after the connection
+	// to the cluster has been closed.
+	ErrClusterClosed = errors.New("cluster closed")
+	// ErrNoConnections is returned when there are no active connections in the
+	// clusters connection pool.
+	ErrNoConnections = errors.New("gorethink: no connections were available")
+	// ErrConnectionClosed is returned when trying to send a query with a closed
+	// connection.
 	ErrConnectionClosed = errors.New("gorethink: the connection is closed")
-
-	ErrBusyBuffer = errors.New("Busy buffer")
 )
 
 func printCarrots(t Term, frames []*p.Frame) string {
@@ -65,6 +72,8 @@ var ErrEmptyResult = errors.New("The result does not contain any more rows")
 
 // Connection/Response errors
 
+// rqlResponseError is the base type for all errors, it formats both
+// for the response and query if set.
 type rqlResponseError struct {
 	response *Response
 	term     *Term
@@ -88,18 +97,25 @@ func (e rqlResponseError) String() string {
 	return e.Error()
 }
 
+// RQLCompileError represents an error that occurs when compiling a query on
+// the database server.
 type RQLCompileError struct {
 	rqlResponseError
 }
 
+// RQLRuntimeError represents an error when executing an error on the database
+// server, this is also returned by the database when using the `Error` term.
 type RQLRuntimeError struct {
 	rqlResponseError
 }
 
+// RQLClientError represents a client error returned from the database.
 type RQLClientError struct {
 	rqlResponseError
 }
 
+// RQLDriverError represents an unexpected error with the driver, if this error
+// persists please create an issue.
 type RQLDriverError struct {
 	message string
 }
@@ -112,6 +128,8 @@ func (e RQLDriverError) String() string {
 	return e.Error()
 }
 
+// RQLConnectionError represents an error when communicating with the database
+// server.
 type RQLConnectionError struct {
 	message string
 }

--- a/errors.go
+++ b/errors.go
@@ -88,38 +88,38 @@ func (e rqlResponseError) String() string {
 	return e.Error()
 }
 
-type RQLCompileError struct {
+type RqlCompileError struct {
 	rqlResponseError
 }
 
-type RQLRuntimeError struct {
+type RqlRuntimeError struct {
 	rqlResponseError
 }
 
-type RQLClientError struct {
+type RqlClientError struct {
 	rqlResponseError
 }
 
-type RQLDriverError struct {
+type RqlDriverError struct {
 	message string
 }
 
-func (e RQLDriverError) Error() string {
+func (e RqlDriverError) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e RQLDriverError) String() string {
+func (e RqlDriverError) String() string {
 	return e.Error()
 }
 
-type RQLConnectionError struct {
+type RqlConnectionError struct {
 	message string
 }
 
-func (e RQLConnectionError) Error() string {
+func (e RqlConnectionError) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e RQLConnectionError) String() string {
+func (e RqlConnectionError) String() string {
 	return e.Error()
 }

--- a/errors.go
+++ b/errors.go
@@ -88,38 +88,38 @@ func (e rqlResponseError) String() string {
 	return e.Error()
 }
 
-type RqlCompileError struct {
+type RQLCompileError struct {
 	rqlResponseError
 }
 
-type RqlRuntimeError struct {
+type RQLRuntimeError struct {
 	rqlResponseError
 }
 
-type RqlClientError struct {
+type RQLClientError struct {
 	rqlResponseError
 }
 
-type RqlDriverError struct {
+type RQLDriverError struct {
 	message string
 }
 
-func (e RqlDriverError) Error() string {
+func (e RQLDriverError) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e RqlDriverError) String() string {
+func (e RQLDriverError) String() string {
 	return e.Error()
 }
 
-type RqlConnectionError struct {
+type RQLConnectionError struct {
 	message string
 }
 
-func (e RqlConnectionError) Error() string {
+func (e RQLConnectionError) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e RqlConnectionError) String() string {
+func (e RQLConnectionError) String() string {
 	return e.Error()
 }

--- a/errors.go
+++ b/errors.go
@@ -88,38 +88,38 @@ func (e rqlResponseError) String() string {
 	return e.Error()
 }
 
-type RqlCompileError struct {
+type ErrRQLCompile struct {
 	rqlResponseError
 }
 
-type RqlRuntimeError struct {
+type ErrRQLRuntime struct {
 	rqlResponseError
 }
 
-type RqlClientError struct {
+type ErrRQLClient struct {
 	rqlResponseError
 }
 
-type RqlDriverError struct {
+type ErrRQLDriver struct {
 	message string
 }
 
-func (e RqlDriverError) Error() string {
+func (e ErrRQLDriver) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e RqlDriverError) String() string {
+func (e ErrRQLDriver) String() string {
 	return e.Error()
 }
 
-type RqlConnectionError struct {
+type ErrRQLConnection struct {
 	message string
 }
 
-func (e RqlConnectionError) Error() string {
+func (e ErrRQLConnection) Error() string {
 	return fmt.Sprintf("gorethink: %s", e.message)
 }
 
-func (e RqlConnectionError) String() string {
+func (e ErrRQLConnection) String() string {
 	return e.Error()
 }

--- a/example_query_select_test.go
+++ b/example_query_select_test.go
@@ -1,21 +1,18 @@
-package gorethink_test
+package gorethink
 
 import (
 	"fmt"
-	"log"
-
-	r "github.com/dancannon/gorethink"
 )
 
 func Example_Get() {
 	type Person struct {
-		Id        string `gorethink:"id, omitempty"`
+		ID        string `gorethink:"id, omitempty"`
 		FirstName string `gorethink:"first_name"`
 		LastName  string `gorethink:"last_name"`
 		Gender    string `gorethink:"gender"`
 	}
 
-	sess, err := r.Connect(r.ConnectOpts{
+	sess, err := Connect(ConnectOpts{
 		Address: url,
 		AuthKey: authKey,
 	})
@@ -24,12 +21,12 @@ func Example_Get() {
 	}
 
 	// Setup table
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
-	r.DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
+	DB("test").TableDrop("table").Run(sess)
+	DB("test").TableCreate("table").Run(sess)
+	DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
 
 	// Fetch the row from the database
-	res, err := r.DB("test").Table("table").Get("1").Run(sess)
+	res, err := DB("test").Table("table").Get("1").Run(sess)
 	if err != nil {
 		log.Fatalf("Error finding person: %s", err)
 	}
@@ -52,13 +49,13 @@ func Example_Get() {
 
 func Example_GetAll_Compound() {
 	type Person struct {
-		Id        string `gorethink:"id, omitempty"`
+		ID        string `gorethink:"id, omitempty"`
 		FirstName string `gorethink:"first_name"`
 		LastName  string `gorethink:"last_name"`
 		Gender    string `gorethink:"gender"`
 	}
 
-	sess, err := r.Connect(r.ConnectOpts{
+	sess, err := Connect(ConnectOpts{
 		Address: url,
 		AuthKey: authKey,
 	})
@@ -67,16 +64,16 @@ func Example_GetAll_Compound() {
 	}
 
 	// Setup table
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
-	r.DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
-	r.DB("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
+	DB("test").TableDrop("table").Run(sess)
+	DB("test").TableCreate("table").Run(sess)
+	DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
+	DB("test").Table("table").IndexCreateFunc("full_name", func(row Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).Run(sess)
-	r.DB("test").Table("table").IndexWait().Run(sess)
+	DB("test").Table("table").IndexWait().Run(sess)
 
 	// Fetch the row from the database
-	res, err := r.DB("test").Table("table").GetAllByIndex("full_name", []interface{}{"John", "Smith"}).Run(sess)
+	res, err := DB("test").Table("table").GetAllByIndex("full_name", []interface{}{"John", "Smith"}).Run(sess)
 	if err != nil {
 		log.Fatalf("Error finding person: %s", err)
 	}
@@ -88,7 +85,7 @@ func Example_GetAll_Compound() {
 	// Scan query result into the person variable
 	var person Person
 	err = res.One(&person)
-	if err == r.ErrEmptyResult {
+	if err == ErrEmptyResult {
 		log.Fatalf("Person not found")
 	} else if err != nil {
 		log.Fatalf("Error scanning database result: %s", err)

--- a/example_query_select_test.go
+++ b/example_query_select_test.go
@@ -24,12 +24,12 @@ func Example_Get() {
 	}
 
 	// Setup table
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
-	r.DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
+	r.Db("test").TableDrop("table").Run(sess)
+	r.Db("test").TableCreate("table").Run(sess)
+	r.Db("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
 
 	// Fetch the row from the database
-	res, err := r.DB("test").Table("table").Get("1").Run(sess)
+	res, err := r.Db("test").Table("table").Get("1").Run(sess)
 	if err != nil {
 		log.Fatalf("Error finding person: %s", err)
 	}
@@ -67,16 +67,16 @@ func Example_GetAll_Compound() {
 	}
 
 	// Setup table
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
-	r.DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
-	r.DB("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
+	r.Db("test").TableDrop("table").Run(sess)
+	r.Db("test").TableCreate("table").Run(sess)
+	r.Db("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
+	r.Db("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).Run(sess)
-	r.DB("test").Table("table").IndexWait().Run(sess)
+	r.Db("test").Table("table").IndexWait().Run(sess)
 
 	// Fetch the row from the database
-	res, err := r.DB("test").Table("table").GetAllByIndex("full_name", []interface{}{"John", "Smith"}).Run(sess)
+	res, err := r.Db("test").Table("table").GetAllByIndex("full_name", []interface{}{"John", "Smith"}).Run(sess)
 	if err != nil {
 		log.Fatalf("Error finding person: %s", err)
 	}

--- a/example_query_select_test.go
+++ b/example_query_select_test.go
@@ -24,12 +24,12 @@ func Example_Get() {
 	}
 
 	// Setup table
-	r.Db("test").TableDrop("table").Run(sess)
-	r.Db("test").TableCreate("table").Run(sess)
-	r.Db("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
+	r.DB("test").TableDrop("table").Run(sess)
+	r.DB("test").TableCreate("table").Run(sess)
+	r.DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
 
 	// Fetch the row from the database
-	res, err := r.Db("test").Table("table").Get("1").Run(sess)
+	res, err := r.DB("test").Table("table").Get("1").Run(sess)
 	if err != nil {
 		log.Fatalf("Error finding person: %s", err)
 	}
@@ -67,16 +67,16 @@ func Example_GetAll_Compound() {
 	}
 
 	// Setup table
-	r.Db("test").TableDrop("table").Run(sess)
-	r.Db("test").TableCreate("table").Run(sess)
-	r.Db("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
-	r.Db("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
+	r.DB("test").TableDrop("table").Run(sess)
+	r.DB("test").TableCreate("table").Run(sess)
+	r.DB("test").Table("table").Insert(Person{"1", "John", "Smith", "M"}).Run(sess)
+	r.DB("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).Run(sess)
-	r.Db("test").Table("table").IndexWait().Run(sess)
+	r.DB("test").Table("table").IndexWait().Run(sess)
 
 	// Fetch the row from the database
-	res, err := r.Db("test").Table("table").GetAllByIndex("full_name", []interface{}{"John", "Smith"}).Run(sess)
+	res, err := r.DB("test").Table("table").GetAllByIndex("full_name", []interface{}{"John", "Smith"}).Run(sess)
 	if err != nil {
 		log.Fatalf("Error finding person: %s", err)
 	}

--- a/example_query_table_test.go
+++ b/example_query_table_test.go
@@ -17,9 +17,9 @@ func Example_TableCreate() {
 	}
 
 	// Setup database
-	r.DB("test").TableDrop("table").Run(sess)
+	r.Db("test").TableDrop("table").Run(sess)
 
-	response, err := r.DB("test").TableCreate("table").RunWrite(sess)
+	response, err := r.Db("test").TableCreate("table").RunWrite(sess)
 	if err != nil {
 		log.Fatalf("Error creating table: %s", err)
 	}
@@ -40,10 +40,10 @@ func Example_IndexCreate() {
 	}
 
 	// Setup database
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
+	r.Db("test").TableDrop("table").Run(sess)
+	r.Db("test").TableCreate("table").Run(sess)
 
-	response, err := r.DB("test").Table("table").IndexCreate("name").RunWrite(sess)
+	response, err := r.Db("test").Table("table").IndexCreate("name").RunWrite(sess)
 	if err != nil {
 		log.Fatalf("Error creating index: %s", err)
 	}
@@ -64,10 +64,10 @@ func Example_IndexCreate_compound() {
 	}
 
 	// Setup database
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
+	r.Db("test").TableDrop("table").Run(sess)
+	r.Db("test").TableCreate("table").Run(sess)
 
-	response, err := r.DB("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
+	response, err := r.Db("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).RunWrite(sess)
 	if err != nil {

--- a/example_query_table_test.go
+++ b/example_query_table_test.go
@@ -1,14 +1,11 @@
-package gorethink_test
+package gorethink
 
 import (
 	"fmt"
-	"log"
-
-	r "github.com/dancannon/gorethink"
 )
 
 func Example_TableCreate() {
-	sess, err := r.Connect(r.ConnectOpts{
+	sess, err := Connect(ConnectOpts{
 		Address: url,
 		AuthKey: authKey,
 	})
@@ -17,9 +14,9 @@ func Example_TableCreate() {
 	}
 
 	// Setup database
-	r.DB("test").TableDrop("table").Run(sess)
+	DB("test").TableDrop("table").Run(sess)
 
-	response, err := r.DB("test").TableCreate("table").RunWrite(sess)
+	response, err := DB("test").TableCreate("table").RunWrite(sess)
 	if err != nil {
 		log.Fatalf("Error creating table: %s", err)
 	}
@@ -31,7 +28,7 @@ func Example_TableCreate() {
 }
 
 func Example_IndexCreate() {
-	sess, err := r.Connect(r.ConnectOpts{
+	sess, err := Connect(ConnectOpts{
 		Address: url,
 		AuthKey: authKey,
 	})
@@ -40,10 +37,10 @@ func Example_IndexCreate() {
 	}
 
 	// Setup database
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
+	DB("test").TableDrop("table").Run(sess)
+	DB("test").TableCreate("table").Run(sess)
 
-	response, err := r.DB("test").Table("table").IndexCreate("name").RunWrite(sess)
+	response, err := DB("test").Table("table").IndexCreate("name").RunWrite(sess)
 	if err != nil {
 		log.Fatalf("Error creating index: %s", err)
 	}
@@ -55,7 +52,7 @@ func Example_IndexCreate() {
 }
 
 func Example_IndexCreate_compound() {
-	sess, err := r.Connect(r.ConnectOpts{
+	sess, err := Connect(ConnectOpts{
 		Address: url,
 		AuthKey: authKey,
 	})
@@ -64,10 +61,10 @@ func Example_IndexCreate_compound() {
 	}
 
 	// Setup database
-	r.DB("test").TableDrop("table").Run(sess)
-	r.DB("test").TableCreate("table").Run(sess)
+	DB("test").TableDrop("table").Run(sess)
+	DB("test").TableCreate("table").Run(sess)
 
-	response, err := r.DB("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
+	response, err := DB("test").Table("table").IndexCreateFunc("full_name", func(row Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).RunWrite(sess)
 	if err != nil {

--- a/example_query_table_test.go
+++ b/example_query_table_test.go
@@ -17,9 +17,9 @@ func Example_TableCreate() {
 	}
 
 	// Setup database
-	r.Db("test").TableDrop("table").Run(sess)
+	r.DB("test").TableDrop("table").Run(sess)
 
-	response, err := r.Db("test").TableCreate("table").RunWrite(sess)
+	response, err := r.DB("test").TableCreate("table").RunWrite(sess)
 	if err != nil {
 		log.Fatalf("Error creating table: %s", err)
 	}
@@ -40,10 +40,10 @@ func Example_IndexCreate() {
 	}
 
 	// Setup database
-	r.Db("test").TableDrop("table").Run(sess)
-	r.Db("test").TableCreate("table").Run(sess)
+	r.DB("test").TableDrop("table").Run(sess)
+	r.DB("test").TableCreate("table").Run(sess)
 
-	response, err := r.Db("test").Table("table").IndexCreate("name").RunWrite(sess)
+	response, err := r.DB("test").Table("table").IndexCreate("name").RunWrite(sess)
 	if err != nil {
 		log.Fatalf("Error creating index: %s", err)
 	}
@@ -64,10 +64,10 @@ func Example_IndexCreate_compound() {
 	}
 
 	// Setup database
-	r.Db("test").TableDrop("table").Run(sess)
-	r.Db("test").TableCreate("table").Run(sess)
+	r.DB("test").TableDrop("table").Run(sess)
+	r.DB("test").TableCreate("table").Run(sess)
 
-	response, err := r.Db("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
+	response, err := r.DB("test").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).RunWrite(sess)
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -1,29 +1,11 @@
-package gorethink_test
+package gorethink
 
 import (
 	"fmt"
-	"log"
-	"os"
-
-	r "github.com/dancannon/gorethink"
 )
 
-var session *r.Session
-var url, authKey string
-
-func init() {
-	// Needed for wercker. By default url is "localhost:28015"
-	url = os.Getenv("RETHINKDB_URL")
-	if url == "" {
-		url = "localhost:28015"
-	}
-
-	// Needed for running tests for RethinkDB with a non-empty authkey
-	authKey = os.Getenv("RETHINKDB_AUTHKEY")
-}
-
 func Example() {
-	session, err := r.Connect(r.ConnectOpts{
+	session, err := Connect(ConnectOpts{
 		Address: url,
 		AuthKey: authKey,
 	})
@@ -31,7 +13,7 @@ func Example() {
 		log.Fatalf("Error connecting to DB: %s", err)
 	}
 
-	res, err := r.Expr("Hello World").Run(session)
+	res, err := Expr("Hello World").Run(session)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}

--- a/gorethink_test.go
+++ b/gorethink_test.go
@@ -71,16 +71,16 @@ func testBenchmarkSetup() {
 		log.Fatalln(err.Error())
 	}
 
-	DbDrop(bDbName).Exec(bSess)
-	DbCreate(bDbName).Exec(bSess)
+	DBDrop(bDbName).Exec(bSess)
+	DBCreate(bDbName).Exec(bSess)
 
-	Db(bDbName).TableDrop(bTableName).Run(bSess)
-	Db(bDbName).TableCreate(bTableName).Run(bSess)
+	DB(bDbName).TableDrop(bTableName).Run(bSess)
+	DB(bDbName).TableCreate(bTableName).Run(bSess)
 
 }
 
 func testBenchmarkTeardown() {
-	Db(bDbName).TableDrop(bTableName).Run(bSess)
+	DB(bDbName).TableDrop(bTableName).Run(bSess)
 	bSess.Close()
 }
 
@@ -278,9 +278,9 @@ func (s *RethinkSuite) BenchmarkNoReplyExpr(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkGet(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").RunWrite(sess)
-	Db("test").TableCreate("TestMany").RunWrite(sess)
-	Db("test").Table("TestMany").Delete().RunWrite(sess)
+	DBCreate("test").RunWrite(sess)
+	DB("test").TableCreate("TestMany").RunWrite(sess)
+	DB("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -289,14 +289,14 @@ func (s *RethinkSuite) BenchmarkGet(c *test.C) {
 			"id": i,
 		})
 	}
-	Db("test").Table("TestMany").Insert(data).Run(sess)
+	DB("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		n := rand.Intn(100)
 
 		// Test query
 		var response interface{}
-		query := Db("test").Table("TestMany").Get(n)
+		query := DB("test").Table("TestMany").Get(n)
 		res, err := query.Run(sess)
 		c.Assert(err, test.IsNil)
 
@@ -309,9 +309,9 @@ func (s *RethinkSuite) BenchmarkGet(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkGetStruct(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").RunWrite(sess)
-	Db("test").TableCreate("TestMany").RunWrite(sess)
-	Db("test").Table("TestMany").Delete().RunWrite(sess)
+	DBCreate("test").RunWrite(sess)
+	DB("test").TableCreate("TestMany").RunWrite(sess)
+	DB("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -325,14 +325,14 @@ func (s *RethinkSuite) BenchmarkGetStruct(c *test.C) {
 			}},
 		})
 	}
-	Db("test").Table("TestMany").Insert(data).Run(sess)
+	DB("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		n := rand.Intn(100)
 
 		// Test query
 		var resObj object
-		query := Db("test").Table("TestMany").Get(n)
+		query := DB("test").Table("TestMany").Get(n)
 		res, err := query.Run(sess)
 		c.Assert(err, test.IsNil)
 
@@ -344,9 +344,9 @@ func (s *RethinkSuite) BenchmarkGetStruct(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkSelectMany(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").RunWrite(sess)
-	Db("test").TableCreate("TestMany").RunWrite(sess)
-	Db("test").Table("TestMany").Delete().RunWrite(sess)
+	DBCreate("test").RunWrite(sess)
+	DB("test").TableCreate("TestMany").RunWrite(sess)
+	DB("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -355,11 +355,11 @@ func (s *RethinkSuite) BenchmarkSelectMany(c *test.C) {
 			"id": i,
 		})
 	}
-	Db("test").Table("TestMany").Insert(data).Run(sess)
+	DB("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		// Test query
-		res, err := Db("test").Table("TestMany").Run(sess)
+		res, err := DB("test").Table("TestMany").Run(sess)
 		c.Assert(err, test.IsNil)
 
 		var response []map[string]interface{}
@@ -372,9 +372,9 @@ func (s *RethinkSuite) BenchmarkSelectMany(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkSelectManyStruct(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").RunWrite(sess)
-	Db("test").TableCreate("TestMany").RunWrite(sess)
-	Db("test").Table("TestMany").Delete().RunWrite(sess)
+	DBCreate("test").RunWrite(sess)
+	DB("test").TableCreate("TestMany").RunWrite(sess)
+	DB("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -388,11 +388,11 @@ func (s *RethinkSuite) BenchmarkSelectManyStruct(c *test.C) {
 			}},
 		})
 	}
-	Db("test").Table("TestMany").Insert(data).Run(sess)
+	DB("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		// Test query
-		res, err := Db("test").Table("TestMany").Run(sess)
+		res, err := DB("test").Table("TestMany").Run(sess)
 		c.Assert(err, test.IsNil)
 
 		var response []object

--- a/gorethink_test.go
+++ b/gorethink_test.go
@@ -71,16 +71,16 @@ func testBenchmarkSetup() {
 		log.Fatalln(err.Error())
 	}
 
-	DBDrop(bDbName).Exec(bSess)
-	DBCreate(bDbName).Exec(bSess)
+	DbDrop(bDbName).Exec(bSess)
+	DbCreate(bDbName).Exec(bSess)
 
-	DB(bDbName).TableDrop(bTableName).Run(bSess)
-	DB(bDbName).TableCreate(bTableName).Run(bSess)
+	Db(bDbName).TableDrop(bTableName).Run(bSess)
+	Db(bDbName).TableCreate(bTableName).Run(bSess)
 
 }
 
 func testBenchmarkTeardown() {
-	DB(bDbName).TableDrop(bTableName).Run(bSess)
+	Db(bDbName).TableDrop(bTableName).Run(bSess)
 	bSess.Close()
 }
 
@@ -278,9 +278,9 @@ func (s *RethinkSuite) BenchmarkNoReplyExpr(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkGet(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").RunWrite(sess)
-	DB("test").TableCreate("TestMany").RunWrite(sess)
-	DB("test").Table("TestMany").Delete().RunWrite(sess)
+	DbCreate("test").RunWrite(sess)
+	Db("test").TableCreate("TestMany").RunWrite(sess)
+	Db("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -289,14 +289,14 @@ func (s *RethinkSuite) BenchmarkGet(c *test.C) {
 			"id": i,
 		})
 	}
-	DB("test").Table("TestMany").Insert(data).Run(sess)
+	Db("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		n := rand.Intn(100)
 
 		// Test query
 		var response interface{}
-		query := DB("test").Table("TestMany").Get(n)
+		query := Db("test").Table("TestMany").Get(n)
 		res, err := query.Run(sess)
 		c.Assert(err, test.IsNil)
 
@@ -309,9 +309,9 @@ func (s *RethinkSuite) BenchmarkGet(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkGetStruct(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").RunWrite(sess)
-	DB("test").TableCreate("TestMany").RunWrite(sess)
-	DB("test").Table("TestMany").Delete().RunWrite(sess)
+	DbCreate("test").RunWrite(sess)
+	Db("test").TableCreate("TestMany").RunWrite(sess)
+	Db("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -325,14 +325,14 @@ func (s *RethinkSuite) BenchmarkGetStruct(c *test.C) {
 			}},
 		})
 	}
-	DB("test").Table("TestMany").Insert(data).Run(sess)
+	Db("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		n := rand.Intn(100)
 
 		// Test query
 		var resObj object
-		query := DB("test").Table("TestMany").Get(n)
+		query := Db("test").Table("TestMany").Get(n)
 		res, err := query.Run(sess)
 		c.Assert(err, test.IsNil)
 
@@ -344,9 +344,9 @@ func (s *RethinkSuite) BenchmarkGetStruct(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkSelectMany(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").RunWrite(sess)
-	DB("test").TableCreate("TestMany").RunWrite(sess)
-	DB("test").Table("TestMany").Delete().RunWrite(sess)
+	DbCreate("test").RunWrite(sess)
+	Db("test").TableCreate("TestMany").RunWrite(sess)
+	Db("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -355,11 +355,11 @@ func (s *RethinkSuite) BenchmarkSelectMany(c *test.C) {
 			"id": i,
 		})
 	}
-	DB("test").Table("TestMany").Insert(data).Run(sess)
+	Db("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		// Test query
-		res, err := DB("test").Table("TestMany").Run(sess)
+		res, err := Db("test").Table("TestMany").Run(sess)
 		c.Assert(err, test.IsNil)
 
 		var response []map[string]interface{}
@@ -372,9 +372,9 @@ func (s *RethinkSuite) BenchmarkSelectMany(c *test.C) {
 
 func (s *RethinkSuite) BenchmarkSelectManyStruct(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").RunWrite(sess)
-	DB("test").TableCreate("TestMany").RunWrite(sess)
-	DB("test").Table("TestMany").Delete().RunWrite(sess)
+	DbCreate("test").RunWrite(sess)
+	Db("test").TableCreate("TestMany").RunWrite(sess)
+	Db("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	data := []interface{}{}
@@ -388,11 +388,11 @@ func (s *RethinkSuite) BenchmarkSelectManyStruct(c *test.C) {
 			}},
 		})
 	}
-	DB("test").Table("TestMany").Insert(data).Run(sess)
+	Db("test").Table("TestMany").Insert(data).Run(sess)
 
 	for i := 0; i < c.N; i++ {
 		// Test query
-		res, err := DB("test").Table("TestMany").Run(sess)
+		res, err := Db("test").Table("TestMany").Run(sess)
 		c.Assert(err, test.IsNil)
 
 		var response []object

--- a/node.go
+++ b/node.go
@@ -139,7 +139,7 @@ func (n *Node) Exec(q Query) (err error) {
 // as being healthy.
 func (n *Node) Refresh() {
 	cursor, err := n.pool.Query(newQuery(
-		Db("rethinkdb").Table("server_status").Get(n.ID),
+		DB("rethinkdb").Table("server_status").Get(n.ID),
 		map[string]interface{}{},
 		n.cluster.opts,
 	))

--- a/node.go
+++ b/node.go
@@ -139,7 +139,7 @@ func (n *Node) Exec(q Query) (err error) {
 // as being healthy.
 func (n *Node) Refresh() {
 	cursor, err := n.pool.Query(newQuery(
-		DB("rethinkdb").Table("server_status").Get(n.ID),
+		Db("rethinkdb").Table("server_status").Get(n.ID),
 		map[string]interface{}{},
 		n.cluster.opts,
 	))

--- a/pool.go
+++ b/pool.go
@@ -37,7 +37,6 @@ type Pool struct {
 	opts *ConnectOpts
 
 	mu           sync.Mutex // protects following fields
-	err          error      // the last error that occurred
 	freeConn     []*poolConn
 	connRequests []chan connRequest
 	numOpen      int

--- a/pool.go
+++ b/pool.go
@@ -16,10 +16,9 @@ const maxBadConnRetries = 10
 var (
 	connectionRequestQueueSize = 1000000
 
-	errPoolClosed   = errors.New("gorethink: pool is closed")
-	errConnClosed   = errors.New("gorethink: conn is closed")
-	errConnBusy     = errors.New("gorethink: conn is busy")
-	errConnInactive = errors.New("gorethink: conn was never active")
+	errPoolClosed = errors.New("gorethink: pool is closed")
+	errConnClosed = errors.New("gorethink: conn is closed")
+	errConnBusy   = errors.New("gorethink: conn is busy")
 )
 
 // depSet is a finalCloser's outstanding dependencies

--- a/pseudotypes.go
+++ b/pseudotypes.go
@@ -187,32 +187,33 @@ func reqlGeometryToNativeGeometry(obj map[string]interface{}) (interface{}, erro
 	} else if coords, ok := obj["coordinates"]; !ok {
 		return nil, fmt.Errorf("pseudo-type GEOMETRY object %v does not have the expected field \"coordinates\"", obj)
 	} else if typ == "Point" {
-		if point, err := types.UnmarshalPoint(coords); err != nil {
+		point, err := types.UnmarshalPoint(coords)
+		if err != nil {
 			return nil, err
-		} else {
-			return types.Geometry{
-				Type:  "Point",
-				Point: point,
-			}, nil
 		}
+
+		return types.Geometry{
+			Type:  "Point",
+			Point: point,
+		}, nil
 	} else if typ == "LineString" {
-		if line, err := types.UnmarshalLineString(coords); err != nil {
+		line, err := types.UnmarshalLineString(coords)
+		if err != nil {
 			return nil, err
-		} else {
-			return types.Geometry{
-				Type: "LineString",
-				Line: line,
-			}, nil
 		}
+		return types.Geometry{
+			Type: "LineString",
+			Line: line,
+		}, nil
 	} else if typ == "Polygon" {
-		if lines, err := types.UnmarshalPolygon(coords); err != nil {
+		lines, err := types.UnmarshalPolygon(coords)
+		if err != nil {
 			return nil, err
-		} else {
-			return types.Geometry{
-				Type:  "Polygon",
-				Lines: lines,
-			}, nil
 		}
+		return types.Geometry{
+			Type:  "Polygon",
+			Lines: lines,
+		}, nil
 	} else {
 		return nil, fmt.Errorf("pseudo-type GEOMETRY object %v field has unknown type %s", obj, typ)
 	}

--- a/query.go
+++ b/query.go
@@ -143,32 +143,32 @@ type OptArgs interface {
 	toMap() map[string]interface{}
 }
 
-// WriteResponse is a helper typed used when dealing with the response of a
+// WriteResponse is a helper type used when dealing with the response of a
 // write query. It is also returned by the RunWrite function.
 type WriteResponse struct {
-	Errors        int           `gorethink:"errors"`
-	Inserted      int           `gorethink:"inserted"`
-	Updated       int           `gorethink:"updated"`
-	Unchanged     int           `gorethink:"unchanged"`
-	Replaced      int           `gorethink:"replaced"`
-	Renamed       int           `gorethink:"renamed"`
-	Skipped       int           `gorethink:"skipped"`
-	Deleted       int           `gorethink:"deleted"`
-	Created       int           `gorethink:"created"`
-	DBsCreated    int           `gorethink:"dbs_created"`
-	TablesCreated int           `gorethink:"tables_created"`
-	Dropped       int           `gorethink:"dropped"`
-	DBsDropped    int           `gorethink:"dbs_dropped"`
-	TablesDropped int           `gorethink:"tables_dropped"`
-	GeneratedKeys []string      `gorethink:"generated_keys"`
-	FirstError    string        `gorethink:"first_error"` // populated if Errors > 0
-	ConfigChanges []ChangeValue `gorethink:"config_changes"`
-	Changes       []ChangeValue
+	Errors        int              `gorethink:"errors"`
+	Inserted      int              `gorethink:"inserted"`
+	Updated       int              `gorethink:"updated"`
+	Unchanged     int              `gorethink:"unchanged"`
+	Replaced      int              `gorethink:"replaced"`
+	Renamed       int              `gorethink:"renamed"`
+	Skipped       int              `gorethink:"skipped"`
+	Deleted       int              `gorethink:"deleted"`
+	Created       int              `gorethink:"created"`
+	DBsCreated    int              `gorethink:"dbs_created"`
+	TablesCreated int              `gorethink:"tables_created"`
+	Dropped       int              `gorethink:"dropped"`
+	DBsDropped    int              `gorethink:"dbs_dropped"`
+	TablesDropped int              `gorethink:"tables_dropped"`
+	GeneratedKeys []string         `gorethink:"generated_keys"`
+	FirstError    string           `gorethink:"first_error"` // populated if Errors > 0
+	ConfigChanges []ChangeResponse `gorethink:"config_changes"`
+	Changes       []ChangeResponse
 }
 
-// ChangeValue is a helper type used when dealing with changefeeds. The type
+// ChangeResponse is a helper type used when dealing with changefeeds. The type
 // contains both the value before the query and the new value.
-type ChangeValue struct {
+type ChangeResponse struct {
 	NewValue interface{} `gorethink:"new_val"`
 	OldValue interface{} `gorethink:"old_val"`
 }

--- a/query.go
+++ b/query.go
@@ -8,6 +8,11 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
+// A Query represents a query ready to be sent to the database, A Query differs
+// from a Term as it contains both a query type and token. These values are used
+// by the database to determine if the query is continuing a previous request
+// and also allows the driver to identify the response as they can come out of
+// order.
 type Query struct {
 	Type  p.Query_QueryType
 	Token int64
@@ -30,6 +35,13 @@ func (q *Query) build() []interface{} {
 
 type termsList []Term
 type termsObj map[string]Term
+
+// A Term represents a query that is being built. Terms consist of a an array of
+// "sub-terms" and a term type. When a Term is a sub-term the first element of
+// the terms data is its parent Term.
+//
+// When built the term becomes a JSON array, for more information on the format
+// see http://rethinkdb.com/docs/writing-drivers/.
 type Term struct {
 	name     string
 	rootTerm bool
@@ -124,36 +136,44 @@ func (t Term) String() string {
 	return fmt.Sprintf("%s.%s(%s)", t.args[0].String(), t.name, strings.Join(allArgsToStringSlice(t.args[1:], t.optArgs), ", "))
 }
 
+// OptArgs is an interface used to represent a terms optional arguments. All
+// optional argument types have a toMap function, the returned map can be encoded
+// and sent as part of the query.
 type OptArgs interface {
 	toMap() map[string]interface{}
 }
 
+// WriteResponse is a helper typed used when dealing with the response of a
+// write query. It is also returned by the RunWrite function.
 type WriteResponse struct {
-	Errors        int            `gorethink:"errors"`
-	Inserted      int            `gorethink:"inserted"`
-	Updated       int            `gorethink:"updadte"`
-	Unchanged     int            `gorethink:"unchanged"`
-	Replaced      int            `gorethink:"replaced"`
-	Renamed       int            `gorethink:"renamed"`
-	Skipped       int            `gorethink:"skipped"`
-	Deleted       int            `gorethink:"deleted"`
-	Created       int            `gorethink:"created"`
-	DBsCreated    int            `gorethink:"dbs_created"`
-	TablesCreated int            `gorethink:"tables_created"`
-	Dropped       int            `gorethink:"dropped"`
-	DBsDropped    int            `gorethink:"dbs_dropped"`
-	TablesDropped int            `gorethink:"tables_dropped"`
-	GeneratedKeys []string       `gorethink:"generated_keys"`
-	FirstError    string         `gorethink:"first_error"` // populated if Errors > 0
-	ConfigChanges []WriteChanges `gorethink:"config_changes"`
-	Changes       []WriteChanges
+	Errors        int           `gorethink:"errors"`
+	Inserted      int           `gorethink:"inserted"`
+	Updated       int           `gorethink:"updated"`
+	Unchanged     int           `gorethink:"unchanged"`
+	Replaced      int           `gorethink:"replaced"`
+	Renamed       int           `gorethink:"renamed"`
+	Skipped       int           `gorethink:"skipped"`
+	Deleted       int           `gorethink:"deleted"`
+	Created       int           `gorethink:"created"`
+	DBsCreated    int           `gorethink:"dbs_created"`
+	TablesCreated int           `gorethink:"tables_created"`
+	Dropped       int           `gorethink:"dropped"`
+	DBsDropped    int           `gorethink:"dbs_dropped"`
+	TablesDropped int           `gorethink:"tables_dropped"`
+	GeneratedKeys []string      `gorethink:"generated_keys"`
+	FirstError    string        `gorethink:"first_error"` // populated if Errors > 0
+	ConfigChanges []ChangeValue `gorethink:"config_changes"`
+	Changes       []ChangeValue
 }
 
-type WriteChanges struct {
+// ChangeValue is a helper type used when dealing with changefeeds. The type
+// contains both the value before the query and the new value.
+type ChangeValue struct {
 	NewValue interface{} `gorethink:"new_val"`
 	OldValue interface{} `gorethink:"old_val"`
 }
 
+// RunOpts contains the optional arguments for the Run function.
 type RunOpts struct {
 	Db             interface{} `gorethink:"db,omitempty"`
 	Profile        interface{} `gorethink:"profile,omitempty"`
@@ -219,8 +239,9 @@ func (t Term) RunWrite(s *Session, optArgs ...RunOpts) (WriteResponse, error) {
 	return response, nil
 }
 
-// ExecOpts inherits its options from RunOpts, the only difference is the
-// addition of the NoReply field.
+// ExecOpts contains the optional arguments for the Exec function and  inherits
+// its options from RunOpts, the only difference is the addition of the NoReply
+// field.
 //
 // When NoReply is true it causes the driver not to wait to receive the result
 // and return immediately.

--- a/query_admin.go
+++ b/query_admin.go
@@ -16,6 +16,7 @@ func (t Term) Rebalance() Term {
 	return constructMethodTerm(t, "Rebalance", p.Term_REBALANCE, []interface{}{}, map[string]interface{}{})
 }
 
+// ReconfigureOpts contains the optional arguments for the Reconfigure term.
 type ReconfigureOpts struct {
 	Shards     interface{} `gorethink:"shards,omitempty"`
 	Replicas   interface{} `gorethink:"replicas,omitempty"`
@@ -37,6 +38,7 @@ func (t Term) Status() Term {
 	return constructMethodTerm(t, "Status", p.Term_STATUS, []interface{}{}, map[string]interface{}{})
 }
 
+// WaitOpts contains the optional arguments for the Wait term.
 type WaitOpts struct {
 	WaitFor interface{} `gorethink:"wait_for,omitempty"`
 	Timeout interface{} `gorethink:"timeout,omitempty"`

--- a/query_admin_test.go
+++ b/query_admin_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 func (s *RethinkSuite) TestAdminDbConfig(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := DB("test").Table("test").Config()
+	query := Db("test").Table("test").Config()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
@@ -22,11 +22,11 @@ func (s *RethinkSuite) TestAdminDbConfig(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminTableConfig(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := DB("test").Config()
+	query := Db("test").Config()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
@@ -39,11 +39,11 @@ func (s *RethinkSuite) TestAdminTableConfig(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminTableStatus(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := DB("test").Table("test").Status()
+	query := Db("test").Table("test").Status()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
@@ -57,8 +57,8 @@ func (s *RethinkSuite) TestAdminTableStatus(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminWait(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
 	query := Wait()
@@ -74,10 +74,10 @@ func (s *RethinkSuite) TestAdminWait(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminWaitOpts(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
-	query := DB("test").Table("test").Wait(WaitOpts{
+	query := Db("test").Table("test").Wait(WaitOpts{
 		WaitFor: "all_replicas_ready",
 		Timeout: 10,
 	})
@@ -93,11 +93,11 @@ func (s *RethinkSuite) TestAdminWaitOpts(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminStatus(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := DB("test").Table("test").Wait()
+	query := Db("test").Table("test").Wait()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)

--- a/query_admin_test.go
+++ b/query_admin_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 func (s *RethinkSuite) TestAdminDbConfig(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := Db("test").Table("test").Config()
+	query := DB("test").Table("test").Config()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
@@ -22,11 +22,11 @@ func (s *RethinkSuite) TestAdminDbConfig(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminTableConfig(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := Db("test").Config()
+	query := DB("test").Config()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
@@ -39,11 +39,11 @@ func (s *RethinkSuite) TestAdminTableConfig(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminTableStatus(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := Db("test").Table("test").Status()
+	query := DB("test").Table("test").Status()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
@@ -57,8 +57,8 @@ func (s *RethinkSuite) TestAdminTableStatus(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminWait(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
 	query := Wait()
@@ -74,10 +74,10 @@ func (s *RethinkSuite) TestAdminWait(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminWaitOpts(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
-	query := Db("test").Table("test").Wait(WaitOpts{
+	query := DB("test").Table("test").Wait(WaitOpts{
 		WaitFor: "all_replicas_ready",
 		Timeout: 10,
 	})
@@ -93,11 +93,11 @@ func (s *RethinkSuite) TestAdminWaitOpts(c *test.C) {
 }
 
 func (s *RethinkSuite) TestAdminStatus(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
 	// Test index rename
-	query := Db("test").Table("test").Wait()
+	query := DB("test").Table("test").Wait()
 
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)

--- a/query_aggregation.go
+++ b/query_aggregation.go
@@ -45,6 +45,20 @@ func (t Term) Group(fieldOrFunctions ...interface{}) Term {
 	return constructMethodTerm(t, "Group", p.Term_GROUP, funcWrapArgs(fieldOrFunctions), map[string]interface{}{})
 }
 
+// MultiGroup takes a stream and partitions it into multiple groups based on the
+// fields or functions provided. Commands chained after group will be
+// called on each of these grouped sub-streams, producing grouped data.
+//
+// Unlike Group single documents can be assigned to multiple groups, similar
+// to the behavior of multi-indexes. When the grouping value is an array, documents
+// will be placed in each group that corresponds to the elements of the array. If
+// the array is empty the row will be ignored.
+func (t Term) MultiGroup(fieldOrFunctions ...interface{}) Term {
+	return constructMethodTerm(t, "Group", p.Term_GROUP, funcWrapArgs(fieldOrFunctions), map[string]interface{}{
+		"multi": true,
+	})
+}
+
 // GroupByIndex takes a stream and partitions it into multiple groups based on the
 // fields or functions provided. Commands chained after group will be
 // called on each of these grouped sub-streams, producing grouped data.
@@ -54,8 +68,23 @@ func (t Term) GroupByIndex(index interface{}, fieldOrFunctions ...interface{}) T
 	})
 }
 
+// MultiGroupByIndex takes a stream and partitions it into multiple groups based on the
+// fields or functions provided. Commands chained after group will be
+// called on each of these grouped sub-streams, producing grouped data.
+//
+// Unlike Group single documents can be assigned to multiple groups, similar
+// to the behavior of multi-indexes. When the grouping value is an array, documents
+// will be placed in each group that corresponds to the elements of the array. If
+// the array is empty the row will be ignored.
+func (t Term) MultiGroupByIndex(index interface{}, fieldOrFunctions ...interface{}) Term {
+	return constructMethodTerm(t, "Group", p.Term_GROUP, funcWrapArgs(fieldOrFunctions), map[string]interface{}{
+		"index": index,
+		"mutli": true,
+	})
+}
+
 // Ungroup takes a grouped stream or grouped data and turns it into an array of
-// objects representing the groups. Any commands chained after ungroup will
+// objects representing the groups. Any commands chained after Ungroup will
 // operate on this array, rather than operating on each group individually.
 // This is useful if you want to e.g. order the groups by the value of their
 // reduction.

--- a/query_aggregation.go
+++ b/query_aggregation.go
@@ -20,6 +20,7 @@ func (t Term) Reduce(args ...interface{}) Term {
 	return constructMethodTerm(t, "Reduce", p.Term_REDUCE, funcWrapArgs(args), map[string]interface{}{})
 }
 
+// DistinctOpts contains the optional arguments for the Distinct term
 type DistinctOpts struct {
 	Index interface{} `gorethink:"index,omitempty"`
 }
@@ -28,7 +29,7 @@ func (o *DistinctOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Remove duplicate elements from the sequence.
+// Distinct removes duplicate elements from the sequence.
 func (t Term) Distinct(optArgs ...DistinctOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -37,14 +38,14 @@ func (t Term) Distinct(optArgs ...DistinctOpts) Term {
 	return constructMethodTerm(t, "Distinct", p.Term_DISTINCT, []interface{}{}, opts)
 }
 
-// Takes a stream and partitions it into multiple groups based on the
+// Group takes a stream and partitions it into multiple groups based on the
 // fields or functions provided. Commands chained after group will be
-//  called on each of these grouped sub-streams, producing grouped data.
+// called on each of these grouped sub-streams, producing grouped data.
 func (t Term) Group(fieldOrFunctions ...interface{}) Term {
 	return constructMethodTerm(t, "Group", p.Term_GROUP, funcWrapArgs(fieldOrFunctions), map[string]interface{}{})
 }
 
-// Takes a stream and partitions it into multiple groups based on the
+// GroupByIndex takes a stream and partitions it into multiple groups based on the
 // fields or functions provided. Commands chained after group will be
 // called on each of these grouped sub-streams, producing grouped data.
 func (t Term) GroupByIndex(index interface{}, fieldOrFunctions ...interface{}) Term {
@@ -53,19 +54,24 @@ func (t Term) GroupByIndex(index interface{}, fieldOrFunctions ...interface{}) T
 	})
 }
 
+// Ungroup takes a grouped stream or grouped data and turns it into an array of
+// objects representing the groups. Any commands chained after ungroup will
+// operate on this array, rather than operating on each group individually.
+// This is useful if you want to e.g. order the groups by the value of their
+// reduction.
 func (t Term) Ungroup(args ...interface{}) Term {
 	return constructMethodTerm(t, "Ungroup", p.Term_UNGROUP, args, map[string]interface{}{})
 }
 
-//Returns whether or not a sequence contains all the specified values, or if
-//functions are provided instead, returns whether or not a sequence contains
-//values matching all the specified functions.
+// Contains returns whether or not a sequence contains all the specified values,
+// or if functions are provided instead, returns whether or not a sequence
+// contains values matching all the specified functions.
 func (t Term) Contains(args ...interface{}) Term {
 	return constructMethodTerm(t, "Contains", p.Term_CONTAINS, args, map[string]interface{}{})
 }
 
 // Aggregators
-// These standard aggregator objects are to be used in conjunction with group_by.
+// These standard aggregator objects are to be used in conjunction with Group.
 
 // Count the number of elements in the sequence. With a single argument,
 // count the number of elements equal to it. If the argument is a function,
@@ -74,25 +80,26 @@ func (t Term) Count(args ...interface{}) Term {
 	return constructMethodTerm(t, "Count", p.Term_COUNT, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Sums all the elements of a sequence. If called with a field name, sums all
-// the values of that field in the sequence, skipping elements of the sequence
-// that lack that field. If called with a function, calls that function on every
-// element of the sequence and sums the results, skipping elements of the
-// sequence where that function returns null or a non-existence error.
+// Sum returns the sum of all the elements of a sequence. If called with a field
+// name, sums all the values of that field in the sequence, skipping elements of
+// the sequence that lack that field. If called with a function, calls that
+// function on every element of the sequence and sums the results, skipping
+// elements of the sequence where that function returns null or a non-existence
+// error.
 func (t Term) Sum(args ...interface{}) Term {
 	return constructMethodTerm(t, "Sum", p.Term_SUM, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Averages all the elements of a sequence. If called with a field name, averages
-// all the values of that field in the sequence, skipping elements of the sequence
-// that lack that field. If called with a function, calls that function on every
-// element of the sequence and averages the results, skipping elements of the
+// Avg returns the average of all the elements of a sequence. If called with a field
+// name, averages all the values of that field in the sequence, skipping elements of
+// the sequence that lack that field. If called with a function, calls that function
+// on every element of the sequence and averages the results, skipping elements of the
 // sequence where that function returns null or a non-existence error.
 func (t Term) Avg(args ...interface{}) Term {
 	return constructMethodTerm(t, "Avg", p.Term_AVG, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Finds the minimum of a sequence. If called with a field name, finds the element
+// Min finds the minimum of a sequence. If called with a field name, finds the element
 // of that sequence with the smallest value in that field. If called with a function,
 // calls that function on every element of the sequence and returns the element
 // which produced the smallest value, ignoring any elements where the function
@@ -101,7 +108,7 @@ func (t Term) Min(args ...interface{}) Term {
 	return constructMethodTerm(t, "Min", p.Term_MIN, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Finds the minimum of a sequence. If called with a field name, finds the element
+// MinIndex finds the minimum of a sequence. If called with a field name, finds the element
 // of that sequence with the smallest value in that field. If called with a function,
 // calls that function on every element of the sequence and returns the element
 // which produced the smallest value, ignoring any elements where the function
@@ -112,7 +119,7 @@ func (t Term) MinIndex(index interface{}, args ...interface{}) Term {
 	})
 }
 
-// Finds the maximum of a sequence. If called with a field name, finds the element
+// Max finds the maximum of a sequence. If called with a field name, finds the element
 // of that sequence with the largest value in that field. If called with a function,
 // calls that function on every element of the sequence and returns the element
 // which produced the largest value, ignoring any elements where the function
@@ -121,7 +128,7 @@ func (t Term) Max(args ...interface{}) Term {
 	return constructMethodTerm(t, "Max", p.Term_MAX, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Finds the maximum of a sequence. If called with a field name, finds the element
+// MaxIndex finds the maximum of a sequence. If called with a field name, finds the element
 // of that sequence with the largest value in that field. If called with a function,
 // calls that function on every element of the sequence and returns the element
 // which produced the largest value, ignoring any elements where the function

--- a/query_aggregation_test.go
+++ b/query_aggregation_test.go
@@ -85,15 +85,15 @@ func (s *RethinkSuite) TestAggregationGroupMapReduceUngroup(c *test.C) {
 
 func (s *RethinkSuite) TestAggregationGroupMapReduceTable(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("TestAggregationGroupedMapReduceTable").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("TestAggregationGroupedMapReduceTable").Exec(sess)
 
 	// Insert rows
-	err := Db("test").Table("TestAggregationGroupedMapReduceTable").Insert(objList).Exec(sess)
+	err := DB("test").Table("TestAggregationGroupedMapReduceTable").Insert(objList).Exec(sess)
 	c.Assert(err, test.IsNil)
 
 	var response []interface{}
-	query := Db("test").Table("TestAggregationGroupedMapReduceTable").Group(func(row Term) Term {
+	query := DB("test").Table("TestAggregationGroupedMapReduceTable").Group(func(row Term) Term {
 		return row.Field("id").Mod(2).Eq(0)
 	}).Map(func(row Term) Term {
 		return row.Field("num")
@@ -212,16 +212,16 @@ func (s *RethinkSuite) TestAggregationGroupMax(c *test.C) {
 
 func (s *RethinkSuite) TestAggregationMin(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table2").Exec(sess)
-	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table2").Exec(sess)
+	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table2").Insert(objList).Exec(sess)
+	DB("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := Db("test").Table("Table2").MinIndex("num")
+	query := DB("test").Table("Table2").MinIndex("num")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -233,16 +233,16 @@ func (s *RethinkSuite) TestAggregationMin(c *test.C) {
 
 func (s *RethinkSuite) TestAggregationMaxIndex(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table2").Exec(sess)
-	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table2").Exec(sess)
+	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table2").Insert(objList).Exec(sess)
+	DB("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := Db("test").Table("Table2").MaxIndex("num")
+	query := DB("test").Table("Table2").MaxIndex("num")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 

--- a/query_aggregation_test.go
+++ b/query_aggregation_test.go
@@ -85,15 +85,15 @@ func (s *RethinkSuite) TestAggregationGroupMapReduceUngroup(c *test.C) {
 
 func (s *RethinkSuite) TestAggregationGroupMapReduceTable(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("TestAggregationGroupedMapReduceTable").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("TestAggregationGroupedMapReduceTable").Exec(sess)
 
 	// Insert rows
-	err := DB("test").Table("TestAggregationGroupedMapReduceTable").Insert(objList).Exec(sess)
+	err := Db("test").Table("TestAggregationGroupedMapReduceTable").Insert(objList).Exec(sess)
 	c.Assert(err, test.IsNil)
 
 	var response []interface{}
-	query := DB("test").Table("TestAggregationGroupedMapReduceTable").Group(func(row Term) Term {
+	query := Db("test").Table("TestAggregationGroupedMapReduceTable").Group(func(row Term) Term {
 		return row.Field("id").Mod(2).Eq(0)
 	}).Map(func(row Term) Term {
 		return row.Field("num")
@@ -212,16 +212,16 @@ func (s *RethinkSuite) TestAggregationGroupMax(c *test.C) {
 
 func (s *RethinkSuite) TestAggregationMin(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table2").Exec(sess)
-	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table2").Exec(sess)
+	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table2").Insert(objList).Exec(sess)
+	Db("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := DB("test").Table("Table2").MinIndex("num")
+	query := Db("test").Table("Table2").MinIndex("num")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -233,16 +233,16 @@ func (s *RethinkSuite) TestAggregationMin(c *test.C) {
 
 func (s *RethinkSuite) TestAggregationMaxIndex(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table2").Exec(sess)
-	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table2").Exec(sess)
+	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table2").Insert(objList).Exec(sess)
+	Db("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := DB("test").Table("Table2").MaxIndex("num")
+	query := Db("test").Table("Table2").MaxIndex("num")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 

--- a/query_control.go
+++ b/query_control.go
@@ -10,13 +10,32 @@ import (
 
 var byteSliceType = reflect.TypeOf([]byte(nil))
 
-// Expr converts any value to an expression.  Internally it uses the `json`
-// module to convert any literals, so any type annotations or methods understood
-// by that module can be used. If the value cannot be converted, an error is
-// returned at query .Run(session) time.
+// Expr converts any value to an expression and is also used by many other terms
+// such as Insert and Update. This function can convert the following basic Go
+// types (bool, int, uint, string, float) and even pointers, maps and structs.
 //
-// If you want to call expression methods on an object that is not yet an
-// expression, this is the function you want.
+// When evaluating structs they are encoded into a map before being sent to the
+// server. Each exported field is added to the map unless
+//
+//  - the field's tag is "-", or
+//  - the field is empty and its tag specifies the "omitempty" option.
+//
+// Each fields default name in the map is the field name but can be specified
+// in the struct field's tag value. The "gorethink" key in the struct field's
+// tag value is the key name, followed by an optional comma and options. Examples:
+//
+//   // Field is ignored by this package.
+//   Field int `gorethink:"-"`
+//   // Field appears as key "myName".
+//   Field int `gorethink:"myName"`
+//   // Field appears as key "myName" and
+//   // the field is omitted from the object if its value is empty,
+//   // as defined above.
+//   Field int `gorethink:"myName,omitempty"`
+//   // Field appears as key "Field" (the default), but
+//   // the field is skipped if empty.
+//   // Note the leading comma.
+//   Field int `gorethink:",omitempty"`
 func Expr(val interface{}) Term {
 	return expr(val, 20)
 }
@@ -83,14 +102,14 @@ func expr(val interface{}, depth int) Term {
 				}
 
 				return expr(data, depth-1)
-			} else {
-				vals := make([]Term, valValue.Len())
-				for i := 0; i < valValue.Len(); i++ {
-					vals[i] = expr(valValue.Index(i).Interface(), depth)
-				}
-
-				return makeArray(vals)
 			}
+
+			vals := make([]Term, valValue.Len())
+			for i := 0; i < valValue.Len(); i++ {
+				vals[i] = expr(valValue.Index(i).Interface(), depth)
+			}
+
+			return makeArray(vals)
 		case reflect.Map:
 			vals := make(map[string]Term, len(valValue.MapKeys()))
 			for _, k := range valValue.MapKeys() {
@@ -107,12 +126,14 @@ func expr(val interface{}, depth int) Term {
 	}
 }
 
-// Create a JavaScript expression.
-func Js(jssrc interface{}) Term {
+// JS creates a JavaScript expression which is evaluated by the database when
+// running the query.
+func JS(jssrc interface{}) Term {
 	return constructRootTerm("Js", p.Term_JAVASCRIPT, []interface{}{jssrc}, map[string]interface{}{})
 }
 
-type HttpOpts struct {
+// HTTPOpts contains the optional arguments for the HTTP term
+type HTTPOpts struct {
 	// General Options
 	Timeout      interface{} `gorethink:"timeout,omitempty"`
 	Reattempts   interface{} `gorethink:"reattempts,omitempty"`
@@ -132,12 +153,14 @@ type HttpOpts struct {
 	PageLimit interface{} `gorethink:"page_limit,omitempty"`
 }
 
-func (o *HttpOpts) toMap() map[string]interface{} {
+func (o *HTTPOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Parse a JSON string on the server.
-func Http(url interface{}, optArgs ...HttpOpts) Term {
+// HTTP retrieves data from the specified URL over HTTP. The return type depends
+// on the resultFormat option, which checks the Content-Type of the response by
+// default.
+func HTTP(url interface{}, optArgs ...HTTPOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
 		opts = optArgs[0].toMap()
@@ -145,12 +168,12 @@ func Http(url interface{}, optArgs ...HttpOpts) Term {
 	return constructRootTerm("Http", p.Term_HTTP, []interface{}{url}, opts)
 }
 
-// Parse a JSON string on the server.
-func Json(args ...interface{}) Term {
+// JSON parses a JSON string on the server.
+func JSON(args ...interface{}) Term {
 	return constructRootTerm("Json", p.Term_JSON, args, map[string]interface{}{})
 }
 
-// Throw a runtime error. If called with no arguments inside the second argument
+// Error throws a runtime error. If called with no arguments inside the second argument
 // to `default`, re-throw the current error.
 func Error(args ...interface{}) Term {
 	return constructRootTerm("Error", p.Term_ERROR, args, map[string]interface{}{})
@@ -191,7 +214,7 @@ func binaryTerm(data string) Term {
 	return t
 }
 
-// Evaluate the expr in the context of one or more value bindings. The type of
+// Do evaluates the expr in the context of one or more value bindings. The type of
 // the result is the type of the value returned from expr.
 func (t Term) Do(args ...interface{}) Term {
 	newArgs := []interface{}{}
@@ -202,7 +225,7 @@ func (t Term) Do(args ...interface{}) Term {
 	return constructRootTerm("Do", p.Term_FUNCALL, newArgs, map[string]interface{}{})
 }
 
-// Evaluate the expr in the context of one or more value bindings. The type of
+// Do evaluates the expr in the context of one or more value bindings. The type of
 // the result is the type of the value returned from expr.
 func Do(args ...interface{}) Term {
 	newArgs := []interface{}{}
@@ -212,7 +235,7 @@ func Do(args ...interface{}) Term {
 	return constructRootTerm("Do", p.Term_FUNCALL, newArgs, map[string]interface{}{})
 }
 
-// Evaluate one of two control paths based on the value of an expression.
+// Branch evaluates one of two control paths based on the value of an expression.
 // branch is effectively an if renamed due to language constraints.
 //
 // The type of the result is determined by the type of the branch that gets executed.
@@ -238,7 +261,7 @@ func Range(args ...interface{}) Term {
 	return constructRootTerm("Range", p.Term_RANGE, args, map[string]interface{}{})
 }
 
-// Handle non-existence errors. Tries to evaluate and return its first argument.
+// Default handles non-existence errors. Tries to evaluate and return its first argument.
 // If an error related to the absence of a value is thrown in the process, or if
 // its first argument returns null, returns its second argument. (Alternatively,
 // the second argument may be a function which will be called with either the
@@ -247,7 +270,7 @@ func (t Term) Default(args ...interface{}) Term {
 	return constructMethodTerm(t, "Default", p.Term_DEFAULT, args, map[string]interface{}{})
 }
 
-// Converts a value of one type into another.
+// CoerceTo converts a value of one type into another.
 //
 // You can convert: a selection, sequence, or object into an ARRAY, an array of
 // pairs into an OBJECT, and any DATUM into a STRING.
@@ -255,17 +278,17 @@ func (t Term) CoerceTo(args ...interface{}) Term {
 	return constructMethodTerm(t, "CoerceTo", p.Term_COERCE_TO, args, map[string]interface{}{})
 }
 
-// Gets the type of a value.
+// TypeOf gets the type of a value.
 func (t Term) TypeOf(args ...interface{}) Term {
 	return constructMethodTerm(t, "TypeOf", p.Term_TYPE_OF, args, map[string]interface{}{})
 }
 
-// Gets the type of a value.
+// ToJSON converts a ReQL value or object to a JSON string.
 func (t Term) ToJSON() Term {
 	return constructMethodTerm(t, "ToJSON", p.Term_TO_JSON_STRING, []interface{}{}, map[string]interface{}{})
 }
 
-// Get information about a RQL value.
+// Info gets information about a RQL value.
 func (t Term) Info(args ...interface{}) Term {
 	return constructMethodTerm(t, "Info", p.Term_INFO, args, map[string]interface{}{})
 }

--- a/query_control.go
+++ b/query_control.go
@@ -8,8 +8,6 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-var byteSliceType = reflect.TypeOf([]byte(nil))
-
 // Expr converts any value to an expression and is also used by many other terms
 // such as Insert and Update. This function can convert the following basic Go
 // types (bool, int, uint, string, float) and even pointers, maps and structs.

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -189,7 +189,7 @@ func (s *RethinkSuite) TestControlError(c *test.C) {
 	c.Assert(err, test.NotNil)
 
 	c.Assert(err, test.NotNil)
-	c.Assert(err, test.FitsTypeOf, RqlRuntimeError{})
+	c.Assert(err, test.FitsTypeOf, RQLRuntimeError{})
 
 	c.Assert(err.Error(), test.Equals, "gorethink: An error occurred in: \nr.Error(\"An error occurred\")")
 }

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -189,7 +189,7 @@ func (s *RethinkSuite) TestControlError(c *test.C) {
 	c.Assert(err, test.NotNil)
 
 	c.Assert(err, test.NotNil)
-	c.Assert(err, test.FitsTypeOf, RqlRuntimeError{})
+	c.Assert(err, test.FitsTypeOf, ErrRQLRuntime{})
 
 	c.Assert(err.Error(), test.Equals, "gorethink: An error occurred in: \nr.Error(\"An error occurred\")")
 }

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -189,7 +189,7 @@ func (s *RethinkSuite) TestControlError(c *test.C) {
 	c.Assert(err, test.NotNil)
 
 	c.Assert(err, test.NotNil)
-	c.Assert(err, test.FitsTypeOf, ErrRQLRuntime{})
+	c.Assert(err, test.FitsTypeOf, RQLRuntimeError{})
 
 	c.Assert(err.Error(), test.Equals, "gorethink: An error occurred in: \nr.Error(\"An error occurred\")")
 }

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -189,7 +189,7 @@ func (s *RethinkSuite) TestControlError(c *test.C) {
 	c.Assert(err, test.NotNil)
 
 	c.Assert(err, test.NotNil)
-	c.Assert(err, test.FitsTypeOf, RQLRuntimeError{})
+	c.Assert(err, test.FitsTypeOf, RqlRuntimeError{})
 
 	c.Assert(err.Error(), test.Equals, "gorethink: An error occurred in: \nr.Error(\"An error occurred\")")
 }

--- a/query_control_test.go
+++ b/query_control_test.go
@@ -143,7 +143,7 @@ func (s *RethinkSuite) TestControlExprTypes(c *test.C) {
 
 func (s *RethinkSuite) TestControlJs(c *test.C) {
 	var response int
-	query := Js("1;")
+	query := JS("1;")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -159,7 +159,7 @@ func (s *RethinkSuite) TestControlHttp(c *test.C) {
 	}
 
 	var response map[string]interface{}
-	query := Http("httpbin.org/get?data=1")
+	query := HTTP("httpbin.org/get?data=1")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -173,7 +173,7 @@ func (s *RethinkSuite) TestControlHttp(c *test.C) {
 
 func (s *RethinkSuite) TestControlJson(c *test.C) {
 	var response []int
-	query := Json("[1,2,3]")
+	query := JSON("[1,2,3]")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 

--- a/query_db.go
+++ b/query_db.go
@@ -11,7 +11,7 @@ import (
 // with the same name already exists the operation throws RqlRuntimeError.
 //
 // Note: that you can only use alphanumeric characters and underscores for the database name.
-func DbCreate(args ...interface{}) Term {
+func DBCreate(args ...interface{}) Term {
 	return constructRootTerm("DbCreate", p.Term_DB_CREATE, args, map[string]interface{}{})
 }
 
@@ -20,7 +20,7 @@ func DbCreate(args ...interface{}) Term {
 //
 // If successful, the operation returns the object {dropped: 1}. If the specified
 // database doesn't exist a RqlRuntimeError is thrown.
-func DbDrop(args ...interface{}) Term {
+func DBDrop(args ...interface{}) Term {
 	return constructRootTerm("DbDrop", p.Term_DB_DROP, args, map[string]interface{}{})
 }
 

--- a/query_db.go
+++ b/query_db.go
@@ -4,22 +4,17 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// DBCreate creates a database. A RethinkDB database is a collection of tables, similar to
-// relational databases.
+// DBCreate creates a database. A RethinkDB database is a collection of tables,
+// similar to relational databases.
 //
-// If successful, the operation returns an object: {created: 1}. If a database
-// with the same name already exists the operation throws RqlRuntimeError.
-//
-// Note: that you can only use alphanumeric characters and underscores for the database name.
+// Note: that you can only use alphanumeric characters and underscores for the
+// database name.
 func DBCreate(args ...interface{}) Term {
 	return constructRootTerm("DBCreate", p.Term_DB_CREATE, args, map[string]interface{}{})
 }
 
-// DBDrop drops a database. The database, all its tables, and corresponding data will be
-// deleted.
-//
-// If successful, the operation returns the object {dropped: 1}. If the specified
-// database doesn't exist a RqlRuntimeError is thrown.
+// DBDrop drops a database. The database, all its tables, and corresponding data
+// will be deleted.
 func DBDrop(args ...interface{}) Term {
 	return constructRootTerm("DBDrop", p.Term_DB_DROP, args, map[string]interface{}{})
 }

--- a/query_db.go
+++ b/query_db.go
@@ -4,7 +4,7 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// Create a database. A RethinkDB database is a collection of tables, similar to
+// DBCreate creates a database. A RethinkDB database is a collection of tables, similar to
 // relational databases.
 //
 // If successful, the operation returns an object: {created: 1}. If a database
@@ -12,19 +12,19 @@ import (
 //
 // Note: that you can only use alphanumeric characters and underscores for the database name.
 func DBCreate(args ...interface{}) Term {
-	return constructRootTerm("DbCreate", p.Term_DB_CREATE, args, map[string]interface{}{})
+	return constructRootTerm("DBCreate", p.Term_DB_CREATE, args, map[string]interface{}{})
 }
 
-// Drop a database. The database, all its tables, and corresponding data will be
+// DBDrop drops a database. The database, all its tables, and corresponding data will be
 // deleted.
 //
 // If successful, the operation returns the object {dropped: 1}. If the specified
 // database doesn't exist a RqlRuntimeError is thrown.
 func DBDrop(args ...interface{}) Term {
-	return constructRootTerm("DbDrop", p.Term_DB_DROP, args, map[string]interface{}{})
+	return constructRootTerm("DBDrop", p.Term_DB_DROP, args, map[string]interface{}{})
 }
 
-// List all database names in the system.
-func DbList(args ...interface{}) Term {
-	return constructRootTerm("DbList", p.Term_DB_LIST, args, map[string]interface{}{})
+// DBList lists all database names in the system.
+func DBList(args ...interface{}) Term {
+	return constructRootTerm("DBList", p.Term_DB_LIST, args, map[string]interface{}{})
 }

--- a/query_db.go
+++ b/query_db.go
@@ -11,7 +11,7 @@ import (
 // with the same name already exists the operation throws RqlRuntimeError.
 //
 // Note: that you can only use alphanumeric characters and underscores for the database name.
-func DBCreate(args ...interface{}) Term {
+func DbCreate(args ...interface{}) Term {
 	return constructRootTerm("DbCreate", p.Term_DB_CREATE, args, map[string]interface{}{})
 }
 
@@ -20,7 +20,7 @@ func DBCreate(args ...interface{}) Term {
 //
 // If successful, the operation returns the object {dropped: 1}. If the specified
 // database doesn't exist a RqlRuntimeError is thrown.
-func DBDrop(args ...interface{}) Term {
+func DbDrop(args ...interface{}) Term {
 	return constructRootTerm("DbDrop", p.Term_DB_DROP, args, map[string]interface{}{})
 }
 

--- a/query_db_test.go
+++ b/query_db_test.go
@@ -6,10 +6,10 @@ import (
 
 func (s *RethinkSuite) TestDbCreate(c *test.C) {
 	// Delete the test2 database if it already exists
-	DbDrop("test").Exec(sess)
+	DBDrop("test").Exec(sess)
 
 	// Test database creation
-	query := DbCreate("test")
+	query := DBCreate("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -20,7 +20,7 @@ func (s *RethinkSuite) TestDbList(c *test.C) {
 	var response []interface{}
 
 	// create database
-	DbCreate("test").Exec(sess)
+	DBCreate("test").Exec(sess)
 
 	// Try and find it in the list
 	success := false
@@ -43,15 +43,15 @@ func (s *RethinkSuite) TestDbList(c *test.C) {
 
 func (s *RethinkSuite) TestDbDelete(c *test.C) {
 	// Delete the test2 database if it already exists
-	DbCreate("test").Exec(sess)
+	DBCreate("test").Exec(sess)
 
 	// Test database creation
-	query := DbDrop("test")
+	query := DBDrop("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(response.DBsDropped, jsonEquals, 1)
 
 	// Ensure that there is still a test DB after the test has finished
-	DbCreate("test").Exec(sess)
+	DBCreate("test").Exec(sess)
 }

--- a/query_db_test.go
+++ b/query_db_test.go
@@ -24,7 +24,7 @@ func (s *RethinkSuite) TestDbList(c *test.C) {
 
 	// Try and find it in the list
 	success := false
-	res, err := DbList().Run(sess)
+	res, err := DBList().Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.All(&response)

--- a/query_db_test.go
+++ b/query_db_test.go
@@ -6,10 +6,10 @@ import (
 
 func (s *RethinkSuite) TestDbCreate(c *test.C) {
 	// Delete the test2 database if it already exists
-	DBDrop("test").Exec(sess)
+	DbDrop("test").Exec(sess)
 
 	// Test database creation
-	query := DBCreate("test")
+	query := DbCreate("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -20,7 +20,7 @@ func (s *RethinkSuite) TestDbList(c *test.C) {
 	var response []interface{}
 
 	// create database
-	DBCreate("test").Exec(sess)
+	DbCreate("test").Exec(sess)
 
 	// Try and find it in the list
 	success := false
@@ -43,15 +43,15 @@ func (s *RethinkSuite) TestDbList(c *test.C) {
 
 func (s *RethinkSuite) TestDbDelete(c *test.C) {
 	// Delete the test2 database if it already exists
-	DBCreate("test").Exec(sess)
+	DbCreate("test").Exec(sess)
 
 	// Test database creation
-	query := DBDrop("test")
+	query := DbDrop("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(response.DBsDropped, jsonEquals, 1)
 
 	// Ensure that there is still a test DB after the test has finished
-	DBCreate("test").Exec(sess)
+	DbCreate("test").Exec(sess)
 }

--- a/query_geospatial.go
+++ b/query_geospatial.go
@@ -4,7 +4,7 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// CircleOpts describes the optional arguments for a Circle operation
+// CircleOpts contains the optional arguments for the Circle term.
 type CircleOpts struct {
 	NumVertices interface{} `gorethink:"num_vertices,omitempty"`
 	GeoSystem   interface{} `gorethink:"geo_system,omitempty"`
@@ -28,7 +28,7 @@ func Circle(point, radius interface{}, optArgs ...CircleOpts) Term {
 	return constructRootTerm("Circle", p.Term_CIRCLE, []interface{}{point, radius}, opts)
 }
 
-// DistanceOpts describes the optional arguments for a Distance operation
+// DistanceOpts contains the optional arguments for the Distance term.
 type DistanceOpts struct {
 	GeoSystem interface{} `gorethink:"geo_system,omitempty"`
 	Unit      interface{} `gorethink:"unit,omitempty"`
@@ -67,17 +67,17 @@ func (t Term) Fill() Term {
 	return constructMethodTerm(t, "Fill", p.Term_FILL, []interface{}{}, map[string]interface{}{})
 }
 
-// Geojson converts a GeoJSON object to a ReQL geometry object.
-func Geojson(args ...interface{}) Term {
-	return constructRootTerm("Geojson", p.Term_GEOJSON, args, map[string]interface{}{})
+// GeoJSON converts a GeoJSON object to a ReQL geometry object.
+func GeoJSON(args ...interface{}) Term {
+	return constructRootTerm("GeoJSON", p.Term_GEOJSON, args, map[string]interface{}{})
 }
 
-// ToGeojson converts a ReQL geometry object to a GeoJSON object.
-func (t Term) ToGeojson(args ...interface{}) Term {
-	return constructMethodTerm(t, "ToGeojson", p.Term_TO_GEOJSON, args, map[string]interface{}{})
+// ToGeoJSON converts a ReQL geometry object to a GeoJSON object.
+func (t Term) ToGeoJSON(args ...interface{}) Term {
+	return constructMethodTerm(t, "ToGeoJSON", p.Term_TO_GEOJSON, args, map[string]interface{}{})
 }
 
-// GetIntersectingOpts describes the optional arguments for a GetIntersecting operation
+// GetIntersectingOpts contains the optional arguments for the GetIntersecting term.
 type GetIntersectingOpts struct {
 	Index interface{} `gorethink:"index,omitempty"`
 }
@@ -97,7 +97,7 @@ func (t Term) GetIntersecting(args interface{}, optArgs ...GetIntersectingOpts) 
 	return constructMethodTerm(t, "GetIntersecting", p.Term_GET_INTERSECTING, []interface{}{args}, opts)
 }
 
-// GetIntersectingOpts describes the optional arguments for a GetIntersecting operation
+// GetNearestOpts contains the optional arguments for the GetNearest term.
 type GetNearestOpts struct {
 	Index      interface{} `gorethink:"index,omitempty"`
 	MaxResults interface{} `gorethink:"max_results,omitempty"`

--- a/query_geospatial_test.go
+++ b/query_geospatial_test.go
@@ -298,19 +298,19 @@ func (s *RethinkSuite) TestGeospatialToGeojson(c *test.C) {
 
 func (s *RethinkSuite) TestGeospatialGetIntersecting(c *test.C) {
 	// Setup table
-	Db("test").TableDrop("geospatial").Run(sess)
-	Db("test").TableCreate("geospatial").Run(sess)
-	Db("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
+	DB("test").TableDrop("geospatial").Run(sess)
+	DB("test").TableCreate("geospatial").Run(sess)
+	DB("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
 		Geo: true,
 	}).Run(sess)
-	Db("test").Table("geospatial").Insert([]interface{}{
+	DB("test").Table("geospatial").Insert([]interface{}{
 		map[string]interface{}{"area": Circle(Point(-117.220406, 32.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-100.220406, 20.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-117.200406, 32.723464), 100000)},
 	}).Run(sess)
 
 	var response []interface{}
-	res, err := Db("test").Table("geospatial").GetIntersecting(
+	res, err := DB("test").Table("geospatial").GetIntersecting(
 		Circle(Point(-117.220406, 32.719464), 100000),
 		GetIntersectingOpts{
 			Index: "area",
@@ -325,19 +325,19 @@ func (s *RethinkSuite) TestGeospatialGetIntersecting(c *test.C) {
 
 func (s *RethinkSuite) TestGeospatialGetNearest(c *test.C) {
 	// Setup table
-	Db("test").TableDrop("geospatial").Run(sess)
-	Db("test").TableCreate("geospatial").Run(sess)
-	Db("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
+	DB("test").TableDrop("geospatial").Run(sess)
+	DB("test").TableCreate("geospatial").Run(sess)
+	DB("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
 		Geo: true,
 	}).Run(sess)
-	Db("test").Table("geospatial").Insert([]interface{}{
+	DB("test").Table("geospatial").Insert([]interface{}{
 		map[string]interface{}{"area": Circle(Point(-117.220406, 32.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-100.220406, 20.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-115.210306, 32.733364), 100000)},
 	}).Run(sess)
 
 	var response []interface{}
-	res, err := Db("test").Table("geospatial").GetNearest(
+	res, err := DB("test").Table("geospatial").GetNearest(
 		Point(-117.220406, 32.719464),
 		GetNearestOpts{
 			Index:   "area",

--- a/query_geospatial_test.go
+++ b/query_geospatial_test.go
@@ -298,19 +298,19 @@ func (s *RethinkSuite) TestGeospatialToGeojson(c *test.C) {
 
 func (s *RethinkSuite) TestGeospatialGetIntersecting(c *test.C) {
 	// Setup table
-	DB("test").TableDrop("geospatial").Run(sess)
-	DB("test").TableCreate("geospatial").Run(sess)
-	DB("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
+	Db("test").TableDrop("geospatial").Run(sess)
+	Db("test").TableCreate("geospatial").Run(sess)
+	Db("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
 		Geo: true,
 	}).Run(sess)
-	DB("test").Table("geospatial").Insert([]interface{}{
+	Db("test").Table("geospatial").Insert([]interface{}{
 		map[string]interface{}{"area": Circle(Point(-117.220406, 32.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-100.220406, 20.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-117.200406, 32.723464), 100000)},
 	}).Run(sess)
 
 	var response []interface{}
-	res, err := DB("test").Table("geospatial").GetIntersecting(
+	res, err := Db("test").Table("geospatial").GetIntersecting(
 		Circle(Point(-117.220406, 32.719464), 100000),
 		GetIntersectingOpts{
 			Index: "area",
@@ -325,19 +325,19 @@ func (s *RethinkSuite) TestGeospatialGetIntersecting(c *test.C) {
 
 func (s *RethinkSuite) TestGeospatialGetNearest(c *test.C) {
 	// Setup table
-	DB("test").TableDrop("geospatial").Run(sess)
-	DB("test").TableCreate("geospatial").Run(sess)
-	DB("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
+	Db("test").TableDrop("geospatial").Run(sess)
+	Db("test").TableCreate("geospatial").Run(sess)
+	Db("test").Table("geospatial").IndexCreate("area", IndexCreateOpts{
 		Geo: true,
 	}).Run(sess)
-	DB("test").Table("geospatial").Insert([]interface{}{
+	Db("test").Table("geospatial").Insert([]interface{}{
 		map[string]interface{}{"area": Circle(Point(-117.220406, 32.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-100.220406, 20.719464), 100000)},
 		map[string]interface{}{"area": Circle(Point(-115.210306, 32.733364), 100000)},
 	}).Run(sess)
 
 	var response []interface{}
-	res, err := DB("test").Table("geospatial").GetNearest(
+	res, err := Db("test").Table("geospatial").GetNearest(
 		Point(-117.220406, 32.719464),
 		GetNearestOpts{
 			Index:   "area",

--- a/query_geospatial_test.go
+++ b/query_geospatial_test.go
@@ -270,9 +270,9 @@ func (s *RethinkSuite) TestGeospatialFill(c *test.C) {
 	})
 }
 
-func (s *RethinkSuite) TestGeospatialGeojson(c *test.C) {
+func (s *RethinkSuite) TestGeospatialGeoJSON(c *test.C) {
 	var response types.Geometry
-	res, err := Geojson(map[string]interface{}{
+	res, err := GeoJSON(map[string]interface{}{
 		"type":        "Point",
 		"coordinates": []interface{}{-122.423246, 37.779388},
 	}).Run(sess)
@@ -283,9 +283,9 @@ func (s *RethinkSuite) TestGeospatialGeojson(c *test.C) {
 	c.Assert(response, geometryEquals, "Point", []float64{-122.423246, 37.779388})
 }
 
-func (s *RethinkSuite) TestGeospatialToGeojson(c *test.C) {
+func (s *RethinkSuite) TestGeospatialToGeoJSON(c *test.C) {
 	var response map[string]interface{}
-	res, err := Point(-122.423246, 37.779388).ToGeojson().Run(sess)
+	res, err := Point(-122.423246, 37.779388).ToGeoJSON().Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.One(&response)

--- a/query_join.go
+++ b/query_join.go
@@ -4,7 +4,7 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// Returns the inner product of two sequences (e.g. a table, a filter result)
+// InnerJoin returns the inner product of two sequences (e.g. a table, a filter result)
 // filtered by the predicate. The query compares each row of the left sequence
 // with each row of the right sequence to find all pairs of rows which satisfy
 // the predicate. When the predicate is satisfied, each matched pair of rows
@@ -13,12 +13,13 @@ func (t Term) InnerJoin(args ...interface{}) Term {
 	return constructMethodTerm(t, "InnerJoin", p.Term_INNER_JOIN, args, map[string]interface{}{})
 }
 
-// Computes a left outer join by retaining each row in the left table even if no
-// match was found in the right table.
+// OuterJoin computes a left outer join by retaining each row in the left table even
+// if no match was found in the right table.
 func (t Term) OuterJoin(args ...interface{}) Term {
 	return constructMethodTerm(t, "OuterJoin", p.Term_OUTER_JOIN, args, map[string]interface{}{})
 }
 
+// EqJoinOpts contains the optional arguments for the EqJoin term.
 type EqJoinOpts struct {
 	Index interface{} `gorethink:"index,omitempty"`
 }
@@ -27,7 +28,7 @@ func (o *EqJoinOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// An efficient join that looks up elements in the right table by primary key.
+// EqJoin is an efficient join that looks up elements in the right table by primary key.
 //
 // Optional arguments: "index" (string - name of the index to use in right table instead of the primary key)
 func (t Term) EqJoin(left, right interface{}, optArgs ...EqJoinOpts) Term {
@@ -38,7 +39,7 @@ func (t Term) EqJoin(left, right interface{}, optArgs ...EqJoinOpts) Term {
 	return constructMethodTerm(t, "EqJoin", p.Term_EQ_JOIN, []interface{}{funcWrap(left), right}, opts)
 }
 
-// Used to 'zip' up the result of a join by merging the 'right' fields into 'left'
+// Zip is used to 'zip' up the result of a join by merging the 'right' fields into 'left'
 // fields of each member of the sequence.
 func (t Term) Zip(args ...interface{}) Term {
 	return constructMethodTerm(t, "Zip", p.Term_ZIP, args, map[string]interface{}{})

--- a/query_join_test.go
+++ b/query_join_test.go
@@ -6,17 +6,17 @@ import (
 
 func (s *RethinkSuite) TestJoinInnerJoin(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Join1").Exec(sess)
-	DB("test").TableCreate("Join2").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Join1").Exec(sess)
+	Db("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Join1").InnerJoin(DB("test").Table("Join2"), func(a, b Term) Term {
+	query := Db("test").Table("Join1").InnerJoin(Db("test").Table("Join2"), func(a, b Term) Term {
 		return a.Field("id").Eq(b.Field("id"))
 	})
 	res, err := query.Run(sess)
@@ -37,17 +37,17 @@ func (s *RethinkSuite) TestJoinInnerJoin(c *test.C) {
 
 func (s *RethinkSuite) TestJoinInnerJoinZip(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Join1").Exec(sess)
-	DB("test").TableCreate("Join2").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Join1").Exec(sess)
+	Db("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Join1").InnerJoin(DB("test").Table("Join2"), func(a, b Term) Term {
+	query := Db("test").Table("Join1").InnerJoin(Db("test").Table("Join2"), func(a, b Term) Term {
 		return a.Field("id").Eq(b.Field("id"))
 	}).Zip()
 	res, err := query.Run(sess)
@@ -64,17 +64,17 @@ func (s *RethinkSuite) TestJoinInnerJoinZip(c *test.C) {
 
 func (s *RethinkSuite) TestJoinOuterJoinZip(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Join1").Exec(sess)
-	DB("test").TableCreate("Join2").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Join1").Exec(sess)
+	Db("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Join1").OuterJoin(DB("test").Table("Join2"), func(a, b Term) Term {
+	query := Db("test").Table("Join1").OuterJoin(Db("test").Table("Join2"), func(a, b Term) Term {
 		return a.Field("id").Eq(b.Field("id"))
 	}).Zip().OrderBy("id")
 	res, err := query.Run(sess)
@@ -92,17 +92,17 @@ func (s *RethinkSuite) TestJoinOuterJoinZip(c *test.C) {
 
 func (s *RethinkSuite) TestJoinEqJoinZip(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Join1").Exec(sess)
-	DB("test").TableCreate("Join2").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Join1").Exec(sess)
+	Db("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Join1").EqJoin("id", DB("test").Table("Join2")).Zip()
+	query := Db("test").Table("Join1").EqJoin("id", Db("test").Table("Join2")).Zip()
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -115,23 +115,23 @@ func (s *RethinkSuite) TestJoinEqJoinZip(c *test.C) {
 
 func (s *RethinkSuite) TestJoinEqJoinDiffIdsZip(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Join1").Exec(sess)
-	err := DB("test").TableCreate("Join3", TableCreateOpts{
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Join1").Exec(sess)
+	err := Db("test").TableCreate("Join3", TableCreateOpts{
 		PrimaryKey: "it",
 	}).Exec(sess)
 	c.Assert(err, test.IsNil)
-	DB("test").Table("Join3").IndexCreate("it").Exec(sess)
+	Db("test").Table("Join3").IndexCreate("it").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Join1").Delete().Exec(sess)
-	DB("test").Table("Join3").Delete().Exec(sess)
-	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	DB("test").Table("Join3").Insert(joinTable3).Exec(sess)
+	Db("test").Table("Join1").Delete().Exec(sess)
+	Db("test").Table("Join3").Delete().Exec(sess)
+	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	Db("test").Table("Join3").Insert(joinTable3).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Join1").EqJoin("id", DB("test").Table("Join3"), EqJoinOpts{
+	query := Db("test").Table("Join1").EqJoin("id", Db("test").Table("Join3"), EqJoinOpts{
 		Index: "it",
 	}).Zip()
 	res, err := query.Run(sess)
@@ -149,11 +149,11 @@ func (s *RethinkSuite) TestOrderByJoinEq(c *test.C) {
 	var err error
 
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
-	DB("test").TableCreate("test2").Exec(sess)
-	tab := DB("test").Table("test")
-	tab2 := DB("test").Table("test2")
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+	Db("test").TableCreate("test2").Exec(sess)
+	tab := Db("test").Table("test")
+	tab2 := Db("test").Table("test2")
 
 	// insert rows
 	err = tab.Insert(Map{"S": "s1", "T": 2}).Exec(sess)

--- a/query_join_test.go
+++ b/query_join_test.go
@@ -6,17 +6,17 @@ import (
 
 func (s *RethinkSuite) TestJoinInnerJoin(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Join1").Exec(sess)
-	Db("test").TableCreate("Join2").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Join1").Exec(sess)
+	DB("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Join1").InnerJoin(Db("test").Table("Join2"), func(a, b Term) Term {
+	query := DB("test").Table("Join1").InnerJoin(DB("test").Table("Join2"), func(a, b Term) Term {
 		return a.Field("id").Eq(b.Field("id"))
 	})
 	res, err := query.Run(sess)
@@ -37,17 +37,17 @@ func (s *RethinkSuite) TestJoinInnerJoin(c *test.C) {
 
 func (s *RethinkSuite) TestJoinInnerJoinZip(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Join1").Exec(sess)
-	Db("test").TableCreate("Join2").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Join1").Exec(sess)
+	DB("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Join1").InnerJoin(Db("test").Table("Join2"), func(a, b Term) Term {
+	query := DB("test").Table("Join1").InnerJoin(DB("test").Table("Join2"), func(a, b Term) Term {
 		return a.Field("id").Eq(b.Field("id"))
 	}).Zip()
 	res, err := query.Run(sess)
@@ -64,17 +64,17 @@ func (s *RethinkSuite) TestJoinInnerJoinZip(c *test.C) {
 
 func (s *RethinkSuite) TestJoinOuterJoinZip(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Join1").Exec(sess)
-	Db("test").TableCreate("Join2").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Join1").Exec(sess)
+	DB("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Join1").OuterJoin(Db("test").Table("Join2"), func(a, b Term) Term {
+	query := DB("test").Table("Join1").OuterJoin(DB("test").Table("Join2"), func(a, b Term) Term {
 		return a.Field("id").Eq(b.Field("id"))
 	}).Zip().OrderBy("id")
 	res, err := query.Run(sess)
@@ -92,17 +92,17 @@ func (s *RethinkSuite) TestJoinOuterJoinZip(c *test.C) {
 
 func (s *RethinkSuite) TestJoinEqJoinZip(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Join1").Exec(sess)
-	Db("test").TableCreate("Join2").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Join1").Exec(sess)
+	DB("test").TableCreate("Join2").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	Db("test").Table("Join2").Insert(joinTable2).Exec(sess)
+	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	DB("test").Table("Join2").Insert(joinTable2).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Join1").EqJoin("id", Db("test").Table("Join2")).Zip()
+	query := DB("test").Table("Join1").EqJoin("id", DB("test").Table("Join2")).Zip()
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -115,23 +115,23 @@ func (s *RethinkSuite) TestJoinEqJoinZip(c *test.C) {
 
 func (s *RethinkSuite) TestJoinEqJoinDiffIdsZip(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Join1").Exec(sess)
-	err := Db("test").TableCreate("Join3", TableCreateOpts{
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Join1").Exec(sess)
+	err := DB("test").TableCreate("Join3", TableCreateOpts{
 		PrimaryKey: "it",
 	}).Exec(sess)
 	c.Assert(err, test.IsNil)
-	Db("test").Table("Join3").IndexCreate("it").Exec(sess)
+	DB("test").Table("Join3").IndexCreate("it").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Join1").Delete().Exec(sess)
-	Db("test").Table("Join3").Delete().Exec(sess)
-	Db("test").Table("Join1").Insert(joinTable1).Exec(sess)
-	Db("test").Table("Join3").Insert(joinTable3).Exec(sess)
+	DB("test").Table("Join1").Delete().Exec(sess)
+	DB("test").Table("Join3").Delete().Exec(sess)
+	DB("test").Table("Join1").Insert(joinTable1).Exec(sess)
+	DB("test").Table("Join3").Insert(joinTable3).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Join1").EqJoin("id", Db("test").Table("Join3"), EqJoinOpts{
+	query := DB("test").Table("Join1").EqJoin("id", DB("test").Table("Join3"), EqJoinOpts{
 		Index: "it",
 	}).Zip()
 	res, err := query.Run(sess)
@@ -149,11 +149,11 @@ func (s *RethinkSuite) TestOrderByJoinEq(c *test.C) {
 	var err error
 
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
-	Db("test").TableCreate("test2").Exec(sess)
-	tab := Db("test").Table("test")
-	tab2 := Db("test").Table("test2")
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
+	DB("test").TableCreate("test2").Exec(sess)
+	tab := DB("test").Table("test")
+	tab2 := DB("test").Table("test2")
 
 	// insert rows
 	err = tab.Insert(Map{"S": "s1", "T": 2}).Exec(sess)

--- a/query_manipulation.go
+++ b/query_manipulation.go
@@ -4,108 +4,110 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// Returns the currently visited document.
+// Row returns the currently visited document.
 var Row = constructRootTerm("Doc", p.Term_IMPLICIT_VAR, []interface{}{}, map[string]interface{}{})
 
+// Literal replaces an object in a field instead of merging it with an existing
+// object in a merge or update operation.
 func Literal(args ...interface{}) Term {
 	return constructRootTerm("Literal", p.Term_LITERAL, args, map[string]interface{}{})
 }
 
-// Get a single field from an object. If called on a sequence, gets that field
+// Field gets a single field from an object. If called on a sequence, gets that field
 // from every object in the sequence, skipping objects that lack it.
 func (t Term) Field(args ...interface{}) Term {
 	return constructMethodTerm(t, "Field", p.Term_GET_FIELD, args, map[string]interface{}{})
 }
 
-// Test if an object has all of the specified fields. An object has a field if
+// HasFields tests if an object has all of the specified fields. An object has a field if
 // it has the specified key and that key maps to a non-null value. For instance,
 //  the object `{'a':1,'b':2,'c':null}` has the fields `a` and `b`.
 func (t Term) HasFields(args ...interface{}) Term {
 	return constructMethodTerm(t, "HasFields", p.Term_HAS_FIELDS, args, map[string]interface{}{})
 }
 
-// Plucks out one or more attributes from either an object or a sequence of
+// Pluck plucks out one or more attributes from either an object or a sequence of
 // objects (projection).
 func (t Term) Pluck(args ...interface{}) Term {
 	return constructMethodTerm(t, "Pluck", p.Term_PLUCK, args, map[string]interface{}{})
 }
 
-// The opposite of pluck; takes an object or a sequence of objects, and returns
+// Without is the opposite of pluck; takes an object or a sequence of objects, and returns
 // them with the specified paths removed.
 func (t Term) Without(args ...interface{}) Term {
 	return constructMethodTerm(t, "Without", p.Term_WITHOUT, args, map[string]interface{}{})
 }
 
-// Merge two objects together to construct a new object with properties from both.
+// Merge merges two objects together to construct a new object with properties from both.
 // Gives preference to attributes from other when there is a conflict.
 func (t Term) Merge(args ...interface{}) Term {
 	return constructMethodTerm(t, "Merge", p.Term_MERGE, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Append a value to an array.
+// Append appends a value to an array.
 func (t Term) Append(args ...interface{}) Term {
 	return constructMethodTerm(t, "Append", p.Term_APPEND, args, map[string]interface{}{})
 }
 
-// Prepend a value to an array.
+// Prepend prepends a value to an array.
 func (t Term) Prepend(args ...interface{}) Term {
 	return constructMethodTerm(t, "Prepend", p.Term_PREPEND, args, map[string]interface{}{})
 }
 
-// Remove the elements of one array from another array.
+// Difference removes the elements of one array from another array.
 func (t Term) Difference(args ...interface{}) Term {
 	return constructMethodTerm(t, "Difference", p.Term_DIFFERENCE, args, map[string]interface{}{})
 }
 
-// Add a value to an array and return it as a set (an array with distinct values).
+// SetInsert adds a value to an array and return it as a set (an array with distinct values).
 func (t Term) SetInsert(args ...interface{}) Term {
 	return constructMethodTerm(t, "SetInsert", p.Term_SET_INSERT, args, map[string]interface{}{})
 }
 
-// Add a several values to an array and return it as a set (an array with
+// SetUnion adds several values to an array and return it as a set (an array with
 // distinct values).
 func (t Term) SetUnion(args ...interface{}) Term {
 	return constructMethodTerm(t, "SetUnion", p.Term_SET_UNION, args, map[string]interface{}{})
 }
 
-// Intersect two arrays returning values that occur in both of them as a set (an
-// array with distinct values).
+// SetIntersection calculates the intersection of two arrays returning values that
+// occur in both of them as a set (an array with distinct values).
 func (t Term) SetIntersection(args ...interface{}) Term {
 	return constructMethodTerm(t, "SetIntersection", p.Term_SET_INTERSECTION, args, map[string]interface{}{})
 }
 
-// Remove the elements of one array from another and return them as a set (an
+// SetDifference removes the elements of one array from another and return them as a set (an
 // array with distinct values).
 func (t Term) SetDifference(args ...interface{}) Term {
 	return constructMethodTerm(t, "SetDifference", p.Term_SET_DIFFERENCE, args, map[string]interface{}{})
 }
 
-// Insert a value in to an array at a given index. Returns the modified array.
+// InsertAt inserts a value in to an array at a given index. Returns the modified array.
 func (t Term) InsertAt(args ...interface{}) Term {
 	return constructMethodTerm(t, "InsertAt", p.Term_INSERT_AT, args, map[string]interface{}{})
 }
 
-// Insert several values in to an array at a given index. Returns the modified array.
+// SpliceAt inserts several values in to an array at a given index. Returns the modified array.
 func (t Term) SpliceAt(args ...interface{}) Term {
 	return constructMethodTerm(t, "SpliceAt", p.Term_SPLICE_AT, args, map[string]interface{}{})
 }
 
-// Remove an element from an array at a given index. Returns the modified array.
+// DeleteAt removes an element from an array at a given index. Returns the modified array.
 func (t Term) DeleteAt(args ...interface{}) Term {
 	return constructMethodTerm(t, "DeleteAt", p.Term_DELETE_AT, args, map[string]interface{}{})
 }
 
-// Change a value in an array at a given index. Returns the modified array.
+// ChangeAt changes a value in an array at a given index. Returns the modified array.
 func (t Term) ChangeAt(args ...interface{}) Term {
 	return constructMethodTerm(t, "ChangeAt", p.Term_CHANGE_AT, args, map[string]interface{}{})
 }
 
-// Return an array containing all of the object's keys.
+// Keys returns an array containing all of the object's keys.
 func (t Term) Keys(args ...interface{}) Term {
 	return constructMethodTerm(t, "Keys", p.Term_KEYS, args, map[string]interface{}{})
 }
 
-// Creates an object from a list of key-value pairs, where the keys must be strings.
+// Object creates an object from a list of key-value pairs, where the keys must be strings.
 func Object(args ...interface{}) Term {
 	return constructRootTerm("Object", p.Term_OBJECT, args, map[string]interface{}{})
 }

--- a/query_manipulation.go
+++ b/query_manipulation.go
@@ -4,7 +4,11 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// Row returns the currently visited document.
+// Row returns the currently visited document. Note that Row does not work within
+// subqueries to access nested documents; you should use anonymous functions to
+// access those documents instead. Also note that unlike in other drivers to
+// access a rows fields you should call Field. For example:
+//   r.row("fieldname") should instead be r.Row.Field("fieldname")
 var Row = constructRootTerm("Doc", p.Term_IMPLICIT_VAR, []interface{}{}, map[string]interface{}{})
 
 // Literal replaces an object in a field instead of merging it with an existing

--- a/query_math.go
+++ b/query_math.go
@@ -151,6 +151,7 @@ func Not(args ...interface{}) Term {
 	return constructRootTerm("Not", p.Term_NOT, args, map[string]interface{}{})
 }
 
+// RandomOpts contains the optional arguments for the Random term.
 type RandomOpts struct {
 	Float interface{} `gorethink:"float,omitempty"`
 }
@@ -159,8 +160,8 @@ func (o *RandomOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Generate a random number between the given bounds. If no arguments are
-// given, the result will be a floating-point number in the range [0,1).
+// Random generates a random number between the given bounds. If no arguments
+// are given, the result will be a floating-point number in the range [0,1).
 //
 // When passing a single argument, r.random(x), the result will be in the
 // range [0,x), and when passing two arguments, r.random(x,y), the range is

--- a/query_select.go
+++ b/query_select.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Reference a database.
-func DB(args ...interface{}) Term {
+func Db(args ...interface{}) Term {
 	return constructRootTerm("Db", p.Term_DB, args, map[string]interface{}{})
 }
 

--- a/query_select.go
+++ b/query_select.go
@@ -9,6 +9,7 @@ func DB(args ...interface{}) Term {
 	return constructRootTerm("DB", p.Term_DB, args, map[string]interface{}{})
 }
 
+// TableOpts contains the optional arguments for the Table term
 type TableOpts struct {
 	UseOutdated      interface{} `gorethink:"use_outdated,omitempty"`
 	IdentifierFormat interface{} `gorethink:"identifier_format,omitempty"`
@@ -18,11 +19,16 @@ func (o *TableOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Select all documents in a table. This command can be chained with other
-// commands to do further processing on the data.
+// Table selects all documents in a table. This command can be chained with
+// other commands to do further processing on the data.
 //
-// Optional arguments (see http://www.rethinkdb.com/api/#js:selecting_data-table for more information):
-// "use_outdated" (boolean - defaults to false)
+// There are two optional arguments.
+//   - useOutdated: if true, this allows potentially out-of-date data to be
+//     returned, with potentially faster reads. It also allows you to perform reads
+//     from a secondary replica if a primary has failed. Default false.
+//   - identifierFormat: possible values are name and uuid, with a default of name.
+//     If set to uuid, then system tables will refer to servers, databases and tables
+//     by UUID rather than name. (This only has an effect when used with system tables.)
 func Table(name interface{}, optArgs ...TableOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -31,11 +37,16 @@ func Table(name interface{}, optArgs ...TableOpts) Term {
 	return constructRootTerm("Table", p.Term_TABLE, []interface{}{name}, opts)
 }
 
-// Select all documents in a table. This command can be chained with other
-// commands to do further processing on the data.
+// Table selects all documents in a table. This command can be chained with
+// other commands to do further processing on the data.
 //
-// Optional arguments (see http://www.rethinkdb.com/api/#js:selecting_data-table for more information):
-// "use_outdated" (boolean - defaults to false)
+// There are two optional arguments.
+//   - useOutdated: if true, this allows potentially out-of-date data to be
+//     returned, with potentially faster reads. It also allows you to perform reads
+//     from a secondary replica if a primary has failed. Default false.
+//   - identifierFormat: possible values are name and uuid, with a default of name.
+//     If set to uuid, then system tables will refer to servers, databases and tables
+//     by UUID rather than name. (This only has an effect when used with system tables.)
 func (t Term) Table(name interface{}, optArgs ...TableOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -44,21 +55,23 @@ func (t Term) Table(name interface{}, optArgs ...TableOpts) Term {
 	return constructMethodTerm(t, "Table", p.Term_TABLE, []interface{}{name}, opts)
 }
 
-// Get a document by primary key. If nothing was found, RethinkDB will return a nil value.
+// Get gets a document by primary key. If nothing was found, RethinkDB will return a nil value.
 func (t Term) Get(args ...interface{}) Term {
 	return constructMethodTerm(t, "Get", p.Term_GET, args, map[string]interface{}{})
 }
 
-// Get all documents where the given value matches the value of the primary index.
+// GetAll gets all documents where the given value matches the value of the primary index.
 func (t Term) GetAll(keys ...interface{}) Term {
 	return constructMethodTerm(t, "GetAll", p.Term_GET_ALL, keys, map[string]interface{}{})
 }
 
-// Get all documents where the given value matches the value of the requested index.
+// GetAllByIndex gets all documents where the given value matches the value of
+// the requested index.
 func (t Term) GetAllByIndex(index interface{}, keys ...interface{}) Term {
 	return constructMethodTerm(t, "GetAll", p.Term_GET_ALL, keys, map[string]interface{}{"index": index})
 }
 
+// BetweenOpts contains the optional arguments for the Between term
 type BetweenOpts struct {
 	Index      interface{} `gorethink:"index,omitempty"`
 	LeftBound  interface{} `gorethink:"left_bound,omitempty"`
@@ -69,13 +82,18 @@ func (o *BetweenOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Get all documents between two keys. Accepts three optional arguments: `index`,
-// `left_bound`, and `right_bound`. If `index` is set to the name of a secondary
-// index, `between` will return all documents where that index's value is in the
-// specified range (it uses the primary key by default). `left_bound` or
-// `right_bound` may be set to `open` or `closed` to indicate whether or not to
-// include that endpoint of the range (by default, `left_bound` is closed and
-// `right_bound` is open).
+// Between gets all documents between two keys. Accepts three optional arguments:
+// index, leftBound, and rightBound. If index is set to the name of a secondary
+// index, between will return all documents where that index’s value is in the
+// specified range (it uses the primary key by default). leftBound or rightBound
+// may be set to open or closed to indicate whether or not to include that endpoint
+// of the range (by default, leftBound is closed and rightBound is open).
+//
+// You may also use the special constants r.minval and r.maxval for boundaries,
+// which represent “less than any index key” and “more than any index key”
+// respectively. For instance, if you use r.minval as the lower key, then between
+// will return all documents whose primary keys (or indexes) are less than the
+// specified upper key.
 func (t Term) Between(lowerKey, upperKey interface{}, optArgs ...BetweenOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -84,6 +102,7 @@ func (t Term) Between(lowerKey, upperKey interface{}, optArgs ...BetweenOpts) Te
 	return constructMethodTerm(t, "Between", p.Term_BETWEEN, []interface{}{lowerKey, upperKey}, opts)
 }
 
+// FilterOpts contains the optional arguments for the Filter term
 type FilterOpts struct {
 	Default interface{} `gorethink:"default,omitempty"`
 }
@@ -92,7 +111,7 @@ func (o *FilterOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Get all the documents for which the given predicate is true.
+// Filter gets all the documents for which the given predicate is true.
 //
 // Filter can be called on a sequence, selection, or a field containing an array
 // of elements. The return type is the same as the type on which the function was

--- a/query_select.go
+++ b/query_select.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Reference a database.
-func Db(args ...interface{}) Term {
+func DB(args ...interface{}) Term {
 	return constructRootTerm("Db", p.Term_DB, args, map[string]interface{}{})
 }
 

--- a/query_select.go
+++ b/query_select.go
@@ -4,9 +4,9 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// Reference a database.
+// DB references a database.
 func DB(args ...interface{}) Term {
-	return constructRootTerm("Db", p.Term_DB, args, map[string]interface{}{})
+	return constructRootTerm("DB", p.Term_DB, args, map[string]interface{}{})
 }
 
 type TableOpts struct {

--- a/query_select_test.go
+++ b/query_select_test.go
@@ -11,15 +11,15 @@ import (
 
 func (s *RethinkSuite) TestSelectGet(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table1").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table1").Insert(objList).Exec(sess)
+	Db("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := DB("test").Table("Table1").Get(6)
+	query := Db("test").Table("Table1").Get(6)
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -33,16 +33,16 @@ func (s *RethinkSuite) TestSelectGet(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAll(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table1").Exec(sess)
-	DB("test").Table("Table1").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table1").Exec(sess)
+	Db("test").Table("Table1").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table1").Insert(objList).Exec(sess)
+	Db("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Table1").GetAll(6).OrderBy("id")
+	query := Db("test").Table("Table1").GetAll(6).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -58,16 +58,16 @@ func (s *RethinkSuite) TestSelectGetAll(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllMultiple(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table1").Exec(sess)
-	DB("test").Table("Table1").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table1").Exec(sess)
+	Db("test").Table("Table1").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table1").Insert(objList).Exec(sess)
+	Db("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Table1").GetAll(1, 2, 3).OrderBy("id")
+	query := Db("test").Table("Table1").GetAll(1, 2, 3).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -85,16 +85,16 @@ func (s *RethinkSuite) TestSelectGetAllMultiple(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllByIndex(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table1").Exec(sess)
-	DB("test").Table("Table1").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table1").Exec(sess)
+	Db("test").Table("Table1").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table1").Insert(objList).Exec(sess)
+	Db("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := DB("test").Table("Table1").GetAllByIndex("num", 15).OrderBy("id")
+	query := Db("test").Table("Table1").GetAllByIndex("num", 15).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -108,16 +108,16 @@ func (s *RethinkSuite) TestSelectGetAllByIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllMultipleByIndex(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table2").Exec(sess)
-	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table2").Exec(sess)
+	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table2").Insert(objList).Exec(sess)
+	Db("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := DB("test").Table("Table2").GetAllByIndex("num", 15).OrderBy("id")
+	query := Db("test").Table("Table2").GetAllByIndex("num", 15).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -131,21 +131,21 @@ func (s *RethinkSuite) TestSelectGetAllMultipleByIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllCompoundIndex(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableDrop("TableCompound").Exec(sess)
-	DB("test").TableCreate("TableCompound").Exec(sess)
-	write, err := DB("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
+	DbCreate("test").Exec(sess)
+	Db("test").TableDrop("TableCompound").Exec(sess)
+	Db("test").TableCreate("TableCompound").Exec(sess)
+	write, err := Db("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).RunWrite(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(write.Created, test.Equals, 1)
 
 	// Insert rows
-	DB("test").Table("TableCompound").Insert(nameList).Exec(sess)
+	Db("test").Table("TableCompound").Insert(nameList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := DB("test").Table("TableCompound").GetAllByIndex("full_name", []interface{}{"John", "Smith"})
+	query := Db("test").Table("TableCompound").GetAllByIndex("full_name", []interface{}{"John", "Smith"})
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -159,15 +159,15 @@ func (s *RethinkSuite) TestSelectGetAllCompoundIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectBetween(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table1").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table1").Insert(objList).Exec(sess)
+	Db("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Table1").Between(1, 3).OrderBy("id")
+	query := Db("test").Table("Table1").Between(1, 3).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -184,16 +184,16 @@ func (s *RethinkSuite) TestSelectBetween(c *test.C) {
 
 func (s *RethinkSuite) TestSelectBetweenWithIndex(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table2").Exec(sess)
-	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table2").Exec(sess)
+	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table2").Insert(objList).Exec(sess)
+	Db("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Table2").Between(10, 50, BetweenOpts{
+	query := Db("test").Table("Table2").Between(10, 50, BetweenOpts{
 		Index: "num",
 	}).OrderBy("id")
 	res, err := query.Run(sess)
@@ -213,16 +213,16 @@ func (s *RethinkSuite) TestSelectBetweenWithIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectBetweenWithOptions(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table2").Exec(sess)
-	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table2").Exec(sess)
+	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table2").Insert(objList).Exec(sess)
+	Db("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Table2").Between(10, 50, BetweenOpts{
+	query := Db("test").Table("Table2").Between(10, 50, BetweenOpts{
 		Index:      "num",
 		RightBound: "closed",
 	}).OrderBy("id")
@@ -244,15 +244,15 @@ func (s *RethinkSuite) TestSelectBetweenWithOptions(c *test.C) {
 
 func (s *RethinkSuite) TestSelectFilterImplicit(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table1").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table1").Insert(objList).Exec(sess)
+	Db("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Table1").Filter(Row.Field("num").Ge(50)).OrderBy("id")
+	query := Db("test").Table("Table1").Filter(Row.Field("num").Ge(50)).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -269,15 +269,15 @@ func (s *RethinkSuite) TestSelectFilterImplicit(c *test.C) {
 
 func (s *RethinkSuite) TestSelectFilterFunc(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").Exec(sess)
-	DB("test").TableCreate("Table1").Exec(sess)
+	DbCreate("test").Exec(sess)
+	Db("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	DB("test").Table("Table1").Insert(objList).Exec(sess)
+	Db("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := DB("test").Table("Table1").Filter(func(row Term) Term {
+	query := Db("test").Table("Table1").Filter(func(row Term) Term {
 		return row.Field("num").Ge(50)
 	}).OrderBy("id")
 	res, err := query.Run(sess)
@@ -296,9 +296,9 @@ func (s *RethinkSuite) TestSelectFilterFunc(c *test.C) {
 
 func (s *RethinkSuite) TestSelectManyRows(c *test.C) {
 	// Ensure table + database exist
-	DBCreate("test").RunWrite(sess)
-	DB("test").TableCreate("TestMany").RunWrite(sess)
-	DB("test").Table("TestMany").Delete().RunWrite(sess)
+	DbCreate("test").RunWrite(sess)
+	Db("test").TableCreate("TestMany").RunWrite(sess)
+	Db("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	for i := 0; i < 100; i++ {
@@ -311,11 +311,11 @@ func (s *RethinkSuite) TestSelectManyRows(c *test.C) {
 			})
 		}
 
-		DB("test").Table("TestMany").Insert(data).RunWrite(sess)
+		Db("test").Table("TestMany").Insert(data).RunWrite(sess)
 	}
 
 	// Test query
-	res, err := DB("test").Table("TestMany").Run(sess, RunOpts{
+	res, err := Db("test").Table("TestMany").Run(sess, RunOpts{
 		MaxBatchRows: 1,
 	})
 	c.Assert(err, test.IsNil)
@@ -346,19 +346,19 @@ func (s *RethinkSuite) TestConcurrentSelectManyWorkers(c *test.C) {
 	})
 
 	// Ensure table + database exist
-	DBCreate("test").RunWrite(sess)
-	DB("test").TableDrop("TestConcurrent").RunWrite(sess)
-	DB("test").TableCreate("TestConcurrent").RunWrite(sess)
-	DB("test").TableDrop("TestConcurrent2").RunWrite(sess)
-	DB("test").TableCreate("TestConcurrent2").RunWrite(sess)
+	DbCreate("test").RunWrite(sess)
+	Db("test").TableDrop("TestConcurrent").RunWrite(sess)
+	Db("test").TableCreate("TestConcurrent").RunWrite(sess)
+	Db("test").TableDrop("TestConcurrent2").RunWrite(sess)
+	Db("test").TableCreate("TestConcurrent2").RunWrite(sess)
 
 	// Insert rows
 	for j := 0; j < 200; j++ {
-		DB("test").Table("TestConcurrent").Insert(map[string]interface{}{
+		Db("test").Table("TestConcurrent").Insert(map[string]interface{}{
 			"id": j,
 			"i":  j,
 		}).Exec(sess)
-		DB("test").Table("TestConcurrent2").Insert(map[string]interface{}{
+		Db("test").Table("TestConcurrent2").Insert(map[string]interface{}{
 			"j": j,
 			"k": j * 2,
 		}).Exec(sess)
@@ -374,7 +374,7 @@ func (s *RethinkSuite) TestConcurrentSelectManyWorkers(c *test.C) {
 	for i := 0; i < numWorkers; i++ {
 		go func() {
 			for _ = range queryChan {
-				res, err := DB("test").Table("TestConcurrent2").EqJoin("j", DB("test").Table("TestConcurrent")).Zip().Run(sess)
+				res, err := Db("test").Table("TestConcurrent2").EqJoin("j", Db("test").Table("TestConcurrent")).Zip().Run(sess)
 				if err != nil {
 					doneChan <- err
 					return
@@ -396,7 +396,7 @@ func (s *RethinkSuite) TestConcurrentSelectManyWorkers(c *test.C) {
 					return
 				}
 
-				res, err = DB("test").Table("TestConcurrent").Get(response[rand.Intn(len(response))]["id"]).Run(sess)
+				res, err = Db("test").Table("TestConcurrent").Get(response[rand.Intn(len(response))]["id"]).Run(sess)
 				if err != nil {
 					doneChan <- err
 					return
@@ -442,13 +442,13 @@ func (s *RethinkSuite) TestConcurrentSelectManyRows(c *test.C) {
 	}
 
 	// Ensure table + database exist
-	DBCreate("test").RunWrite(sess)
-	DB("test").TableCreate("TestMany").RunWrite(sess)
-	DB("test").Table("TestMany").Delete().RunWrite(sess)
+	DbCreate("test").RunWrite(sess)
+	Db("test").TableCreate("TestMany").RunWrite(sess)
+	Db("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	for i := 0; i < 100; i++ {
-		DB("test").Table("TestMany").Insert(map[string]interface{}{
+		Db("test").Table("TestMany").Insert(map[string]interface{}{
 			"i": i,
 		}).Exec(sess)
 	}
@@ -459,7 +459,7 @@ func (s *RethinkSuite) TestConcurrentSelectManyRows(c *test.C) {
 
 	for i := 0; i < attempts; i++ {
 		go func(i int, c chan error) {
-			res, err := DB("test").Table("TestMany").Run(sess)
+			res, err := Db("test").Table("TestMany").Run(sess)
 			if err != nil {
 				c <- err
 				return

--- a/query_select_test.go
+++ b/query_select_test.go
@@ -11,15 +11,15 @@ import (
 
 func (s *RethinkSuite) TestSelectGet(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table1").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table1").Insert(objList).Exec(sess)
+	DB("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := Db("test").Table("Table1").Get(6)
+	query := DB("test").Table("Table1").Get(6)
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -33,16 +33,16 @@ func (s *RethinkSuite) TestSelectGet(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAll(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table1").Exec(sess)
-	Db("test").Table("Table1").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table1").Exec(sess)
+	DB("test").Table("Table1").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table1").Insert(objList).Exec(sess)
+	DB("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Table1").GetAll(6).OrderBy("id")
+	query := DB("test").Table("Table1").GetAll(6).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -58,16 +58,16 @@ func (s *RethinkSuite) TestSelectGetAll(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllMultiple(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table1").Exec(sess)
-	Db("test").Table("Table1").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table1").Exec(sess)
+	DB("test").Table("Table1").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table1").Insert(objList).Exec(sess)
+	DB("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Table1").GetAll(1, 2, 3).OrderBy("id")
+	query := DB("test").Table("Table1").GetAll(1, 2, 3).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -85,16 +85,16 @@ func (s *RethinkSuite) TestSelectGetAllMultiple(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllByIndex(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table1").Exec(sess)
-	Db("test").Table("Table1").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table1").Exec(sess)
+	DB("test").Table("Table1").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table1").Insert(objList).Exec(sess)
+	DB("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := Db("test").Table("Table1").GetAllByIndex("num", 15).OrderBy("id")
+	query := DB("test").Table("Table1").GetAllByIndex("num", 15).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -108,16 +108,16 @@ func (s *RethinkSuite) TestSelectGetAllByIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllMultipleByIndex(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table2").Exec(sess)
-	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table2").Exec(sess)
+	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table2").Insert(objList).Exec(sess)
+	DB("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := Db("test").Table("Table2").GetAllByIndex("num", 15).OrderBy("id")
+	query := DB("test").Table("Table2").GetAllByIndex("num", 15).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -131,21 +131,21 @@ func (s *RethinkSuite) TestSelectGetAllMultipleByIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectGetAllCompoundIndex(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableDrop("TableCompound").Exec(sess)
-	Db("test").TableCreate("TableCompound").Exec(sess)
-	write, err := Db("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
+	DBCreate("test").Exec(sess)
+	DB("test").TableDrop("TableCompound").Exec(sess)
+	DB("test").TableCreate("TableCompound").Exec(sess)
+	write, err := DB("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).RunWrite(sess)
 	c.Assert(err, test.IsNil)
 	c.Assert(write.Created, test.Equals, 1)
 
 	// Insert rows
-	Db("test").Table("TableCompound").Insert(nameList).Exec(sess)
+	DB("test").Table("TableCompound").Insert(nameList).Exec(sess)
 
 	// Test query
 	var response interface{}
-	query := Db("test").Table("TableCompound").GetAllByIndex("full_name", []interface{}{"John", "Smith"})
+	query := DB("test").Table("TableCompound").GetAllByIndex("full_name", []interface{}{"John", "Smith"})
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -159,15 +159,15 @@ func (s *RethinkSuite) TestSelectGetAllCompoundIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectBetween(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table1").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table1").Insert(objList).Exec(sess)
+	DB("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Table1").Between(1, 3).OrderBy("id")
+	query := DB("test").Table("Table1").Between(1, 3).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -184,16 +184,16 @@ func (s *RethinkSuite) TestSelectBetween(c *test.C) {
 
 func (s *RethinkSuite) TestSelectBetweenWithIndex(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table2").Exec(sess)
-	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table2").Exec(sess)
+	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table2").Insert(objList).Exec(sess)
+	DB("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Table2").Between(10, 50, BetweenOpts{
+	query := DB("test").Table("Table2").Between(10, 50, BetweenOpts{
 		Index: "num",
 	}).OrderBy("id")
 	res, err := query.Run(sess)
@@ -213,16 +213,16 @@ func (s *RethinkSuite) TestSelectBetweenWithIndex(c *test.C) {
 
 func (s *RethinkSuite) TestSelectBetweenWithOptions(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table2").Exec(sess)
-	Db("test").Table("Table2").IndexCreate("num").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table2").Exec(sess)
+	DB("test").Table("Table2").IndexCreate("num").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table2").Insert(objList).Exec(sess)
+	DB("test").Table("Table2").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Table2").Between(10, 50, BetweenOpts{
+	query := DB("test").Table("Table2").Between(10, 50, BetweenOpts{
 		Index:      "num",
 		RightBound: "closed",
 	}).OrderBy("id")
@@ -244,15 +244,15 @@ func (s *RethinkSuite) TestSelectBetweenWithOptions(c *test.C) {
 
 func (s *RethinkSuite) TestSelectFilterImplicit(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table1").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table1").Insert(objList).Exec(sess)
+	DB("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Table1").Filter(Row.Field("num").Ge(50)).OrderBy("id")
+	query := DB("test").Table("Table1").Filter(Row.Field("num").Ge(50)).OrderBy("id")
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -269,15 +269,15 @@ func (s *RethinkSuite) TestSelectFilterImplicit(c *test.C) {
 
 func (s *RethinkSuite) TestSelectFilterFunc(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").Exec(sess)
-	Db("test").TableCreate("Table1").Exec(sess)
+	DBCreate("test").Exec(sess)
+	DB("test").TableCreate("Table1").Exec(sess)
 
 	// Insert rows
-	Db("test").Table("Table1").Insert(objList).Exec(sess)
+	DB("test").Table("Table1").Insert(objList).Exec(sess)
 
 	// Test query
 	var response []interface{}
-	query := Db("test").Table("Table1").Filter(func(row Term) Term {
+	query := DB("test").Table("Table1").Filter(func(row Term) Term {
 		return row.Field("num").Ge(50)
 	}).OrderBy("id")
 	res, err := query.Run(sess)
@@ -296,9 +296,9 @@ func (s *RethinkSuite) TestSelectFilterFunc(c *test.C) {
 
 func (s *RethinkSuite) TestSelectManyRows(c *test.C) {
 	// Ensure table + database exist
-	DbCreate("test").RunWrite(sess)
-	Db("test").TableCreate("TestMany").RunWrite(sess)
-	Db("test").Table("TestMany").Delete().RunWrite(sess)
+	DBCreate("test").RunWrite(sess)
+	DB("test").TableCreate("TestMany").RunWrite(sess)
+	DB("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	for i := 0; i < 100; i++ {
@@ -311,11 +311,11 @@ func (s *RethinkSuite) TestSelectManyRows(c *test.C) {
 			})
 		}
 
-		Db("test").Table("TestMany").Insert(data).RunWrite(sess)
+		DB("test").Table("TestMany").Insert(data).RunWrite(sess)
 	}
 
 	// Test query
-	res, err := Db("test").Table("TestMany").Run(sess, RunOpts{
+	res, err := DB("test").Table("TestMany").Run(sess, RunOpts{
 		MaxBatchRows: 1,
 	})
 	c.Assert(err, test.IsNil)
@@ -346,19 +346,19 @@ func (s *RethinkSuite) TestConcurrentSelectManyWorkers(c *test.C) {
 	})
 
 	// Ensure table + database exist
-	DbCreate("test").RunWrite(sess)
-	Db("test").TableDrop("TestConcurrent").RunWrite(sess)
-	Db("test").TableCreate("TestConcurrent").RunWrite(sess)
-	Db("test").TableDrop("TestConcurrent2").RunWrite(sess)
-	Db("test").TableCreate("TestConcurrent2").RunWrite(sess)
+	DBCreate("test").RunWrite(sess)
+	DB("test").TableDrop("TestConcurrent").RunWrite(sess)
+	DB("test").TableCreate("TestConcurrent").RunWrite(sess)
+	DB("test").TableDrop("TestConcurrent2").RunWrite(sess)
+	DB("test").TableCreate("TestConcurrent2").RunWrite(sess)
 
 	// Insert rows
 	for j := 0; j < 200; j++ {
-		Db("test").Table("TestConcurrent").Insert(map[string]interface{}{
+		DB("test").Table("TestConcurrent").Insert(map[string]interface{}{
 			"id": j,
 			"i":  j,
 		}).Exec(sess)
-		Db("test").Table("TestConcurrent2").Insert(map[string]interface{}{
+		DB("test").Table("TestConcurrent2").Insert(map[string]interface{}{
 			"j": j,
 			"k": j * 2,
 		}).Exec(sess)
@@ -374,7 +374,7 @@ func (s *RethinkSuite) TestConcurrentSelectManyWorkers(c *test.C) {
 	for i := 0; i < numWorkers; i++ {
 		go func() {
 			for _ = range queryChan {
-				res, err := Db("test").Table("TestConcurrent2").EqJoin("j", Db("test").Table("TestConcurrent")).Zip().Run(sess)
+				res, err := DB("test").Table("TestConcurrent2").EqJoin("j", DB("test").Table("TestConcurrent")).Zip().Run(sess)
 				if err != nil {
 					doneChan <- err
 					return
@@ -396,7 +396,7 @@ func (s *RethinkSuite) TestConcurrentSelectManyWorkers(c *test.C) {
 					return
 				}
 
-				res, err = Db("test").Table("TestConcurrent").Get(response[rand.Intn(len(response))]["id"]).Run(sess)
+				res, err = DB("test").Table("TestConcurrent").Get(response[rand.Intn(len(response))]["id"]).Run(sess)
 				if err != nil {
 					doneChan <- err
 					return
@@ -442,13 +442,13 @@ func (s *RethinkSuite) TestConcurrentSelectManyRows(c *test.C) {
 	}
 
 	// Ensure table + database exist
-	DbCreate("test").RunWrite(sess)
-	Db("test").TableCreate("TestMany").RunWrite(sess)
-	Db("test").Table("TestMany").Delete().RunWrite(sess)
+	DBCreate("test").RunWrite(sess)
+	DB("test").TableCreate("TestMany").RunWrite(sess)
+	DB("test").Table("TestMany").Delete().RunWrite(sess)
 
 	// Insert rows
 	for i := 0; i < 100; i++ {
-		Db("test").Table("TestMany").Insert(map[string]interface{}{
+		DB("test").Table("TestMany").Insert(map[string]interface{}{
 			"i": i,
 		}).Exec(sess)
 	}
@@ -459,7 +459,7 @@ func (s *RethinkSuite) TestConcurrentSelectManyRows(c *test.C) {
 
 	for i := 0; i < attempts; i++ {
 		go func(i int, c chan error) {
-			res, err := Db("test").Table("TestMany").Run(sess)
+			res, err := DB("test").Table("TestMany").Run(sess)
 			if err != nil {
 				c <- err
 				return

--- a/query_string.go
+++ b/query_string.go
@@ -4,15 +4,24 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// Match against a regular expression. Returns a match object containing the
-// matched string, that string's start/end position, and the capture groups.
+// Match matches against a regular expression. If no match is found, returns
+// null. If there is a match then an object with the following fields is
+// returned:
+//   str: The matched string
+//   start: The matched string’s start
+//   end: The matched string’s end
+//   groups: The capture groups defined with parentheses
 //
-//	Expr("id:0,name:mlucy,foo:bar").Match("name:(\\w+)").Field("groups").Nth(0).Field("str")
+// Accepts RE2 syntax (https://code.google.com/p/re2/wiki/Syntax). You can
+// enable case-insensitive matching by prefixing the regular expression with
+// (?i). See the linked RE2 documentation for more flags.
+//
+// The match command does not support backreferences.
 func (t Term) Match(args ...interface{}) Term {
 	return constructMethodTerm(t, "Match", p.Term_MATCH, args, map[string]interface{}{})
 }
 
-// Splits a string into substrings. Splits on whitespace when called with no arguments.
+// Split splits a string into substrings. Splits on whitespace when called with no arguments.
 // When called with a separator, splits on that separator. When called with a separator
 // and a maximum number of splits, splits on that separator at most max_splits times.
 // (Can be called with null as the separator if you want to split on whitespace while still
@@ -24,12 +33,12 @@ func (t Term) Split(args ...interface{}) Term {
 	return constructMethodTerm(t, "Split", p.Term_SPLIT, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Upcases a string.
+// Upcase upper-cases a string.
 func (t Term) Upcase(args ...interface{}) Term {
 	return constructMethodTerm(t, "Upcase", p.Term_UPCASE, args, map[string]interface{}{})
 }
 
-// Downcases a string.
+// Downcase lower-cases a string.
 func (t Term) Downcase(args ...interface{}) Term {
 	return constructMethodTerm(t, "Downcase", p.Term_DOWNCASE, args, map[string]interface{}{})
 }

--- a/query_table.go
+++ b/query_table.go
@@ -4,6 +4,8 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
+// TableCreateOpts contains the optional arguments for the TableCreate term
+// TODO(dancannon) arguments have changed and should be updated
 type TableCreateOpts struct {
 	PrimaryKey interface{} `gorethink:"primary_key,omitempty"`
 	Durability interface{} `gorethink:"durability,omitempty"`
@@ -15,15 +17,18 @@ func (o *TableCreateOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Create a table. A RethinkDB table is a collection of JSON documents.
+// TableCreate creates a table. A RethinkDB table is a collection of JSON
+// documents.
 //
-// If successful, the operation returns an object: {created: 1}. If a table with
-// the same name already exists, the operation throws RqlRuntimeError.
+// If successful, the command returns an object with two fields:
+//   tables_created: always 1.
+//   config_changes: a list containing one two-field object, old_val and new_val:
+//   old_val: always null.
+//   new_val: the table’s new config value.
+// If a table with the same name already exists, the command throws
+// RqlRuntimeError.
 //
-// Note: that you can only use alphanumeric characters and underscores for the
-// table name.
-//
-// r.Db("database").TableCreate("table", "durability", "soft").Run(sess)
+// Note: Only alphanumeric characters and underscores are valid for the table name.
 func (t Term) TableCreate(name interface{}, optArgs ...TableCreateOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -32,19 +37,17 @@ func (t Term) TableCreate(name interface{}, optArgs ...TableCreateOpts) Term {
 	return constructMethodTerm(t, "TableCreate", p.Term_TABLE_CREATE, []interface{}{name}, opts)
 }
 
-// Drop a table. The table and all its data will be deleted.
-//
-// If successful, the operation returns an object: {dropped: 1}. If the specified
-// table doesn't exist a RqlRuntimeError is thrown.
+// TableDrop deletes a table. The table and all its data will be deleted.
 func (t Term) TableDrop(args ...interface{}) Term {
 	return constructMethodTerm(t, "TableDrop", p.Term_TABLE_DROP, args, map[string]interface{}{})
 }
 
-// List all table names in a database.
+// TableList lists all table names in a database.
 func (t Term) TableList(args ...interface{}) Term {
 	return constructMethodTerm(t, "TableList", p.Term_TABLE_LIST, args, map[string]interface{}{})
 }
 
+// IndexCreateOpts contains the optional arguments for the IndexCreate term
 type IndexCreateOpts struct {
 	Multi interface{} `gorethink:"multi,omitempty"`
 	Geo   interface{} `gorethink:"geo,omitempty"`
@@ -54,12 +57,16 @@ func (o *IndexCreateOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Create a new secondary index on this table.
+// IndexCreate creates a new secondary index on a table. Secondary indexes
+// improve the speed of many read queries at the slight cost of increased
+// storage space and decreased write performance.
 //
-// A multi index can be created by passing an optional multi argument. Multi indexes
-//  functions should return arrays and allow you to query based on whether a value
-//  is present in the returned array. The example would allow us to get heroes who
-//  possess a specific ability (the field 'abilities' is an array).
+// IndexCreate supports the creation of the following types of indexes, to create
+// indexes using arbitrary expressions use IndexCreateFunc.
+//   - Simple indexes based on the value of a single field.
+//   - Compound indexes based on multiple fields.
+//   - Multi indexes based on arrays of values, created when the multi optional argument is true.
+//   - Geospatial indexes based on indexes of geometry objects, created when the geo optional argument is true.
 func (t Term) IndexCreate(name interface{}, optArgs ...IndexCreateOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -68,28 +75,31 @@ func (t Term) IndexCreate(name interface{}, optArgs ...IndexCreateOpts) Term {
 	return constructMethodTerm(t, "IndexCreate", p.Term_INDEX_CREATE, []interface{}{name}, opts)
 }
 
-// Create a new secondary index on this table based on the value of the function
-// passed.
+// IndexCreateFunc creates a new secondary index on a table. Secondary indexes
+// improve the speed of many read queries at the slight cost of increased
+// storage space and decreased write performance.
 //
-// A compound index can be created by returning an array of values to use as the secondary index key.
-func (t Term) IndexCreateFunc(name, f interface{}, optArgs ...IndexCreateOpts) Term {
+// The indexFunction can be an anonymous function or a binary representation
+// obtained from the function field of indexStatus.
+func (t Term) IndexCreateFunc(name, indexFunction interface{}, optArgs ...IndexCreateOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
 		opts = optArgs[0].toMap()
 	}
-	return constructMethodTerm(t, "IndexCreate", p.Term_INDEX_CREATE, []interface{}{name, funcWrap(f)}, opts)
+	return constructMethodTerm(t, "IndexCreate", p.Term_INDEX_CREATE, []interface{}{name, funcWrap(indexFunction)}, opts)
 }
 
-// Delete a previously created secondary index of this table.
+// IndexDrop deletes a previously created secondary index of a table.
 func (t Term) IndexDrop(args ...interface{}) Term {
 	return constructMethodTerm(t, "IndexDrop", p.Term_INDEX_DROP, args, map[string]interface{}{})
 }
 
-// List all the secondary indexes of this table.
+// IndexList lists all the secondary indexes of a table.
 func (t Term) IndexList(args ...interface{}) Term {
 	return constructMethodTerm(t, "IndexList", p.Term_INDEX_LIST, args, map[string]interface{}{})
 }
 
+// IndexRenameOpts contains the optional arguments for the IndexRename term
 type IndexRenameOpts struct {
 	Overwrite interface{} `gorethink:"overwrite,omitempty"`
 }
@@ -98,10 +108,7 @@ func (o *IndexRenameOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// IndexRename renames an existing secondary index on a table. If the optional
-// argument overwrite is specified as True, a previously existing index with the
-// new name will be deleted and the index will be renamed. If overwrite is False
-// (the default) an error will be raised if the new index name already exists.
+// IndexRename renames an existing secondary index on a table.
 func (t Term) IndexRename(oldName, newName interface{}, optArgs ...IndexRenameOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -110,31 +117,30 @@ func (t Term) IndexRename(oldName, newName interface{}, optArgs ...IndexRenameOp
 	return constructMethodTerm(t, "IndexRename", p.Term_INDEX_RENAME, []interface{}{oldName, newName}, opts)
 }
 
-// Get the status of the specified indexes on this table, or the status of all
-// indexes on this table if no indexes are specified.
+// IndexStatus gets the status of the specified indexes on this table, or the
+// status of all indexes on this table if no indexes are specified.
 func (t Term) IndexStatus(args ...interface{}) Term {
 	return constructMethodTerm(t, "IndexStatus", p.Term_INDEX_STATUS, args, map[string]interface{}{})
 }
 
-// Wait for the specified indexes on this table to be ready, or for all indexes
-// on this table to be ready if no indexes are specified.
+// IndexWait waits for the specified indexes on this table to be ready, or for
+// all indexes on this table to be ready if no indexes are specified.
 func (t Term) IndexWait(args ...interface{}) Term {
 	return constructMethodTerm(t, "IndexWait", p.Term_INDEX_WAIT, args, map[string]interface{}{})
 }
 
+// ChangesOpts contains the optional arguments for the Changes term
 type ChangesOpts struct {
 	Squash        interface{} `gorethink:"squash,omitempty"`
 	IncludeStates interface{} `gorethink:"include_states,omitempty"`
 }
 
+// ChangesOpts contains the optional arguments for the Changes term
 func (o *ChangesOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Takes a table and returns an infinite stream of objects representing changes to that table.
-// Whenever an insert, delete, update or replace is performed on the table, an object of the form
-// {old_val:..., new_val:...} will be added to the stream. For an insert, old_val will be
-// null, and for a delete, new_val will be null.
+// Changes returns an infinite stream of objects representing changes to a query.
 func (t Term) Changes(optArgs ...ChangesOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {

--- a/query_table.go
+++ b/query_table.go
@@ -5,12 +5,12 @@ import (
 )
 
 // TableCreateOpts contains the optional arguments for the TableCreate term
-// TODO(dancannon) arguments have changed and should be updated
 type TableCreateOpts struct {
-	PrimaryKey interface{} `gorethink:"primary_key,omitempty"`
-	Durability interface{} `gorethink:"durability,omitempty"`
-	CacheSize  interface{} `gorethink:"cache_size,omitempty"`
-	DataCenter interface{} `gorethink:"datacenter,omitempty"`
+	PrimaryKey        interface{} `gorethink:"primary_key,omitempty"`
+	Durability        interface{} `gorethink:"durability,omitempty"`
+	Shards            interface{} `gorethink:"shards,omitempty"`
+	DataCenter        interface{} `gorethink:"replicas,omitempty"`
+	PrimaryReplicaTag interface{} `gorethink:"primary_replica_tag,omitempty"`
 }
 
 func (o *TableCreateOpts) toMap() map[string]interface{} {
@@ -19,14 +19,6 @@ func (o *TableCreateOpts) toMap() map[string]interface{} {
 
 // TableCreate creates a table. A RethinkDB table is a collection of JSON
 // documents.
-//
-// If successful, the command returns an object with two fields:
-//   tables_created: always 1.
-//   config_changes: a list containing one two-field object, old_val and new_val:
-//   old_val: always null.
-//   new_val: the table’s new config value.
-// If a table with the same name already exists, the command throws
-// RqlRuntimeError.
 //
 // Note: Only alphanumeric characters and underscores are valid for the table name.
 func (t Term) TableCreate(name interface{}, optArgs ...TableCreateOpts) Term {

--- a/query_table_test.go
+++ b/query_table_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func (s *RethinkSuite) TestTableCreate(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
 
 	// Test database creation
-	query := DB("test").TableCreate("test")
+	query := Db("test").TableCreate("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -18,10 +18,10 @@ func (s *RethinkSuite) TestTableCreate(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCreatePrimaryKey(c *test.C) {
-	DB("test").TableDrop("testOpts").Exec(sess)
+	Db("test").TableDrop("testOpts").Exec(sess)
 
 	// Test database creation
-	query := DB("test").TableCreate("testOpts", TableCreateOpts{
+	query := Db("test").TableCreate("testOpts", TableCreateOpts{
 		PrimaryKey: "it",
 	})
 
@@ -31,10 +31,10 @@ func (s *RethinkSuite) TestTableCreatePrimaryKey(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCreateSoftDurability(c *test.C) {
-	DB("test").TableDrop("testOpts").Exec(sess)
+	Db("test").TableDrop("testOpts").Exec(sess)
 
 	// Test database creation
-	query := DB("test").TableCreate("testOpts", TableCreateOpts{
+	query := Db("test").TableCreate("testOpts", TableCreateOpts{
 		Durability: "soft",
 	})
 
@@ -44,10 +44,10 @@ func (s *RethinkSuite) TestTableCreateSoftDurability(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCreateSoftMultipleOpts(c *test.C) {
-	DB("test").TableDrop("testOpts").Exec(sess)
+	Db("test").TableDrop("testOpts").Exec(sess)
 
 	// Test database creation
-	query := DB("test").TableCreate("testOpts", TableCreateOpts{
+	query := Db("test").TableCreate("testOpts", TableCreateOpts{
 		PrimaryKey: "it",
 		Durability: "soft",
 	})
@@ -56,17 +56,17 @@ func (s *RethinkSuite) TestTableCreateSoftMultipleOpts(c *test.C) {
 	c.Assert(err, test.IsNil)
 	c.Assert(response.TablesCreated, jsonEquals, 1)
 
-	DB("test").TableDrop("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
 }
 
 func (s *RethinkSuite) TestTableList(c *test.C) {
 	var response []interface{}
 
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
 	// Try and find it in the list
 	success := false
-	res, err := DB("test").TableList().Run(sess)
+	res, err := Db("test").TableList().Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.All(&response)
@@ -84,10 +84,10 @@ func (s *RethinkSuite) TestTableList(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableDelete(c *test.C) {
-	DB("test").TableCreate("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
 
 	// Test database creation
-	query := DB("test").TableDrop("test")
+	query := Db("test").TableDrop("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -95,11 +95,11 @@ func (s *RethinkSuite) TestTableDelete(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableIndexCreate(c *test.C) {
-	DB("test").TableCreate("test").Exec(sess)
-	DB("test").Table("test").IndexDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+	Db("test").Table("test").IndexDrop("test").Exec(sess)
 
 	// Test database creation
-	query := DB("test").Table("test").IndexCreate("test", IndexCreateOpts{
+	query := Db("test").Table("test").IndexCreate("test", IndexCreateOpts{
 		Multi: true,
 	})
 
@@ -109,10 +109,10 @@ func (s *RethinkSuite) TestTableIndexCreate(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCompoundIndexCreate(c *test.C) {
-	DBCreate("test").Exec(sess)
-	DB("test").TableDrop("TableCompound").Exec(sess)
-	DB("test").TableCreate("TableCompound").Exec(sess)
-	response, err := DB("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
+	DbCreate("test").Exec(sess)
+	Db("test").TableDrop("TableCompound").Exec(sess)
+	Db("test").TableCreate("TableCompound").Exec(sess)
+	response, err := Db("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -122,12 +122,12 @@ func (s *RethinkSuite) TestTableCompoundIndexCreate(c *test.C) {
 func (s *RethinkSuite) TestTableIndexList(c *test.C) {
 	var response []interface{}
 
-	DB("test").TableCreate("test").Exec(sess)
-	DB("test").Table("test").IndexCreate("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+	Db("test").Table("test").IndexCreate("test").Exec(sess)
 
 	// Try and find it in the list
 	success := false
-	res, err := DB("test").Table("test").IndexList().Run(sess)
+	res, err := Db("test").Table("test").IndexList().Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.All(&response)
@@ -145,11 +145,11 @@ func (s *RethinkSuite) TestTableIndexList(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableIndexDelete(c *test.C) {
-	DB("test").TableCreate("test").Exec(sess)
-	DB("test").Table("test").IndexCreate("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+	Db("test").Table("test").IndexCreate("test").Exec(sess)
 
 	// Test database creation
-	query := DB("test").Table("test").IndexDrop("test")
+	query := Db("test").Table("test").IndexDrop("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -157,12 +157,12 @@ func (s *RethinkSuite) TestTableIndexDelete(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableIndexRename(c *test.C) {
-	DB("test").TableDrop("test").Exec(sess)
-	DB("test").TableCreate("test").Exec(sess)
-	DB("test").Table("test").IndexCreate("test").Exec(sess)
+	Db("test").TableDrop("test").Exec(sess)
+	Db("test").TableCreate("test").Exec(sess)
+	Db("test").Table("test").IndexCreate("test").Exec(sess)
 
 	// Test index rename
-	query := DB("test").Table("test").IndexRename("test", "test2")
+	query := Db("test").Table("test").IndexRename("test", "test2")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -170,12 +170,12 @@ func (s *RethinkSuite) TestTableIndexRename(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableChanges(c *test.C) {
-	DB("test").TableDrop("changes").Exec(sess)
-	DB("test").TableCreate("changes").Exec(sess)
+	Db("test").TableDrop("changes").Exec(sess)
+	Db("test").TableCreate("changes").Exec(sess)
 
 	var n int
 
-	res, err := DB("test").Table("changes").Changes().Run(sess)
+	res, err := Db("test").Table("changes").Changes().Run(sess)
 	if err != nil {
 		c.Fatal(err.Error())
 	}
@@ -198,16 +198,16 @@ func (s *RethinkSuite) TestTableChanges(c *test.C) {
 		wg.Done()
 	}()
 
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 1}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 2}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 3}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 4}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 5}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 6}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 7}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 8}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 9}).Exec(sess)
-	DB("test").Table("changes").Insert(map[string]interface{}{"n": 10}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 1}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 2}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 3}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 4}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 5}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 6}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 7}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 8}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 9}).Exec(sess)
+	Db("test").Table("changes").Insert(map[string]interface{}{"n": 10}).Exec(sess)
 
 	wg.Wait()
 

--- a/query_table_test.go
+++ b/query_table_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func (s *RethinkSuite) TestTableCreate(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
 
 	// Test database creation
-	query := Db("test").TableCreate("test")
+	query := DB("test").TableCreate("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -18,10 +18,10 @@ func (s *RethinkSuite) TestTableCreate(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCreatePrimaryKey(c *test.C) {
-	Db("test").TableDrop("testOpts").Exec(sess)
+	DB("test").TableDrop("testOpts").Exec(sess)
 
 	// Test database creation
-	query := Db("test").TableCreate("testOpts", TableCreateOpts{
+	query := DB("test").TableCreate("testOpts", TableCreateOpts{
 		PrimaryKey: "it",
 	})
 
@@ -31,10 +31,10 @@ func (s *RethinkSuite) TestTableCreatePrimaryKey(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCreateSoftDurability(c *test.C) {
-	Db("test").TableDrop("testOpts").Exec(sess)
+	DB("test").TableDrop("testOpts").Exec(sess)
 
 	// Test database creation
-	query := Db("test").TableCreate("testOpts", TableCreateOpts{
+	query := DB("test").TableCreate("testOpts", TableCreateOpts{
 		Durability: "soft",
 	})
 
@@ -44,10 +44,10 @@ func (s *RethinkSuite) TestTableCreateSoftDurability(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCreateSoftMultipleOpts(c *test.C) {
-	Db("test").TableDrop("testOpts").Exec(sess)
+	DB("test").TableDrop("testOpts").Exec(sess)
 
 	// Test database creation
-	query := Db("test").TableCreate("testOpts", TableCreateOpts{
+	query := DB("test").TableCreate("testOpts", TableCreateOpts{
 		PrimaryKey: "it",
 		Durability: "soft",
 	})
@@ -56,17 +56,17 @@ func (s *RethinkSuite) TestTableCreateSoftMultipleOpts(c *test.C) {
 	c.Assert(err, test.IsNil)
 	c.Assert(response.TablesCreated, jsonEquals, 1)
 
-	Db("test").TableDrop("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
 }
 
 func (s *RethinkSuite) TestTableList(c *test.C) {
 	var response []interface{}
 
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
 	// Try and find it in the list
 	success := false
-	res, err := Db("test").TableList().Run(sess)
+	res, err := DB("test").TableList().Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.All(&response)
@@ -84,10 +84,10 @@ func (s *RethinkSuite) TestTableList(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableDelete(c *test.C) {
-	Db("test").TableCreate("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
 
 	// Test database creation
-	query := Db("test").TableDrop("test")
+	query := DB("test").TableDrop("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -95,11 +95,11 @@ func (s *RethinkSuite) TestTableDelete(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableIndexCreate(c *test.C) {
-	Db("test").TableCreate("test").Exec(sess)
-	Db("test").Table("test").IndexDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
+	DB("test").Table("test").IndexDrop("test").Exec(sess)
 
 	// Test database creation
-	query := Db("test").Table("test").IndexCreate("test", IndexCreateOpts{
+	query := DB("test").Table("test").IndexCreate("test", IndexCreateOpts{
 		Multi: true,
 	})
 
@@ -109,10 +109,10 @@ func (s *RethinkSuite) TestTableIndexCreate(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableCompoundIndexCreate(c *test.C) {
-	DbCreate("test").Exec(sess)
-	Db("test").TableDrop("TableCompound").Exec(sess)
-	Db("test").TableCreate("TableCompound").Exec(sess)
-	response, err := Db("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
+	DBCreate("test").Exec(sess)
+	DB("test").TableDrop("TableCompound").Exec(sess)
+	DB("test").TableCreate("TableCompound").Exec(sess)
+	response, err := DB("test").Table("TableCompound").IndexCreateFunc("full_name", func(row Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}
 	}).RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -122,12 +122,12 @@ func (s *RethinkSuite) TestTableCompoundIndexCreate(c *test.C) {
 func (s *RethinkSuite) TestTableIndexList(c *test.C) {
 	var response []interface{}
 
-	Db("test").TableCreate("test").Exec(sess)
-	Db("test").Table("test").IndexCreate("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
+	DB("test").Table("test").IndexCreate("test").Exec(sess)
 
 	// Try and find it in the list
 	success := false
-	res, err := Db("test").Table("test").IndexList().Run(sess)
+	res, err := DB("test").Table("test").IndexList().Run(sess)
 	c.Assert(err, test.IsNil)
 
 	err = res.All(&response)
@@ -145,11 +145,11 @@ func (s *RethinkSuite) TestTableIndexList(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableIndexDelete(c *test.C) {
-	Db("test").TableCreate("test").Exec(sess)
-	Db("test").Table("test").IndexCreate("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
+	DB("test").Table("test").IndexCreate("test").Exec(sess)
 
 	// Test database creation
-	query := Db("test").Table("test").IndexDrop("test")
+	query := DB("test").Table("test").IndexDrop("test")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -157,12 +157,12 @@ func (s *RethinkSuite) TestTableIndexDelete(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableIndexRename(c *test.C) {
-	Db("test").TableDrop("test").Exec(sess)
-	Db("test").TableCreate("test").Exec(sess)
-	Db("test").Table("test").IndexCreate("test").Exec(sess)
+	DB("test").TableDrop("test").Exec(sess)
+	DB("test").TableCreate("test").Exec(sess)
+	DB("test").Table("test").IndexCreate("test").Exec(sess)
 
 	// Test index rename
-	query := Db("test").Table("test").IndexRename("test", "test2")
+	query := DB("test").Table("test").IndexRename("test", "test2")
 
 	response, err := query.RunWrite(sess)
 	c.Assert(err, test.IsNil)
@@ -170,12 +170,12 @@ func (s *RethinkSuite) TestTableIndexRename(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTableChanges(c *test.C) {
-	Db("test").TableDrop("changes").Exec(sess)
-	Db("test").TableCreate("changes").Exec(sess)
+	DB("test").TableDrop("changes").Exec(sess)
+	DB("test").TableCreate("changes").Exec(sess)
 
 	var n int
 
-	res, err := Db("test").Table("changes").Changes().Run(sess)
+	res, err := DB("test").Table("changes").Changes().Run(sess)
 	if err != nil {
 		c.Fatal(err.Error())
 	}
@@ -198,16 +198,16 @@ func (s *RethinkSuite) TestTableChanges(c *test.C) {
 		wg.Done()
 	}()
 
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 1}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 2}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 3}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 4}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 5}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 6}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 7}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 8}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 9}).Exec(sess)
-	Db("test").Table("changes").Insert(map[string]interface{}{"n": 10}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 1}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 2}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 3}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 4}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 5}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 6}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 7}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 8}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 9}).Exec(sess)
+	DB("test").Table("changes").Insert(map[string]interface{}{"n": 10}).Exec(sess)
 
 	wg.Wait()
 

--- a/query_time.go
+++ b/query_time.go
@@ -4,21 +4,22 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
-// Returns a time object representing the current time in UTC
+// Now returns a time object representing the current time in UTC
 func Now(args ...interface{}) Term {
 	return constructRootTerm("Now", p.Term_NOW, args, map[string]interface{}{})
 }
 
-// Create a time object for a specific time
+// Time creates a time object for a specific time
 func Time(args ...interface{}) Term {
 	return constructRootTerm("Time", p.Term_TIME, args, map[string]interface{}{})
 }
 
-// Returns a time object based on seconds since epoch
+// EpochTime returns a time object based on seconds since epoch
 func EpochTime(args ...interface{}) Term {
 	return constructRootTerm("EpochTime", p.Term_EPOCH_TIME, args, map[string]interface{}{})
 }
 
+// ISO8601Opts contains the optional arguments for the ISO8601 term
 type ISO8601Opts struct {
 	DefaultTimezone interface{} `gorethink:"default_timezone,omitempty"`
 }
@@ -27,10 +28,7 @@ func (o *ISO8601Opts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Returns a time object based on an ISO8601 formatted date-time string
-//
-// Optional arguments (see http://www.rethinkdb.com/api/#js:dates_and_times-iso8601 for more information):
-// "default_timezone" (string)
+// ISO8601 returns a time object based on an ISO8601 formatted date-time string
 func ISO8601(date interface{}, optArgs ...ISO8601Opts) Term {
 
 	opts := map[string]interface{}{}
@@ -40,19 +38,20 @@ func ISO8601(date interface{}, optArgs ...ISO8601Opts) Term {
 	return constructRootTerm("ISO8601", p.Term_ISO8601, []interface{}{date}, opts)
 }
 
-// Returns a new time object with a different time zone. While the time
-// stays the same, the results returned by methods such as hours() will
+// InTimezone returns a new time object with a different time zone. While the
+// time stays the same, the results returned by methods such as hours() will
 // change since they take the timezone into account. The timezone argument
 // has to be of the ISO 8601 format.
 func (t Term) InTimezone(args ...interface{}) Term {
 	return constructMethodTerm(t, "InTimezone", p.Term_IN_TIMEZONE, args, map[string]interface{}{})
 }
 
-// Returns the timezone of the time object
+// Timezone returns the timezone of the time object
 func (t Term) Timezone(args ...interface{}) Term {
 	return constructMethodTerm(t, "Timezone", p.Term_TIMEZONE, args, map[string]interface{}{})
 }
 
+// DuringOpts contains the optional arguments for the During term
 type DuringOpts struct {
 	LeftBound  interface{} `gorethink:"left_bound,omitempty"`
 	RightBound interface{} `gorethink:"right_bound,omitempty"`
@@ -62,11 +61,8 @@ func (o *DuringOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Returns true if a time is between two other times
+// During returns true if a time is between two other times
 // (by default, inclusive for the start, exclusive for the end).
-//
-// Optional arguments (see http://www.rethinkdb.com/api/#js:dates_and_times-during for more information):
-// "left_bound" and "right_bound" ("open" for exclusive or "closed" for inclusive)
 func (t Term) During(startTime, endTime interface{}, optArgs ...DuringOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -75,36 +71,36 @@ func (t Term) During(startTime, endTime interface{}, optArgs ...DuringOpts) Term
 	return constructMethodTerm(t, "During", p.Term_DURING, []interface{}{startTime, endTime}, opts)
 }
 
-// Return a new time object only based on the day, month and year
+// Date returns a new time object only based on the day, month and year
 // (ie. the same day at 00:00).
 func (t Term) Date(args ...interface{}) Term {
 	return constructMethodTerm(t, "Date", p.Term_DATE, args, map[string]interface{}{})
 }
 
-// Return the number of seconds elapsed since the beginning of the
+// TimeOfDay returns the number of seconds elapsed since the beginning of the
 // day stored in the time object.
 func (t Term) TimeOfDay(args ...interface{}) Term {
 	return constructMethodTerm(t, "TimeOfDay", p.Term_TIME_OF_DAY, args, map[string]interface{}{})
 }
 
-// Return the year of a time object.
+// Year returns the year of a time object.
 func (t Term) Year(args ...interface{}) Term {
 	return constructMethodTerm(t, "Year", p.Term_YEAR, args, map[string]interface{}{})
 }
 
-// Return the month of a time object as a number between 1 and 12.
+// Month returns the month of a time object as a number between 1 and 12.
 // For your convenience, the terms r.January(), r.February() etc. are
 // defined and map to the appropriate integer.
 func (t Term) Month(args ...interface{}) Term {
 	return constructMethodTerm(t, "Month", p.Term_MONTH, args, map[string]interface{}{})
 }
 
-// Return the day of a time object as a number between 1 and 31.
+// Day return the day of a time object as a number between 1 and 31.
 func (t Term) Day(args ...interface{}) Term {
 	return constructMethodTerm(t, "Day", p.Term_DAY, args, map[string]interface{}{})
 }
 
-// Return the day of week of a time object as a number between
+// DayOfWeek returns the day of week of a time object as a number between
 // 1 and 7 (following ISO 8601 standard). For your convenience,
 // the terms r.Monday(), r.Tuesday() etc. are defined and map to
 // the appropriate integer.
@@ -112,59 +108,80 @@ func (t Term) DayOfWeek(args ...interface{}) Term {
 	return constructMethodTerm(t, "DayOfWeek", p.Term_DAY_OF_WEEK, args, map[string]interface{}{})
 }
 
-// Return the day of the year of a time object as a number between
+// DayOfYear returns the day of the year of a time object as a number between
 // 1 and 366 (following ISO 8601 standard).
 func (t Term) DayOfYear(args ...interface{}) Term {
 	return constructMethodTerm(t, "DayOfYear", p.Term_DAY_OF_YEAR, args, map[string]interface{}{})
 }
 
-// Return the hour in a time object as a number between 0 and 23.
+// Hours returns the hour in a time object as a number between 0 and 23.
 func (t Term) Hours(args ...interface{}) Term {
 	return constructMethodTerm(t, "Hours", p.Term_HOURS, args, map[string]interface{}{})
 }
 
-// Return the minute in a time object as a number between 0 and 59.
+// Minutes returns the minute in a time object as a number between 0 and 59.
 func (t Term) Minutes(args ...interface{}) Term {
 	return constructMethodTerm(t, "Minutes", p.Term_MINUTES, args, map[string]interface{}{})
 }
 
-// Return the seconds in a time object as a number between 0 and
+// Seconds returns the seconds in a time object as a number between 0 and
 // 59.999 (double precision).
 func (t Term) Seconds(args ...interface{}) Term {
 	return constructMethodTerm(t, "Seconds", p.Term_SECONDS, args, map[string]interface{}{})
 }
 
-// Convert a time object to its iso 8601 format.
+// ToISO8601 converts a time object to its iso 8601 format.
 func (t Term) ToISO8601(args ...interface{}) Term {
 	return constructMethodTerm(t, "ToISO8601", p.Term_TO_ISO8601, args, map[string]interface{}{})
 }
 
-// Convert a time object to its epoch time.
+// ToEpochTime converts a time object to its epoch time.
 func (t Term) ToEpochTime(args ...interface{}) Term {
 	return constructMethodTerm(t, "ToEpochTime", p.Term_TO_EPOCH_TIME, args, map[string]interface{}{})
 }
 
 var (
 	// Days
-	Monday    = constructRootTerm("Monday", p.Term_MONDAY, []interface{}{}, map[string]interface{}{})
-	Tuesday   = constructRootTerm("Tuesday", p.Term_TUESDAY, []interface{}{}, map[string]interface{}{})
+
+	// Monday is a constant representing the day of the week Monday
+	Monday = constructRootTerm("Monday", p.Term_MONDAY, []interface{}{}, map[string]interface{}{})
+	// Tuesday is a constant representing the day of the week Tuesday
+	Tuesday = constructRootTerm("Tuesday", p.Term_TUESDAY, []interface{}{}, map[string]interface{}{})
+	// Wednesday is a constant representing the day of the week Wednesday
 	Wednesday = constructRootTerm("Wednesday", p.Term_WEDNESDAY, []interface{}{}, map[string]interface{}{})
-	Thursday  = constructRootTerm("Thursday", p.Term_THURSDAY, []interface{}{}, map[string]interface{}{})
-	Friday    = constructRootTerm("Friday", p.Term_FRIDAY, []interface{}{}, map[string]interface{}{})
-	Saturday  = constructRootTerm("Saturday", p.Term_SATURDAY, []interface{}{}, map[string]interface{}{})
-	Sunday    = constructRootTerm("Sunday", p.Term_SUNDAY, []interface{}{}, map[string]interface{}{})
+	// Thursday is a constant representing the day of the week Thursday
+	Thursday = constructRootTerm("Thursday", p.Term_THURSDAY, []interface{}{}, map[string]interface{}{})
+	// Friday is a constant representing the day of the week Friday
+	Friday = constructRootTerm("Friday", p.Term_FRIDAY, []interface{}{}, map[string]interface{}{})
+	// Saturday is a constant representing the day of the week Saturday
+	Saturday = constructRootTerm("Saturday", p.Term_SATURDAY, []interface{}{}, map[string]interface{}{})
+	// Sunday is a constant representing the day of the week Sunday
+	Sunday = constructRootTerm("Sunday", p.Term_SUNDAY, []interface{}{}, map[string]interface{}{})
 
 	// Months
-	January   = constructRootTerm("January", p.Term_JANUARY, []interface{}{}, map[string]interface{}{})
-	February  = constructRootTerm("February", p.Term_FEBRUARY, []interface{}{}, map[string]interface{}{})
-	March     = constructRootTerm("March", p.Term_MARCH, []interface{}{}, map[string]interface{}{})
-	April     = constructRootTerm("April", p.Term_APRIL, []interface{}{}, map[string]interface{}{})
-	May       = constructRootTerm("May", p.Term_MAY, []interface{}{}, map[string]interface{}{})
-	June      = constructRootTerm("June", p.Term_JUNE, []interface{}{}, map[string]interface{}{})
-	July      = constructRootTerm("July", p.Term_JULY, []interface{}{}, map[string]interface{}{})
-	August    = constructRootTerm("August", p.Term_AUGUST, []interface{}{}, map[string]interface{}{})
+
+	// January is a constant representing the month January
+	January = constructRootTerm("January", p.Term_JANUARY, []interface{}{}, map[string]interface{}{})
+	// February is a constant representing the month February
+	February = constructRootTerm("February", p.Term_FEBRUARY, []interface{}{}, map[string]interface{}{})
+	// March is a constant representing the month March
+	March = constructRootTerm("March", p.Term_MARCH, []interface{}{}, map[string]interface{}{})
+	// April is a constant representing the month April
+	April = constructRootTerm("April", p.Term_APRIL, []interface{}{}, map[string]interface{}{})
+	// May is a constant representing the month May
+	May = constructRootTerm("May", p.Term_MAY, []interface{}{}, map[string]interface{}{})
+	// June is a constant representing the month June
+	June = constructRootTerm("June", p.Term_JUNE, []interface{}{}, map[string]interface{}{})
+	// July is a constant representing the month July
+	July = constructRootTerm("July", p.Term_JULY, []interface{}{}, map[string]interface{}{})
+	// August is a constant representing the month August
+	August = constructRootTerm("August", p.Term_AUGUST, []interface{}{}, map[string]interface{}{})
+	// September is a constant representing the month September
 	September = constructRootTerm("September", p.Term_SEPTEMBER, []interface{}{}, map[string]interface{}{})
-	October   = constructRootTerm("October", p.Term_OCTOBER, []interface{}{}, map[string]interface{}{})
-	November  = constructRootTerm("November", p.Term_NOVEMBER, []interface{}{}, map[string]interface{}{})
-	December  = constructRootTerm("December", p.Term_DECEMBER, []interface{}{}, map[string]interface{}{})
+	// October is a constant representing the month October
+	October = constructRootTerm("October", p.Term_OCTOBER, []interface{}{}, map[string]interface{}{})
+	// November is a constant representing the month November
+	November = constructRootTerm("November", p.Term_NOVEMBER, []interface{}{}, map[string]interface{}{})
+	// December is a constant representing the month December
+	December = constructRootTerm("December", p.Term_DECEMBER, []interface{}{}, map[string]interface{}{})
 )

--- a/query_transformation.go
+++ b/query_transformation.go
@@ -31,7 +31,7 @@ func (t Term) Map(args ...interface{}) Term {
 	return constructMethodTerm(t, "Map", p.Term_MAP, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Takes a sequence of objects and a list of fields. If any objects in the
+// WithFields takes a sequence of objects and a list of fields. If any objects in the
 // sequence don't have all of the specified fields, they're dropped from the
 // sequence. The remaining objects have the specified fields plucked out.
 // (This is identical to `HasFields` followed by `Pluck` on a sequence.)
@@ -39,12 +39,13 @@ func (t Term) WithFields(args ...interface{}) Term {
 	return constructMethodTerm(t, "WithFields", p.Term_WITH_FIELDS, args, map[string]interface{}{})
 }
 
-// Flattens a sequence of arrays returned by the mapping function into a single
+// ConcatMap flattens a sequence of arrays returned by the mapping function into a single
 // sequence.
 func (t Term) ConcatMap(args ...interface{}) Term {
 	return constructMethodTerm(t, "ConcatMap", p.Term_CONCAT_MAP, funcWrapArgs(args), map[string]interface{}{})
 }
 
+// OrderByOpts contains the optional arguments for the OrderBy term
 type OrderByOpts struct {
 	Index interface{} `gorethink:"index,omitempty"`
 }
@@ -53,17 +54,14 @@ func (o *OrderByOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Sort the sequence by document values of the given key(s).
-// To specify the index to use for ordering us a last argument in the following form:
+// OrderBy sorts the sequence by document values of the given key(s). To specify
+// the ordering, wrap the attribute with either r.asc or r.desc (defaults to
+// ascending).
 //
-//	OrderByOpts{Index: "index-name"}
-//
-// OrderBy defaults to ascending ordering. To explicitly specify the ordering,
-// wrap the attribute with either Asc or Desc.
-//
-//	query.OrderBy("name")
-//	query.OrderBy(Asc("name"))
-//	query.OrderBy(Desc("name"))
+// Sorting without an index requires the server to hold the sequence in memory,
+// and is limited to 100,000 documents (or the setting of the arrayLimit option
+// for run). Sorting with an index can be done on arbitrarily large tables, or
+// after a between command using the same index.
 func (t Term) OrderBy(args ...interface{}) Term {
 	var opts = map[string]interface{}{}
 
@@ -84,24 +82,28 @@ func (t Term) OrderBy(args ...interface{}) Term {
 	return constructMethodTerm(t, "OrderBy", p.Term_ORDER_BY, args, opts)
 }
 
+// Desc is used by the OrderBy term to specify the ordering to be descending.
 func Desc(args ...interface{}) Term {
 	return constructRootTerm("Desc", p.Term_DESC, funcWrapArgs(args), map[string]interface{}{})
 }
 
+// Asc is used by the OrderBy term to specify that the ordering be ascending (the
+// default).
 func Asc(args ...interface{}) Term {
 	return constructRootTerm("Asc", p.Term_ASC, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Skip a number of elements from the head of the sequence.
+// Skip skips a number of elements from the head of the sequence.
 func (t Term) Skip(args ...interface{}) Term {
 	return constructMethodTerm(t, "Skip", p.Term_SKIP, args, map[string]interface{}{})
 }
 
-// End the sequence after the given number of elements.
+// Limit ends the sequence after the given number of elements.
 func (t Term) Limit(args ...interface{}) Term {
 	return constructMethodTerm(t, "Limit", p.Term_LIMIT, args, map[string]interface{}{})
 }
 
+// SliceOpts contains the optional arguments for the Slice term
 type SliceOpts struct {
 	LeftBound  interface{} `gorethink:"left_bound,omitempty"`
 	RightBound interface{} `gorethink:"right_bound,omitempty"`
@@ -111,7 +113,7 @@ func (o *SliceOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Trim the sequence to within the bounds provided.
+// Slice trims the sequence to within the bounds provided.
 func (t Term) Slice(args ...interface{}) Term {
 	var opts = map[string]interface{}{}
 
@@ -136,23 +138,23 @@ func (t Term) Nth(args ...interface{}) Term {
 	return constructMethodTerm(t, "Nth", p.Term_NTH, args, map[string]interface{}{})
 }
 
-// Get the indexes of an element in a sequence. If the argument is a predicate,
-// get the indexes of all elements matching it.
+// OffsetsOf gets the indexes of an element in a sequence. If the argument is a
+// predicate, get the indexes of all elements matching it.
 func (t Term) OffsetsOf(args ...interface{}) Term {
 	return constructMethodTerm(t, "OffsetsOf", p.Term_OFFSETS_OF, funcWrapArgs(args), map[string]interface{}{})
 }
 
-// Test if a sequence is empty.
+// IsEmpty tests if a sequence is empty.
 func (t Term) IsEmpty(args ...interface{}) Term {
 	return constructMethodTerm(t, "IsEmpty", p.Term_IS_EMPTY, args, map[string]interface{}{})
 }
 
-// Concatenate two sequences.
+// Union concatenates two sequences.
 func (t Term) Union(args ...interface{}) Term {
 	return constructMethodTerm(t, "Union", p.Term_UNION, args, map[string]interface{}{})
 }
 
-// Select a given number of elements from a sequence with uniform random
+// Sample selects a given number of elements from a sequence with uniform random
 // distribution. Selection is done without replacement.
 func (t Term) Sample(args ...interface{}) Term {
 	return constructMethodTerm(t, "Sample", p.Term_SAMPLE, args, map[string]interface{}{})

--- a/query_transformation.go
+++ b/query_transformation.go
@@ -39,8 +39,10 @@ func (t Term) WithFields(args ...interface{}) Term {
 	return constructMethodTerm(t, "WithFields", p.Term_WITH_FIELDS, args, map[string]interface{}{})
 }
 
-// ConcatMap flattens a sequence of arrays returned by the mapping function into a single
-// sequence.
+// ConcatMap concatenates one or more elements into a single sequence using a
+// mapping function. ConcatMap works in a similar fashion to Map, applying the
+// given function to each element in a sequence, but it will always return a
+// single sequence.
 func (t Term) ConcatMap(args ...interface{}) Term {
 	return constructMethodTerm(t, "ConcatMap", p.Term_CONCAT_MAP, funcWrapArgs(args), map[string]interface{}{})
 }
@@ -55,11 +57,11 @@ func (o *OrderByOpts) toMap() map[string]interface{} {
 }
 
 // OrderBy sorts the sequence by document values of the given key(s). To specify
-// the ordering, wrap the attribute with either r.asc or r.desc (defaults to
+// the ordering, wrap the attribute with either r.Asc or r.Desc (defaults to
 // ascending).
 //
 // Sorting without an index requires the server to hold the sequence in memory,
-// and is limited to 100,000 documents (or the setting of the arrayLimit option
+// and is limited to 100,000 documents (or the setting of the ArrayLimit option
 // for run). Sorting with an index can be done on arbitrarily large tables, or
 // after a between command using the same index.
 func (t Term) OrderBy(args ...interface{}) Term {

--- a/query_transformation_test.go
+++ b/query_transformation_test.go
@@ -155,14 +155,14 @@ func (s *RethinkSuite) TestTransformationOrderByAsc(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTransformationOrderByIndex(c *test.C) {
-	Db("test").TableCreate("OrderByIndex").Exec(sess)
-	Db("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
+	DB("test").TableCreate("OrderByIndex").Exec(sess)
+	DB("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
 
 	// Test database creation
-	Db("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
-	Db("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
+	DB("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
+	DB("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
 
-	query := Db("test").Table("OrderByIndex").OrderBy(OrderByOpts{
+	query := DB("test").Table("OrderByIndex").OrderBy(OrderByOpts{
 		Index: "test",
 	})
 
@@ -185,14 +185,14 @@ func (s *RethinkSuite) TestTransformationOrderByIndex(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTransformationOrderByIndexAsc(c *test.C) {
-	Db("test").TableCreate("OrderByIndex").Exec(sess)
-	Db("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
+	DB("test").TableCreate("OrderByIndex").Exec(sess)
+	DB("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
 
 	// Test database creation
-	Db("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
-	Db("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
+	DB("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
+	DB("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
 
-	query := Db("test").Table("OrderByIndex").OrderBy(OrderByOpts{
+	query := DB("test").Table("OrderByIndex").OrderBy(OrderByOpts{
 		Index: Asc("test"),
 	})
 

--- a/query_transformation_test.go
+++ b/query_transformation_test.go
@@ -155,14 +155,14 @@ func (s *RethinkSuite) TestTransformationOrderByAsc(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTransformationOrderByIndex(c *test.C) {
-	DB("test").TableCreate("OrderByIndex").Exec(sess)
-	DB("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
+	Db("test").TableCreate("OrderByIndex").Exec(sess)
+	Db("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
 
 	// Test database creation
-	DB("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
-	DB("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
+	Db("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
+	Db("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
 
-	query := DB("test").Table("OrderByIndex").OrderBy(OrderByOpts{
+	query := Db("test").Table("OrderByIndex").OrderBy(OrderByOpts{
 		Index: "test",
 	})
 
@@ -185,14 +185,14 @@ func (s *RethinkSuite) TestTransformationOrderByIndex(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTransformationOrderByIndexAsc(c *test.C) {
-	DB("test").TableCreate("OrderByIndex").Exec(sess)
-	DB("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
+	Db("test").TableCreate("OrderByIndex").Exec(sess)
+	Db("test").Table("test").IndexDrop("OrderByIndex").Exec(sess)
 
 	// Test database creation
-	DB("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
-	DB("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
+	Db("test").Table("OrderByIndex").IndexCreateFunc("test", Row.Field("num")).Exec(sess)
+	Db("test").Table("OrderByIndex").Insert(noDupNumObjList).Exec(sess)
 
-	query := DB("test").Table("OrderByIndex").OrderBy(OrderByOpts{
+	query := Db("test").Table("OrderByIndex").OrderBy(OrderByOpts{
 		Index: Asc("test"),
 	})
 

--- a/query_write.go
+++ b/query_write.go
@@ -4,6 +4,7 @@ import (
 	p "github.com/dancannon/gorethink/ql2"
 )
 
+// InsertOpts contains the optional arguments for the Insert term
 type InsertOpts struct {
 	Durability    interface{} `gorethink:"durability,omitempty"`
 	ReturnChanges interface{} `gorethink:"return_changes,omitempty"`
@@ -15,14 +16,8 @@ func (o *InsertOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Insert JSON documents into a table. Accepts a single JSON document or an array
-// of documents. You may also pass the optional argument durability with value
-// 'hard' or 'soft', to override the table or query's default durability setting,
-// or the optional argument return_changes, which will return the value of the row
-// you're inserting when set to true.
-//
-//	table.Insert(map[string]interface{}{"name": "Joe", "email": "joe@example.com"}).RunWrite(sess)
-//	table.Insert([]interface{}{map[string]interface{}{"name": "Joe"}, map[string]interface{}{"name": "Paul"}}).RunWrite(sess)
+// Insert documents into a table. Accepts a single document or an array
+// of documents.
 func (t Term) Insert(arg interface{}, optArgs ...InsertOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -31,6 +26,7 @@ func (t Term) Insert(arg interface{}, optArgs ...InsertOpts) Term {
 	return constructMethodTerm(t, "Insert", p.Term_INSERT, []interface{}{Expr(arg)}, opts)
 }
 
+// UpdateOpts contains the optional arguments for the Update term
 type UpdateOpts struct {
 	Durability    interface{} `gorethink:"durability,omitempty"`
 	ReturnChanges interface{} `gorethink:"return_changes,omitempty"`
@@ -41,12 +37,9 @@ func (o *UpdateOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Update JSON documents in a table. Accepts a JSON document, a RQL expression,
-// or a combination of the two. The optional argument durability with value
-// 'hard' or 'soft' will override the table or query's default durability setting.
-// The optional argument return_changes will return the old and new values of the
-// row you're modifying when set to true (only valid for single-row updates).
-// The optional argument non_atomic lets you permit non-atomic updates.
+// Update JSON documents in a table. Accepts a JSON document, a ReQL expression,
+// or a combination of the two. You can pass options like returnChanges that will
+// return the old and new values of the row you have modified.
 func (t Term) Update(arg interface{}, optArgs ...UpdateOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -55,6 +48,7 @@ func (t Term) Update(arg interface{}, optArgs ...UpdateOpts) Term {
 	return constructMethodTerm(t, "Update", p.Term_UPDATE, []interface{}{funcWrap(arg)}, opts)
 }
 
+// ReplaceOpts contains the optional arguments for the Replace term
 type ReplaceOpts struct {
 	Durability    interface{} `gorethink:"durability,omitempty"`
 	ReturnChanges interface{} `gorethink:"return_changes,omitempty"`
@@ -65,14 +59,9 @@ func (o *ReplaceOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Replace documents in a table. Accepts a JSON document or a RQL expression,
+// Replace documents in a table. Accepts a JSON document or a ReQL expression,
 // and replaces the original document with the new one. The new document must
-// have the same primary key as the original document. The optional argument
-// durability with value 'hard' or 'soft' will override the table or query's
-// default durability setting. The optional argument return_changes will return
-// the old and new values of the row you're modifying when set to true (only
-// valid for single-row replacements). The optional argument non_atomic lets
-// you permit non-atomic updates.
+// have the same primary key as the original document.
 func (t Term) Replace(arg interface{}, optArgs ...ReplaceOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -81,6 +70,7 @@ func (t Term) Replace(arg interface{}, optArgs ...ReplaceOpts) Term {
 	return constructMethodTerm(t, "Replace", p.Term_REPLACE, []interface{}{funcWrap(arg)}, opts)
 }
 
+// DeleteOpts contains the optional arguments for the Delete term
 type DeleteOpts struct {
 	Durability    interface{} `gorethink:"durability,omitempty"`
 	ReturnChanges interface{} `gorethink:"return_changes,omitempty"`
@@ -90,10 +80,7 @@ func (o *DeleteOpts) toMap() map[string]interface{} {
 	return optArgsToMap(o)
 }
 
-// Delete one or more documents from a table. The optional argument return_changes
-// will return the old value of the row you're deleting when set to true (only
-// valid for single-row deletes). The optional argument durability with value
-// 'hard' or 'soft' will override the table or query's default durability setting.
+// Delete one or more documents from a table.
 func (t Term) Delete(optArgs ...DeleteOpts) Term {
 	opts := map[string]interface{}{}
 	if len(optArgs) >= 1 {
@@ -103,9 +90,9 @@ func (t Term) Delete(optArgs ...DeleteOpts) Term {
 }
 
 // Sync ensures that writes on a given table are written to permanent storage.
-// Queries that specify soft durability (Durability: "soft") do not give such
-// guarantees, so sync can be used to ensure the state of these queries. A call
-// to sync does not return until all previous writes to the table are persisted.
+// Queries that specify soft durability ({durability: 'soft'}) do not give such
+// guarantees, so Sync can be used to ensure the state of these queries. A call
+// to Sync does not return until all previous writes to the table are persisted.
 func (t Term) Sync(args ...interface{}) Term {
 	return constructMethodTerm(t, "Sync", p.Term_SYNC, args, map[string]interface{}{})
 }

--- a/query_write.go
+++ b/query_write.go
@@ -8,7 +8,6 @@ import (
 type InsertOpts struct {
 	Durability    interface{} `gorethink:"durability,omitempty"`
 	ReturnChanges interface{} `gorethink:"return_changes,omitempty"`
-	CacheSize     interface{} `gorethink:"cache_size,omitempty"`
 	Conflict      interface{} `gorethink:"conflict,omitempty"`
 }
 

--- a/query_write_test.go
+++ b/query_write_test.go
@@ -5,13 +5,13 @@ import (
 )
 
 func (s *RethinkSuite) TestWriteInsert(c *test.C) {
-	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestWriteInsertChanges(c *test.C) {
-	query := DB("test").Table("test").Insert([]interface{}{
+	query := Db("test").Table("test").Insert([]interface{}{
 		map[string]interface{}{"num": 1},
 		map[string]interface{}{"num": 2},
 	}, InsertOpts{ReturnChanges: true})
@@ -33,7 +33,7 @@ func (s *RethinkSuite) TestWriteInsertStruct(c *test.C) {
 		},
 	}
 
-	query := DB("test").Table("test").Insert(o)
+	query := Db("test").Table("test").Insert(o)
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -55,7 +55,7 @@ func (s *RethinkSuite) TestWriteInsertStructPointer(c *test.C) {
 		},
 	}
 
-	query := DB("test").Table("test").Insert(&o)
+	query := Db("test").Table("test").Insert(&o)
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -66,34 +66,34 @@ func (s *RethinkSuite) TestWriteInsertStructPointer(c *test.C) {
 }
 
 func (s *RethinkSuite) TestWriteUpdate(c *test.C) {
-	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
 	// Update the first row in the table
-	query = DB("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
+	query = Db("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
 	_, err = query.Run(sess)
 	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestWriteReplace(c *test.C) {
-	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
 	// Replace the first row in the table
-	query = DB("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
+	query = Db("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
 	_, err = query.Run(sess)
 	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestWriteDelete(c *test.C) {
-	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
 	// Delete the first row in the table
-	query = DB("test").Table("test").Sample(1).Delete()
+	query = Db("test").Table("test").Sample(1).Delete()
 	_, err = query.Run(sess)
 	c.Assert(err, test.IsNil)
 }

--- a/query_write_test.go
+++ b/query_write_test.go
@@ -5,13 +5,13 @@ import (
 )
 
 func (s *RethinkSuite) TestWriteInsert(c *test.C) {
-	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestWriteInsertChanges(c *test.C) {
-	query := Db("test").Table("test").Insert([]interface{}{
+	query := DB("test").Table("test").Insert([]interface{}{
 		map[string]interface{}{"num": 1},
 		map[string]interface{}{"num": 2},
 	}, InsertOpts{ReturnChanges: true})
@@ -33,7 +33,7 @@ func (s *RethinkSuite) TestWriteInsertStruct(c *test.C) {
 		},
 	}
 
-	query := Db("test").Table("test").Insert(o)
+	query := DB("test").Table("test").Insert(o)
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -55,7 +55,7 @@ func (s *RethinkSuite) TestWriteInsertStructPointer(c *test.C) {
 		},
 	}
 
-	query := Db("test").Table("test").Insert(&o)
+	query := DB("test").Table("test").Insert(&o)
 	res, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
@@ -66,34 +66,34 @@ func (s *RethinkSuite) TestWriteInsertStructPointer(c *test.C) {
 }
 
 func (s *RethinkSuite) TestWriteUpdate(c *test.C) {
-	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
 	// Update the first row in the table
-	query = Db("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
+	query = DB("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
 	_, err = query.Run(sess)
 	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestWriteReplace(c *test.C) {
-	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
 	// Replace the first row in the table
-	query = Db("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
+	query = DB("test").Table("test").Sample(1).Update(map[string]interface{}{"num": 2})
 	_, err = query.Run(sess)
 	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestWriteDelete(c *test.C) {
-	query := Db("test").Table("test").Insert(map[string]interface{}{"num": 1})
+	query := DB("test").Table("test").Insert(map[string]interface{}{"num": 1})
 	_, err := query.Run(sess)
 	c.Assert(err, test.IsNil)
 
 	// Delete the first row in the table
-	query = Db("test").Table("test").Sample(1).Delete()
+	query = DB("test").Table("test").Sample(1).Delete()
 	_, err = query.Run(sess)
 	c.Assert(err, test.IsNil)
 }

--- a/utils.go
+++ b/utils.go
@@ -5,12 +5,10 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/dancannon/gorethink/encoding"
 
 	p "github.com/dancannon/gorethink/ql2"
-	"github.com/golang/protobuf/proto"
 )
 
 // Helper functions for constructing terms
@@ -181,21 +179,6 @@ func convertTermObj(o map[string]interface{}) termsObj {
 	return terms
 }
 
-func mergeArgs(args ...interface{}) []interface{} {
-	newArgs := []interface{}{}
-
-	for _, arg := range args {
-		switch v := arg.(type) {
-		case []interface{}:
-			newArgs = append(newArgs, v...)
-		default:
-			newArgs = append(newArgs, v)
-		}
-	}
-
-	return newArgs
-}
-
 // Helper functions for debugging
 
 func allArgsToStringSlice(args termsList, optArgs termsObj) []string {
@@ -236,13 +219,6 @@ func optArgsToStringSlice(optArgs termsObj) []string {
 	return allArgs
 }
 
-func prefixLines(s string, prefix string) (result string) {
-	for _, line := range strings.Split(s, "\n") {
-		result += prefix + line + "\n"
-	}
-	return
-}
-
 func splitAddress(address string) (hostname string, port int) {
 	hostname = "localhost"
 	port = 28015
@@ -258,13 +234,6 @@ func splitAddress(address string) (hostname string, port int) {
 
 	return
 }
-
-func protobufToString(p proto.Message, indentLevel int) string {
-	return prefixLines(proto.MarshalTextString(p), strings.Repeat("    ", indentLevel))
-}
-
-var timeType = reflect.TypeOf(time.Time{})
-var termType = reflect.TypeOf(Term{})
 
 func encode(data interface{}) (interface{}, error) {
 	if _, ok := data.(Term); ok {

--- a/utils.go
+++ b/utils.go
@@ -49,7 +49,7 @@ func newQuery(t Term, qopts map[string]interface{}, copts *ConnectOpts) Query {
 		queryOpts[k] = Expr(v).build()
 	}
 	if copts.Database != "" {
-		queryOpts["db"] = DB(copts.Database).build()
+		queryOpts["db"] = Db(copts.Database).build()
 	}
 
 	// Construct query

--- a/utils.go
+++ b/utils.go
@@ -78,7 +78,7 @@ func makeObject(args termsObj) Term {
 	}
 }
 
-var nextVarId int64
+var nextVarID int64
 
 func makeFunc(f interface{}) Term {
 	value := reflect.ValueOf(f)
@@ -88,9 +88,9 @@ func makeFunc(f interface{}) Term {
 	var args = make([]reflect.Value, valueType.NumIn())
 	for i := 0; i < valueType.NumIn(); i++ {
 		// Get a slice of the VARs to use as the function arguments
-		args[i] = reflect.ValueOf(constructRootTerm("var", p.Term_VAR, []interface{}{nextVarId}, map[string]interface{}{}))
-		argNums[i] = nextVarId
-		atomic.AddInt64(&nextVarId, 1)
+		args[i] = reflect.ValueOf(constructRootTerm("var", p.Term_VAR, []interface{}{nextVarID}, map[string]interface{}{}))
+		argNums[i] = nextVarID
+		atomic.AddInt64(&nextVarID, 1)
 
 		// make sure all input arguments are of type Term
 		if valueType.In(i).String() != "gorethink.Term" {

--- a/utils.go
+++ b/utils.go
@@ -49,7 +49,7 @@ func newQuery(t Term, qopts map[string]interface{}, copts *ConnectOpts) Query {
 		queryOpts[k] = Expr(v).build()
 	}
 	if copts.Database != "" {
-		queryOpts["db"] = Db(copts.Database).build()
+		queryOpts["db"] = DB(copts.Database).build()
 	}
 
 	// Construct query


### PR DESCRIPTION
In an attempt to make this library more "idiomatic" some functions have been renamed, for the full list of changes see below.
## Added
- Added more documentation.
- Added `Shards`, `Replicas` and `PrimaryReplicaTag` optional arguments in `TableCreateOpts`.
- Added `MultiGroup` and `MultiGroupByIndex` which are equivalent to the running `group` with the `multi` optional argument set to true.
### Changed
- Renamed `Db` to `DB`.
- Renamed `DbCreate` to `DBCreate`.
- Renamed `DbDrop` to `DBDrop`.
- Renamed `RqlConnectionError` to `RQLConnectionError`.
- Renamed `RqlDriverError` to `RQLDriverError`.
- Renamed `RqlClientError` to `RQLClientError`.
- Renamed `RqlRuntimeError` to `RQLRuntimeError`.
- Renamed `RqlCompileError` to `RQLCompileError`.
- Renamed `Js` to `JS`.
- Renamed `Json` to `JSON`.
- Renamed `Http` to `HTTP`.
- Renamed `GeoJson` to `GeoJSON`.
- Renamed `ToGeoJson` to `ToGeoJSON`.
- Renamed `WriteChanges` to `ChangeResponse`, this is now a general type and can be used when dealing with changefeeds.
