### PR TITLE
RunWrite no longer misformats errors with formatting directives in them

### DIFF
--- a/query.go
+++ b/query.go
@@ -265,7 +265,7 @@ func (t Term) RunWrite(s *Session, optArgs ...RunOpts) (WriteResponse, error) {
 	}
 
 	if response.Errors > 0 {
-		return response, fmt.Errorf(response.FirstError)
+		return response, fmt.Errorf("%s", response.FirstError)
 	}
 
 	return response, nil


### PR DESCRIPTION
Minor error formatting fix I ran across while looking at other things.
