### PR TITLE
support for non-epoch timezone encoding

### DIFF
--- a/encoding/encoder_types.go
+++ b/encoding/encoder_types.go
@@ -302,7 +302,7 @@ func timePseudoTypeEncoder(v reflect.Value) interface{} {
 	return map[string]interface{}{
 		"$reql_type$": "TIME",
 		"epoch_time":  timeVal,
-		"timezone":    "+00:00",
+		"timezone":    t.Format("-07:00"),
 	}
 }
 


### PR DESCRIPTION
Hi @dancannon,

First off, thank you so very much for your great work on gorethink!

Our use-case for the driver requires us to record timezones with our dates so we can reproduce documents server-side in their original timezone. I was surprised to find gorethink hard-coded to UTC.

I'm guessing all times are defaulting to epoch to avoid confusion, which would mean this PR could break a basic assumption about gorethink's behavior for other users. My question to you is, if not this change, how should we go about storing timezones with gorethink?
