### PR TITLE
Added ability to configure the keep-alive period for the underlying tcp connection (fixes #278)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -98,7 +98,10 @@ func (c *Connection) Close() error {
 // This function is used internally by Run which should be used for most queries.
 func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 	c.mu.Lock()
-
+	if c == nil {
+		c.mu.Unlock()
+		return nil, nil, ErrConnectionClosed
+	}
 	if c.Conn == nil {
 		c.bad = true
 		c.mu.Unlock()
@@ -112,7 +115,6 @@ func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 			var err error
 			q.Opts["db"], err = DB(c.opts.Database).build()
 			if err != nil {
-				c.mu.Unlock()
 				return nil, nil, err
 			}
 		}

--- a/connection.go
+++ b/connection.go
@@ -98,10 +98,7 @@ func (c *Connection) Close() error {
 // This function is used internally by Run which should be used for most queries.
 func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 	c.mu.Lock()
-	if c == nil {
-		c.mu.Unlock()
-		return nil, nil, ErrConnectionClosed
-	}
+
 	if c.Conn == nil {
 		c.bad = true
 		c.mu.Unlock()
@@ -115,6 +112,7 @@ func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 			var err error
 			q.Opts["db"], err = DB(c.opts.Database).build()
 			if err != nil {
+				c.mu.Unlock()
 				return nil, nil, err
 			}
 		}

--- a/connection.go
+++ b/connection.go
@@ -97,11 +97,10 @@ func (c *Connection) Close() error {
 //
 // This function is used internally by Run which should be used for most queries.
 func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
-	c.mu.Lock()
 	if c == nil {
-		c.mu.Unlock()
 		return nil, nil, ErrConnectionClosed
 	}
+	c.mu.Lock()
 	if c.Conn == nil {
 		c.bad = true
 		c.mu.Unlock()
@@ -115,6 +114,7 @@ func (c *Connection) Query(q Query) (*Response, *Cursor, error) {
 			var err error
 			q.Opts["db"], err = DB(c.opts.Database).build()
 			if err != nil {
+				c.mu.Unlock()
 				return nil, nil, err
 			}
 		}

--- a/session.go
+++ b/session.go
@@ -28,7 +28,9 @@ type ConnectOpts struct {
 	Timeout      time.Duration `gorethink:"timeout,omitempty"`
 	WriteTimeout time.Duration `gorethink:"write_timeout,omitempty"`
 	ReadTimeout  time.Duration `gorethink:"read_timeout,omitempty"`
-	TLSConfig    *tls.Config   `gorethink:"tlsconfig,omitempty"`
+	// The duration in which a connection should send a keep-alive.
+	KeepAlivePeriod time.Duration `gorethink:"keep_alive_timeout,omitempty"`
+	TLSConfig       *tls.Config   `gorethink:"tlsconfig,omitempty"`
 
 	MaxIdle int `gorethink:"max_idle,omitempty"`
 	// By default a maximum of 2 connections are opened per host.


### PR DESCRIPTION
In connection.go SetKeepAlive was being called; however, SetKeepAlivePeriod was not getting set. [This blog post](http://felixge.de/2014/08/26/tcp-keepalive-with-golang.html) has some interesting information on the default keep alive period and I believe it is too long to be useful.

I ended up adding a `KeepAlivePeriod` property in the ConnectOpts struct that will will allow me to set the KeepAlive for the underlying tcp connection.

Example

``` go
opts := r.ConnectOpts{
    KeepAlivePeriod: time.Second*10,
}
```

The `KeepAlivePeriod` is then passed to the net.Dialer which, in turn, calls `SetKeepAlive` `SetKeepAlivePeriod` on the underlying connection ([here](https://github.com/golang/go/blob/b0f4ee533a875c258ac1030ee382f0ffe2de304b/src/net/dial.go#L247-L253)).  I removed lines 65-72 in connection.go as they are now redundant.

This fixes #278
