### PR TITLE
fix typo in ReconfigureOpts.PrimaryTag

### DIFF
--- a/query_admin.go
+++ b/query_admin.go
@@ -20,7 +20,7 @@ func (t Term) Rebalance() Term {
 type ReconfigureOpts struct {
 	Shards               interface{} `gorethink:"shards,omitempty"`
 	Replicas             interface{} `gorethink:"replicas,omitempty"`
-	PrimaryTag           interface{} `gorethink:"primary_replicas_tag,omitempty"`
+	PrimaryTag           interface{} `gorethink:"primary_replica_tag,omitempty"`
 	DryRun               interface{} `gorethink:"dry_run,omitempty"`
 	EmergencyRepair      interface{} `gorethink:"emergency_repair,omitempty"`
 	NonVotingReplicaTags interface{} `gorethink:"nonvoting_replica_tags,omitempty"`


### PR DESCRIPTION
see https://github.com/rethinkdb/rethinkdb/blob/next/src/rdb_protocol/ql2.proto#L543
