### PR TITLE
updated wercker.yml for docker stack

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,18 +1,22 @@
-box: wercker/golang
+box: google/golang
 # Services
 services:
-    - dancannon/rethinkdb@0.4.0
+    - rethinkdb
 # Build definition
 build:
     # The steps that will be executed on build
     steps:
-        - pjvds/setup-go-workspace
+        - setup-go-workspace
+        
+        - script:
+            name: set rethinkdb_url
+            code: |
+              export RETHINKDB_URL=$RETHINKDB_PORT_28015_TCP_ADDR
+
         # Gets the dependencies
         - script:
             name: get dependencies
             code: |
-                cd $WERCKER_SOURCE_DIR
-                go version
                 go get ./...
         # Build the project
         - script:


### PR DESCRIPTION
This modifies the `wercker.yml` file to use wercker's Docker-based stack as opposed to the classic LXC environment. It uses the "official" RethinkDB container from the DockerHub: https://registry.hub.docker.com/_/rethinkdb/

We're currently investigating how to set up a clustered RethinkDB environment to test against.
