### PR TITLE
A bug in conversion of milliseconds

### DIFF
--- a/pseudotypes.go
+++ b/pseudotypes.go
@@ -125,8 +125,9 @@ func recursivelyConvertPseudotype(obj interface{}, opts map[string]interface{}) 
 
 func reqlTimeToNativeTime(timestamp float64, timezone string) (time.Time, error) {
 	sec, ms := math.Modf(timestamp)
-
-	t := time.Unix(int64(sec), int64(ms*1000*1000*1000))
+	
+	// Convert to native time rounding to milliseconds
+	t := time.Unix(int64(sec), int64(math.Floor(ms*1000+0.5))*1000*1000)
 
 	// Caclulate the timezone
 	if timezone != "" {

--- a/query_time_test.go
+++ b/query_time_test.go
@@ -18,12 +18,12 @@ func (s *RethinkSuite) TestTimeTime(c *test.C) {
 
 func (s *RethinkSuite) TestTimeTimeMillisecond(c *test.C) {
 	var response time.Time
-	res, err := Time(1986, 11, 3, 12, 30, 15.679, "Z").Run(session)
+	res, err := Time(1986, 11, 3, 12, 30, 15.6790123, "Z").Run(session)
 	c.Assert(err, test.IsNil)
 
 	err = res.One(&response)
 	c.Assert(err, test.IsNil)
-	c.Assert(response.Equal(time.Date(1986, 11, 3, 12, 30, 15, 679.00002*1000*1000, time.UTC)), test.Equals, true)
+	c.Assert(response.Equal(time.Date(1986, 11, 3, 12, 30, 15, 679*1000*1000, time.UTC)), test.Equals, true)
 }
 
 func (s *RethinkSuite) TestTimeEpochTime(c *test.C) {


### PR DESCRIPTION
Rethink stores time as a floating point number with precision to milliseconds. Go's native time has precision to nanoseconds. The gorethink's conversion of time from float64 milliseconds to time.Time creates artifacts in microseconds and nanoseconds. With the current code every time.Time fetched from RethinkDB must be rounded to milliseconds if consistency of stored vs retrieved value is important. It makes sense to do correct rounding in the driver. The fix ensures that the time is consistent.
