### PR TITLE
errors.go: fix infinite recursion in rqlError.Error()

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -97,7 +97,7 @@ func (e rqlServerError) String() string {
 type rqlError string
 
 func (e rqlError) Error() string {
-	return fmt.Sprintf("gorethink: %s", e)
+	return fmt.Sprintf("gorethink: %s", string(e))
 }
 
 func (e rqlError) String() string {


### PR DESCRIPTION
I had a panic from infinite recursion trying to print an error after restarting rethinkdb (causing a connection with an open changefeed to die) and attempting to use another connection:

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

runtime stack:
runtime.throw(0xa44500, 0xe)
        /usr/local/go/src/runtime/panic.go:527 +0x90
runtime.newstack()
        /usr/local/go/src/runtime/stack1.go:800 +0xb17
runtime.morestack()
        /usr/local/go/src/runtime/asm_amd64.s:330 +0x7f

goroutine 96 [stack growth]:
fmt.(*pp).doPrintf(0xc825f4d110, 0xa40030, 0xd, 0xc8406005d8, 0x1, 0x1)
        /usr/local/go/src/fmt/print.go:1082 fp=0xc840600540 sp=0xc840600538
fmt.Sprintf(0xa40030, 0xd, 0xc8406005d8, 0x1, 0x1, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:203 +0x6f fp=0xc840600590 sp=0xc840600540
github.com/dancannon/gorethink.rqlError.Error(0xc820570240, 0x3e, 0x0, 0x0)
        /home/ckastorff/local/go/src/github.com/dancannon/gorethink/errors.go:100 +0xfb fp=0xc840600618 sp=0xc840600590
github.com/dancannon/gorethink.(*rqlError).Error(0xc825f3fa20, 0x0, 0x0)
        <autogenerated>:151 +0xa4 fp=0xc840600650 sp=0xc840600618
fmt.(*pp).handleMethods(0xc825f4d040, 0xc800000073, 0x0, 0xc82059c001)
        /usr/local/go/src/fmt/print.go:724 +0x4cb fp=0xc840600730 sp=0xc840600650
fmt.(*pp).printArg(0xc825f4d040, 0x947260, 0xc825f3fa20, 0x73, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:806 +0x4a5 fp=0xc8406008b8 sp=0xc840600730
fmt.(*pp).doPrintf(0xc825f4d040, 0xa40030, 0xd, 0xc840600cd8, 0x1, 0x1)
        /usr/local/go/src/fmt/print.go:1219 +0x1dd8 fp=0xc840600c40 sp=0xc8406008b8
fmt.Sprintf(0xa40030, 0xd, 0xc840600cd8, 0x1, 0x1, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:203 +0x6f fp=0xc840600c90 sp=0xc840600c40
github.com/dancannon/gorethink.rqlError.Error(0xc820570240, 0x3e, 0x0, 0x0)
        /home/ckastorff/local/go/src/github.com/dancannon/gorethink/errors.go:100 +0xfb fp=0xc840600d18 sp=0xc840600c90
github.com/dancannon/gorethink.(*rqlError).Error(0xc825f3fa00, 0x0, 0x0)
        <autogenerated>:151 +0xa4 fp=0xc840600d50 sp=0xc840600d18
fmt.(*pp).handleMethods(0xc825f4cf70, 0xc800000073, 0x0, 0xc82059c001)
        /usr/local/go/src/fmt/print.go:724 +0x4cb fp=0xc840600e30 sp=0xc840600d50
fmt.(*pp).printArg(0xc825f4cf70, 0x947260, 0xc825f3fa00, 0x73, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:806 +0x4a5 fp=0xc840600fb8 sp=0xc840600e30
fmt.(*pp).doPrintf(0xc825f4cf70, 0xa40030, 0xd, 0xc8406013d8, 0x1, 0x1)
        /usr/local/go/src/fmt/print.go:1219 +0x1dd8 fp=0xc840601340 sp=0xc840600fb8
fmt.Sprintf(0xa40030, 0xd, 0xc8406013d8, 0x1, 0x1, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:203 +0x6f fp=0xc840601390 sp=0xc840601340
github.com/dancannon/gorethink.rqlError.Error(0xc820570240, 0x3e, 0x0, 0x0)
        /home/ckastorff/local/go/src/github.com/dancannon/gorethink/errors.go:100 +0xfb fp=0xc840601418 sp=0xc840601390
github.com/dancannon/gorethink.(*rqlError).Error(0xc825f3f9e0, 0x0, 0x0)
        <autogenerated>:151 +0xa4 fp=0xc840601450 sp=0xc840601418
fmt.(*pp).handleMethods(0xc825f4cea0, 0xc800000073, 0x0, 0xc82059c001)
        /usr/local/go/src/fmt/print.go:724 +0x4cb fp=0xc840601530 sp=0xc840601450
fmt.(*pp).printArg(0xc825f4cea0, 0x947260, 0xc825f3f9e0, 0x73, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:806 +0x4a5 fp=0xc8406016b8 sp=0xc840601530
fmt.(*pp).doPrintf(0xc825f4cea0, 0xa40030, 0xd, 0xc840601ad8, 0x1, 0x1)
        /usr/local/go/src/fmt/print.go:1219 +0x1dd8 fp=0xc840601a40 sp=0xc8406016b8
fmt.Sprintf(0xa40030, 0xd, 0xc840601ad8, 0x1, 0x1, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:203 +0x6f fp=0xc840601a90 sp=0xc840601a40
github.com/dancannon/gorethink.rqlError.Error(0xc820570240, 0x3e, 0x0, 0x0)
        /home/ckastorff/local/go/src/github.com/dancannon/gorethink/errors.go:100 +0xfb fp=0xc840601b18 sp=0xc840601a90
github.com/dancannon/gorethink.(*rqlError).Error(0xc825f3f9c0, 0x0, 0x0)
        <autogenerated>:151 +0xa4 fp=0xc840601b50 sp=0xc840601b18
fmt.(*pp).handleMethods(0xc825f4cdd0, 0xc800000073, 0x0, 0xc82059c001)
        /usr/local/go/src/fmt/print.go:724 +0x4cb fp=0xc840601c30 sp=0xc840601b50
fmt.(*pp).printArg(0xc825f4cdd0, 0x947260, 0xc825f3f9c0, 0x73, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:806 +0x4a5 fp=0xc840601db8 sp=0xc840601c30
fmt.(*pp).doPrintf(0xc825f4cdd0, 0xa40030, 0xd, 0xc8406021d8, 0x1, 0x1)
        /usr/local/go/src/fmt/print.go:1219 +0x1dd8 fp=0xc840602140 sp=0xc840601db8
fmt.Sprintf(0xa40030, 0xd, 0xc8406021d8, 0x1, 0x1, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:203 +0x6f fp=0xc840602190 sp=0xc840602140
github.com/dancannon/gorethink.rqlError.Error(0xc820570240, 0x3e, 0x0, 0x0)
        /home/ckastorff/local/go/src/github.com/dancannon/gorethink/errors.go:100 +0xfb fp=0xc840602218 sp=0xc840602190
github.com/dancannon/gorethink.(*rqlError).Error(0xc825f3f9a0, 0x0, 0x0)
        <autogenerated>:151 +0xa4 fp=0xc840602250 sp=0xc840602218
fmt.(*pp).handleMethods(0xc825f4cd00, 0xc800000073, 0x0, 0xc82059c001)
        /usr/local/go/src/fmt/print.go:724 +0x4cb fp=0xc840602330 sp=0xc840602250
fmt.(*pp).printArg(0xc825f4cd00, 0x947260, 0xc825f3f9a0, 0x73, 0x0, 0x0)
        /usr/local/go/src/fmt/print.go:806 +0x4a5 fp=0xc8406024b8 sp=0xc840602330
...snip...
```

`rqlError.Error` calls `fmt.Sprintf`, but without changing the type, so `fmt` calls `rqlError.String` which calls `rqlError.Error`, and it repeats. The fix is to convert the type of the argument passed to `fmt.Sprintf` so that it can handle the argument directly.
