### PR TITLE
Update import after user renamed on github

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/cenkalti/backoff"
+	"github.com/cenk/backoff"
 	"github.com/hailocab/go-hostpool"
 )
 


### PR DESCRIPTION
Looks like user cenkalti renamed his account to cenk. Github
automatically redirects but it's better to update the import path.
