### PR TITLE
feat(encoding): allow for referential arrays

### DIFF
--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -324,3 +324,26 @@ func TestReferenceFieldInvalid(t *testing.T) {
 		t.Errorf("expected non-nil error but got nil")
 	}
 }
+
+type RefE struct {
+	ID   string  `gorethink:"id,omitempty"`
+	FIDs *[]RefF `gorethink:"f_ids,reference" gorethink_ref:"id"`
+}
+
+type RefF struct {
+	ID   string `gorethink:"id,omitempty"`
+	Name string `gorethink:"name"`
+}
+
+func TestReferenceFieldArray(t *testing.T) {
+	input := RefE{"1", &[]RefF{RefF{"2", "Name2"}, RefF{"3", "Name3"}}}
+	want := map[string]interface{}{"id": "1", "f_ids": []string{"2", "3"}}
+
+	out, err := Encode(input)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}


### PR DESCRIPTION
Hey Dan, awesome lib, and thanks much for that quick fix on the anon-function race case end of last week, it is very much appreciated.

I hit a structure where I wanted to use your gorethink references in an array style, and have this working with my own stuff locally.

As this stands (and as read by the added test), encoding an object that references an array of objects will flatten those objects into an array of the referenced fields.

Let me know if there's anything missing or if any style/tests/docs could be added or improved. I'm also happy to share more of the use-case if you want more context.
