### PR TITLE
Added query mocking based on testify/mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+ - Added ability to mock queries based on the library github.com/stretchr/testify
+     + Added the `QueryExecutor` interface and changed query runner methods (`Run`/`Exec`) to accept this type instead of `*Session`, `Session` will still be accepted as it implements the `QueryExecutor` interface.
+     + Added the `NewMock` function to create a mock query executor
+     + Queries can be mocked using `On` and `Return`, `Mock` also contains functions for asserting that the required mocked queries were executed.
+     + For more information about how to mock queries see the readme and tests in `mock_test.go`.
+
 ## v2.0.4 - 2016-05-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -297,6 +297,41 @@ Alternatively if you wish to modify the logging behaviour you can modify the log
 r.Log.Out = ioutil.Discard
 ```
 
+## Mocking
+
+The driver includes the ability to mock queries meaning that you can test your code without needing to talk to a real RethinkDB cluster, this is perfect for ensuring that your application has high unit test coverage.
+
+To write tests with mocking you should create an instance of `Mock` and then setup expectations using `On` and `Return`. Expectations allow you to define what results should be returned when a known query is executed, they are configured by passing the query term you want to mock to `On` and then the response and error to `Return`, if a non-nil error is passed to `Return` then any time that query is executed the error will be returned, if no error is passed then a cursor will be built using the value passed to `Return`. Once all your expectations have been created you should then execute you queries using the `Mock` instead of a `Session`.
+
+Here is an example that shows how to mock a query that returns multiple rows and the resulting cursor can be used as normal.
+
+```go
+func TestSomething(t *testing.T) {
+    mock := r.NewMock()
+    mock.on(r.Table("people")).Return([]interface{}{
+        map[string]interface{}{"id": 1, "name": "John Smith"},
+        map[string]interface{}{"id": 2, "name": "Jane Smith"},
+    }, nil)
+
+    cursor, err := r.Table("people").Run(mock)
+    if err != nil {
+        t.Errorf(err)
+    }
+
+    var rows []interface{}
+    err := res.All(&rows)
+    if err != nil {
+        t.Errorf(err)
+    }
+
+    // Test result of rows
+
+    mock.AssertExpectations(t)
+}
+```
+
+The mocking implementation is based on amazing https://github.com/stretchr/testify library, thanks to @stretchr for their awesome work!
+
 ## Benchmarks
 
 Everyone wants their project's benchmarks to be speedy. And while we know that rethinkDb and the gorethink driver are quite fast, our primary goal is for our benchmarks to be correct. They are designed to give you, the user, an accurate picture of writes per second (w/s). If you come up with a accurate test that meets this aim, submit a pull request please. 

--- a/mock.go
+++ b/mock.go
@@ -1,0 +1,254 @@
+package gorethink
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Mocking is based on the amazing package github.com/stretchr/testify
+
+type MockQuery struct {
+	parent *Mock
+
+	// Holds the query and term
+	Query Query
+
+	// Holds the JSON representation of query
+	BuiltQuery []byte
+
+	// Holds the response that should be returned when this method is called.
+	Response interface{}
+
+	// Holds the error that should be returned when this method is called.
+	Error error
+
+	// The number of times to return the return arguments when setting
+	// expectations. 0 means to always return the value.
+	Repeatability int
+
+	// Holds a channel that will be used to block the Return until it either
+	// recieves a message or is closed. nil means it returns immediately.
+	WaitFor <-chan time.Time
+
+	// Amount of times this call has been called
+	count int
+}
+
+func newMockQuery(parent *Mock, q Query) *MockQuery {
+	// Build and marshal term
+	builtQuery, err := json.Marshal(q.build())
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build query: %s", err))
+	}
+
+	return &MockQuery{
+		parent:        parent,
+		Query:         q,
+		BuiltQuery:    builtQuery,
+		Response:      make([]interface{}, 0),
+		Repeatability: 0,
+		WaitFor:       nil,
+	}
+}
+
+func newMockQueryFromTerm(parent *Mock, t Term, opts map[string]interface{}) *MockQuery {
+	q, err := parent.newQuery(t, opts)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build query: %s", err))
+	}
+
+	return newMockQuery(parent, q)
+}
+
+func (mq *MockQuery) lock() {
+	mq.parent.mu.Lock()
+}
+
+func (mq *MockQuery) unlock() {
+	mq.parent.mu.Unlock()
+}
+
+// Return specifies the return arguments for the expectation.
+//
+//    Mock.On("DoSomething").Return(nil, errors.New("failed"))
+func (mq *MockQuery) Return(response interface{}, err error) *MockQuery {
+	mq.lock()
+	defer mq.unlock()
+
+	mq.Response = response
+	mq.Error = err
+
+	return mq
+}
+
+// Once indicates that that the mock should only return the value once.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Once()
+func (mq *MockQuery) Once() *MockQuery {
+	return mq.Times(1)
+}
+
+// Twice indicates that that the mock should only return the value twice.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Twice()
+func (mq *MockQuery) Twice() *MockQuery {
+	return mq.Times(2)
+}
+
+// Times indicates that that the mock should only return the indicated number
+// of times.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Times(5)
+func (mq *MockQuery) Times(i int) *MockQuery {
+	mq.lock()
+	defer mq.unlock()
+	mq.Repeatability = i
+	return mq
+}
+
+// WaitUntil sets the channel that will block the mock's return until its closed
+// or a message is received.
+//
+//    Mock.On("MyMethod", arg1, arg2).WaitUntil(time.After(time.Second))
+func (mq *MockQuery) WaitUntil(w <-chan time.Time) *MockQuery {
+	mq.lock()
+	defer mq.unlock()
+	mq.WaitFor = w
+	return mq
+}
+
+// After sets how long to block until the call returns
+//
+//    Mock.On("MyMethod", arg1, arg2).After(time.Second)
+func (mq *MockQuery) After(d time.Duration) *MockQuery {
+	return mq.WaitUntil(time.After(d))
+}
+
+// On chains a new expectation description onto the mocked interface. This
+// allows syntax like.
+//
+//    Mock.
+//       On("MyMethod", 1).Return(nil).
+//       On("MyOtherMethod", 'a', 'b', 'c').Return(errors.New("Some Error"))
+func (mq *MockQuery) On(t Term) *MockQuery {
+	return mq.parent.On(t)
+}
+
+type Mock struct {
+	mu   sync.Mutex
+	opts ConnectOpts
+
+	ExpectedQueries []*MockQuery
+	Queries         []MockQuery
+}
+
+func NewMock(opts ...ConnectOpts) *Mock {
+	m := &Mock{
+		ExpectedQueries: make([]*MockQuery, 0),
+		Queries:         make([]MockQuery, 0),
+	}
+
+	if len(opts) > 0 {
+		m.opts = opts[0]
+	}
+
+	return m
+}
+
+func (m *Mock) On(t Term, opts ...map[string]interface{}) *MockQuery {
+	var qopts map[string]interface{}
+	if len(opts) > 0 {
+		qopts = opts[0]
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	mq := newMockQueryFromTerm(m, t, qopts)
+	m.ExpectedQueries = append(m.ExpectedQueries, mq)
+	return mq
+}
+
+func (m *Mock) IsConnected() bool {
+	return true
+}
+
+func (m *Mock) Query(q Query) (*Cursor, error) {
+	found, query := m.findExpectedQuery(q)
+
+	if found < 0 {
+		panic(fmt.Sprintf("gorethink: mock: This query was unexpected:\n\t\t%s\n\tat: %s", q.Term.String(), assert.CallerInfo()))
+	} else {
+		m.mu.Lock()
+		switch {
+		case query.Repeatability == 1:
+			query.Repeatability = -1
+			query.count++
+
+		case query.Repeatability > 1:
+			query.Repeatability--
+			query.count++
+
+		case query.Repeatability == 0:
+			query.count++
+		}
+		m.mu.Unlock()
+	}
+
+	// add the query
+	m.mu.Lock()
+	m.Queries = append(m.Queries, *newMockQuery(m, q))
+	m.mu.Unlock()
+
+	// block if specified
+	if query.WaitFor != nil {
+		<-query.WaitFor
+	}
+
+	// Return error without building cursor if non-nil
+	if query.Error != nil {
+		return nil, query.Error
+	}
+
+	// Build cursor and return
+	c := newCursor(nil, "", query.Query.Token, query.Query.Term, query.Query.Opts)
+	c.buffer = append(c.buffer, query.Response)
+	c.finished = true
+	c.fetching = false
+	c.isAtom = true
+
+	return c, nil
+}
+
+func (m *Mock) Exec(q Query) error {
+	_, err := m.Query(q)
+
+	return err
+}
+
+func (m *Mock) newQuery(t Term, opts map[string]interface{}) (Query, error) {
+	return newQuery(t, opts, &m.opts)
+}
+
+func (m *Mock) findExpectedQuery(q Query) (int, *MockQuery) {
+	// Build and marshal query
+	builtQuery, err := json.Marshal(q.build())
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build query: %s", err))
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, query := range m.ExpectedQueries {
+		if bytes.Equal(query.BuiltQuery, builtQuery) && query.Repeatability > -1 {
+			return i, query
+		}
+	}
+
+	return -1, nil
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,0 +1,67 @@
+package gorethink
+
+import (
+	"fmt"
+
+	test "gopkg.in/check.v1"
+)
+
+func (s *RethinkSuite) TestMockExecSuccess(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test").Insert(map[string]string{
+		"id": "mocked",
+	})).Return(nil, nil)
+
+	err := DB("test").Table("test").Insert(map[string]string{
+		"id": "mocked",
+	}).Exec(mock)
+	c.Assert(err, test.IsNil)
+}
+
+func (s *RethinkSuite) TestMockExecFail(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test").Insert(map[string]string{
+		"id": "mocked",
+	})).Return(nil, fmt.Errorf("Expected error"))
+
+	err := DB("test").Table("test").Insert(map[string]string{
+		"id": "mocked",
+	}).Exec(mock)
+	c.Assert(err, test.NotNil)
+}
+
+func (s *RethinkSuite) TestMockRunSuccessSingle(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test").Get("mocked")).Return(map[string]interface{}{
+		"id": "mocked",
+	}, nil)
+
+	res, err := DB("test").Table("test").Get("mocked").Run(mock)
+	c.Assert(err, test.IsNil)
+
+	var response interface{}
+	err = res.One(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, jsonEquals, map[string]interface{}{"id": "mocked"})
+
+	res.Close()
+}
+
+func (s *RethinkSuite) TestMockRunSuccessMultiple(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test")).Return([]interface{}{
+		map[string]interface{}{"id": "mocked"},
+	}, nil)
+
+	res, err := DB("test").Table("test").Run(mock)
+	c.Assert(err, test.IsNil)
+
+	var response []interface{}
+	err = res.One(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, jsonEquals, []interface{}{map[string]interface{}{"id": "mocked"}})
+
+	res.Close()
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -16,6 +16,7 @@ func (s *RethinkSuite) TestMockExecSuccess(c *test.C) {
 		"id": "mocked",
 	}).Exec(mock)
 	c.Assert(err, test.IsNil)
+	mock.AssertExpectations(c)
 }
 
 func (s *RethinkSuite) TestMockExecFail(c *test.C) {
@@ -28,9 +29,10 @@ func (s *RethinkSuite) TestMockExecFail(c *test.C) {
 		"id": "mocked",
 	}).Exec(mock)
 	c.Assert(err, test.NotNil)
+	mock.AssertExpectations(c)
 }
 
-func (s *RethinkSuite) TestMockRunSuccessSingle(c *test.C) {
+func (s *RethinkSuite) TestMockRunSuccessSingleResult(c *test.C) {
 	mock := NewMock()
 	mock.On(DB("test").Table("test").Get("mocked")).Return(map[string]interface{}{
 		"id": "mocked",
@@ -44,11 +46,12 @@ func (s *RethinkSuite) TestMockRunSuccessSingle(c *test.C) {
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, jsonEquals, map[string]interface{}{"id": "mocked"})
+	mock.AssertExpectations(c)
 
 	res.Close()
 }
 
-func (s *RethinkSuite) TestMockRunSuccessMultiple(c *test.C) {
+func (s *RethinkSuite) TestMockRunSuccessMultipleResults(c *test.C) {
 	mock := NewMock()
 	mock.On(DB("test").Table("test")).Return([]interface{}{
 		map[string]interface{}{"id": "mocked"},
@@ -62,6 +65,118 @@ func (s *RethinkSuite) TestMockRunSuccessMultiple(c *test.C) {
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, jsonEquals, []interface{}{map[string]interface{}{"id": "mocked"}})
+	mock.AssertExpectations(c)
 
 	res.Close()
+}
+
+func (s *RethinkSuite) TestMockRunMissingMock(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test")).Return([]interface{}{
+		map[string]interface{}{"id": "mocked"},
+	}, nil).Once()
+
+	c.Assert(func() {
+		c.Assert(DB("test").Table("test").Exec(mock), test.IsNil)
+		c.Assert(DB("test").Table("test").Exec(mock), test.IsNil)
+	}, test.PanicMatches, ""+
+		"gorethink: mock: This query was unexpected:(?s:.*)")
+	mock.AssertExpectations(c)
+}
+
+func (s *RethinkSuite) TestMockRunMissingQuery(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test")).Return([]interface{}{
+		map[string]interface{}{"id": "mocked"},
+	}, nil).Twice()
+
+	c.Assert(DB("test").Table("test").Exec(mock), test.IsNil)
+
+	t := &simpleTestingT{}
+	mock.AssertExpectations(t)
+
+	c.Assert(t.Failed(), test.Equals, true)
+}
+
+func (s *RethinkSuite) TestMockRunMissingQuerySingle(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test")).Return([]interface{}{
+		map[string]interface{}{"id": "mocked"},
+	}, nil).Once()
+
+	t := &simpleTestingT{}
+	mock.AssertExpectations(t)
+
+	c.Assert(t.Failed(), test.Equals, true)
+}
+
+func (s *RethinkSuite) TestMockRunMissingQueryMultiple(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test")).Return([]interface{}{
+		map[string]interface{}{"id": "mocked"},
+	}, nil).Twice()
+
+	c.Assert(DB("test").Table("test").Exec(mock), test.IsNil)
+
+	t := &simpleTestingT{}
+	mock.AssertExpectations(t)
+
+	c.Assert(t.Failed(), test.Equals, true)
+}
+
+func (s *RethinkSuite) TestMockRunMutlipleQueries(c *test.C) {
+	mock := NewMock()
+	mock.On(DB("test").Table("test").Get("mocked1")).Return(map[string]interface{}{
+		"id": "mocked1",
+	}, nil).Times(2)
+	mock.On(DB("test").Table("test").Get("mocked2")).Return(map[string]interface{}{
+		"id": "mocked2",
+	}, nil).Times(1)
+
+	var response interface{}
+
+	// Query 1
+	res, err := DB("test").Table("test").Get("mocked1").Run(mock)
+	c.Assert(err, test.IsNil)
+
+	err = res.One(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, jsonEquals, map[string]interface{}{"id": "mocked1"})
+
+	// Query 2
+	res, err = DB("test").Table("test").Get("mocked1").Run(mock)
+	c.Assert(err, test.IsNil)
+
+	err = res.One(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, jsonEquals, map[string]interface{}{"id": "mocked1"})
+
+	// Query 3
+	res, err = DB("test").Table("test").Get("mocked2").Run(mock)
+	c.Assert(err, test.IsNil)
+
+	err = res.One(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, jsonEquals, map[string]interface{}{"id": "mocked2"})
+
+	mock.AssertExpectations(c)
+}
+
+type simpleTestingT struct {
+	failed bool
+}
+
+func (t *simpleTestingT) Logf(format string, args ...interface{}) {
+}
+func (t *simpleTestingT) Errorf(format string, args ...interface{}) {
+	t.failed = true
+}
+func (t *simpleTestingT) FailNow() {
+	t.failed = true
+}
+func (t *simpleTestingT) Failed() bool {
+	return t.failed
 }

--- a/query_control.go
+++ b/query_control.go
@@ -342,8 +342,8 @@ func (t Term) Info(args ...interface{}) Term {
 	return constructMethodTerm(t, "Info", p.Term_INFO, args, map[string]interface{}{})
 }
 
-// Return a UUID (universally unique identifier), a string that can be used as a
-// unique ID. If a string is passed to uuid as an argument, the UUID will be
+// UUID returns a UUID (universally unique identifier), a string that can be used
+// as a unique ID. If a string is passed to uuid as an argument, the UUID will be
 // deterministic, derived from the string’s SHA-1 hash.
 func UUID(args ...interface{}) Term {
 	return constructRootTerm("UUID", p.Term_UUID, args, map[string]interface{}{})


### PR DESCRIPTION
To write tests with mocking you should create an instance of `Mock` and then setup expectations using `On` and `Return`. Expectations allow you to define what results should be returned when a known query is executed, they are configured by passing the query term you want to mock to `On` and then the response and error to `Return`, if a non-nil error is passed to `Return` then any time that query is executed the error will be returned, if no error is passed then a cursor will be built using the value passed to `Return`. Once all your expectations have been created you should then execute you queries using the `Mock` instead of a `Session`.

Here is an example that shows how to mock a query that returns multiple rows and the resulting cursor can be used as normal.

``` go
func TestSomething(t *testing.T) {
    mock := r.NewMock()
    mock.on(r.Table("people")).Return([]interface{}{
        map[string]interface{}{"id": 1, "name": "John Smith"},
        map[string]interface{}{"id": 2, "name": "Jane Smith"},
    }, nil)

    cursor, err := r.Table("people").Run(mock)
    if err != nil {
        t.Errorf(err)
    }

    var rows []interface{}
    err := res.All(&rows)
    if err != nil {
        t.Errorf(err)
    }

    // Test result of rows

    mock.AssertExpectations(t)
}
```

The mocking implementation is based on amazing https://github.com/stretchr/testify library, thanks to stretchr for their awesome work!
