### PR TITLE
UseJSONNumber

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -1,6 +1,7 @@
 package gorethink
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -197,7 +198,11 @@ func (c *Cursor) loadNextLocked(dest interface{}) (bool, error) {
 		if c.buffer.Len() == 0 && c.responses.Len() > 0 {
 			if response, ok := c.responses.Pop().(json.RawMessage); ok {
 				var value interface{}
-				err := json.Unmarshal(response, &value)
+				decoder := json.NewDecoder(bytes.NewBuffer(response))
+				if c.conn.opts.UseJSONNumber {
+					decoder.UseNumber()
+				}
+				err := decoder.Decode(&value)
 				if err != nil {
 					return false, err
 				}

--- a/query_select_test.go
+++ b/query_select_test.go
@@ -1,6 +1,7 @@
 package gorethink
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -27,6 +28,35 @@ func (s *RethinkSuite) TestSelectGet(c *test.C) {
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, jsonEquals, map[string]interface{}{"id": 6, "g1": 1, "g2": 1, "num": 15})
+
+	res.Close()
+}
+
+func (s *RethinkSuite) TestSelectJSONNumbers(c *test.C) {
+	session, err := Connect(ConnectOpts{
+		Address:       url,
+		AuthKey:       authKey,
+		UseJSONNumber: true,
+	})
+	c.Assert(err, test.IsNil)
+	defer session.Close()
+	// Ensure table + database exist
+	DBCreate("test").Exec(session)
+	DB("test").TableCreate("Table1").Exec(session)
+
+	// Insert rows
+	DB("test").Table("Table1").Insert(objList).Exec(session)
+
+	// Test query
+	var response interface{}
+	query := DB("test").Table("Table1").Get(6)
+	res, err := query.Run(session)
+	c.Assert(err, test.IsNil)
+
+	err = res.One(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, jsonEquals, map[string]interface{}{"id": json.Number("6"), "g1": json.Number("1"), "g2": json.Number("1"), "num": json.Number("15")})
 
 	res.Close()
 }

--- a/session.go
+++ b/session.go
@@ -43,6 +43,10 @@ type ConnectOpts struct {
 	// NodeRefreshInterval is used to determine how often the driver should
 	// refresh the status of a node.
 	NodeRefreshInterval time.Duration `gorethink:"node_refresh_interval,omitempty"`
+
+	// Indicates whether the cursors running in this session should use json.Number instead of float64 while
+	// unmarshaling documents with interface{}. The default is `false`.
+	UseJSONNumber bool
 }
 
 func (o *ConnectOpts) toMap() map[string]interface{} {


### PR DESCRIPTION
This PR adds an option for the connection to change the way the JSON unmarshal works when deserializing JSON with `interface{}`, it's preferred to use `json.Number` instead `float64` as it preserves the original precision.

Proof:
[This snippet](https://play.golang.org/p/qE7l9JY6s1) fails to deserialize the number in the struct because it was previously deserialized into `interface{}` without `decoder.UseNumber()` so all numbers fields are converted to `float64`, when the `interface{}` is serialized back into a json stream and then unmarshaled into a `struct` it fails to fit the `float64` into the `int`.
To solve this situation the decoder would have to preserve the original number instead converting to `float64`, [This snippet](https://play.golang.org/p/Yc-9Ozt1Jp) uses `decoder.UseNumber()` and it works perfectly because the JSON numbers are never converted to float64 in the `interface{}`.
