### PR TITLE
Import "log" for the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Setting up a basic connection with RethinkDB is simple:
 ```go
 import (
     r "github.com/dancannon/gorethink"
+    "log"
 )
 
 var session *r.Session


### PR DESCRIPTION
Since the example is using `log.Fatalln(err.Error())`, it should import `log` too.
