### PR TITLE
v1.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Fixed ongoing queries not being properly stopped when closing the cursor.
+
 ## v1.0.0 RC3 - 2015-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## v1.0.0 - 2015-06-27
 
-### Fixed
-- Fixed ongoing queries not being properly stopped when closing the cursor.
+1.0.0 is finally here, This is the first stable production ready release of GoRethink!
 
-## v1.0.0 RC3 - 2015-06-22
+![GoRethink Logo](https://raw.github.com/wiki/dancannon/gorethink/gopher-and-thinker.png "Golang Gopher and RethinkDB Thinker")
 
-### Changed
- - Reverted change that added sorting to maps when decoding due to performance concerts, instead documented that struct tags should be used. Especially when using a field named `Id`.
-
-## v1.0.0 RC2 - 2015-06-11
-
-### Fixed
- - Fixed issue causing driver to fail when connecting to DB which did not have its canonical address set correctly (#200).
-
-## v1.0.0 RC1 - 2015-06-07
-In an attempt to make this library more "idiomatic" some functions have been renamed, for the full list of changes see below.
+In an attempt to make this library more "idiomatic" some functions have been renamed, for the full list of changes and bug fixes see below.
 
 ### Added
  - Added more documentation.
@@ -43,9 +33,10 @@ In an attempt to make this library more "idiomatic" some functions have been ren
  - Removed depth limit when encoding values using `Expr`
 
 ### Fixed
- - Fixed issue causing inconsistent results when unmarshaling query response into structs (#192)
  - Fixed issue causing errors when closing a changefeed cursor (#191)
  - Fixed issue causing nodes to remain unhealthy when host discovery is disabled (#195)
+ - Fixed issue causing driver to fail when connecting to DB which did not have its canonical address set correctly (#200).
+- Fixed ongoing queries not being properly stopped when closing the cursor.
 
 ### Removed
  - Removed `CacheSize` and `DataCenter` optional arguments in `TableCreateOpts`.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Please note that this version of the driver only supports versions of RethinkDB 
 go get -u github.com/dancannon/gorethink
 ```
 
+Or (pinned to the v1.x.x tag)
+```
+go get gopkg.in/dancannon/gorethink.v1
+```
+
 ## Connection
 
 ### Basic Connection

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 
 [Go](http://golang.org/) driver for [RethinkDB](http://www.rethinkdb.com/) 
 
+![GoRethink Logo](https://raw.github.com/wiki/dancannon/gorethink/gopher-and-thinker-s.png "Golang Gopher and RethinkDB Thinker")
 
-Current version: v1.0.0 RC3 (RethinkDB v2.0) 
+Current version: v1.0.0 (RethinkDB v2.0)
 
 Please note that this version of the driver only supports versions of RethinkDB using the v0.4 protocol (any versions of the driver older than RethinkDB 2.0 will not work).
 

--- a/cursor.go
+++ b/cursor.go
@@ -98,7 +98,7 @@ func (c *Cursor) Close() error {
 	}
 
 	// Stop any unfinished queries
-	if c.closed == 0 && !c.finished {
+	if !c.finished {
 		q := Query{
 			Type:  p.Query_STOP,
 			Token: c.token,

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Package gorethink implements a Go driver for RethinkDB
 //
-// Current version: v1.0.0-rc.3 (RethinkDB v2.0)
+// Current version: v1.0.0 (RethinkDB v2.0)
 // For more in depth information on how to use RethinkDB check out the API docs
 // at http://rethinkdb.com/api
 package gorethink


### PR DESCRIPTION
Almost there... Plan to merge on Monday evening 

Here is the changelog:

```
1.0.0 is finally here, This is the first stable production ready release of GoRethink!

![GoRethink Logo](https://raw.github.com/wiki/dancannon/gorethink/gopher-and-thinker.png "Golang Gopher and RethinkDB Thinker")

In an attempt to make this library more "idiomatic" some functions have been renamed, for the full list of changes and bug fixes see below.

### Added
 - Added more documentation.
 - Added `Shards`, `Replicas` and `PrimaryReplicaTag` optional arguments in `TableCreateOpts`.
 - Added `MultiGroup` and `MultiGroupByIndex` which are equivalent to the running `group` with the `multi` optional argument set to true.

### Changed 
 - Renamed `Db` to `DB`.
 - Renamed `DbCreate` to `DBCreate`.
 - Renamed `DbDrop` to `DBDrop`.
 - Renamed `RqlConnectionError` to `RQLConnectionError`.
 - Renamed `RqlDriverError` to `RQLDriverError`.
 - Renamed `RqlClientError` to `RQLClientError`.
 - Renamed `RqlRuntimeError` to `RQLRuntimeError`.
 - Renamed `RqlCompileError` to `RQLCompileError`.
 - Renamed `Js` to `JS`.
 - Renamed `Json` to `JSON`.
 - Renamed `Http` to `HTTP`.
 - Renamed `GeoJson` to `GeoJSON`.
 - Renamed `ToGeoJson` to `ToGeoJSON`.
 - Renamed `WriteChanges` to `ChangeResponse`, this is now a general type and can be used when dealing with changefeeds.
 - Removed depth limit when encoding values using `Expr`

### Fixed
 - Fixed issue causing errors when closing a changefeed cursor (#191)
 - Fixed issue causing nodes to remain unhealthy when host discovery is disabled (#195)
 - Fixed issue causing driver to fail when connecting to DB which did not have its canonical address set correctly (#200).
- Fixed ongoing queries not being properly stopped when closing the cursor.

### Removed
 - Removed `CacheSize` and `DataCenter` optional arguments in `TableCreateOpts`.
 - Removed `CacheSize` optional argument from `InsertOpts`
```
