### PR TITLE
Adding Merge Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - Fixed incorrectly named `Replicas` field in `TableCreateOpts`
  - Fixed broken optional argument `FinalEmit` in `FoldOpts`
  - Fixed bug causing some queries using `r.Row` to fail with the error `Cannot use r.row in nested queries.`
+ - Fixed typos in `ConnectOpt` field (and related functions) `InitialCap`.
 
 ## v2.1.2 - 2016-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## v2.1.3 - 2016-08-01
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
  - Fixed incorrectly named `Replicas` field in `TableCreateOpts`
+ - Fixed broken optional argument `FinalEmit` in `FoldOpts`
 
 ## v2.1.2 - 2016-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+ - Changed behaviour of function callbacks to allow arguments to be either of type `r.Term` or `interface {}` instead of only `r.Term`
+
 ### Fixed
  - Fixed incorrectly named `Replicas` field in `TableCreateOpts`
  - Fixed broken optional argument `FinalEmit` in `FoldOpts`
+ - Fixed bug causing some queries using `r.Row` to fail with the error `Cannot use r.row in nested queries.`
 
 ## v2.1.2 - 2016-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+ - Fixed incorrectly named `Replicas` field in `TableCreateOpts`
+
 ## v2.1.2 - 2016-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![GoRethink Logo](https://raw.github.com/wiki/dancannon/gorethink/gopher-and-thinker-s.png "Golang Gopher and RethinkDB Thinker")
 
-Current version: v2.1.2 (RethinkDB v2.3)
+Current version: v2.1.3 (RethinkDB v2.3)
 
 Please note that this version of the driver only supports versions of RethinkDB using the v0.4 protocol (any versions of the driver older than RethinkDB 2.0 will not work).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# GoRethink - RethinkDB Driver for Go 
+# GoRethink - RethinkDB Driver for Go
 
 [![GitHub tag](https://img.shields.io/github/tag/dancannon/gorethink.svg?style=flat)](https://github.com/dancannon/gorethink/releases)
 [![GoDoc](https://godoc.org/github.com/dancannon/gorethink?status.png)](https://godoc.org/github.com/dancannon/gorethink)
-[![build status](https://img.shields.io/travis/dancannon/gorethink/master.svg "build status")](https://travis-ci.org/dancannon/gorethink) 
+[![build status](https://img.shields.io/travis/dancannon/gorethink/master.svg "build status")](https://travis-ci.org/dancannon/gorethink)
 
-[Go](http://golang.org/) driver for [RethinkDB](http://www.rethinkdb.com/) 
+[Go](http://golang.org/) driver for [RethinkDB](http://www.rethinkdb.com/)
 
 ![GoRethink Logo](https://raw.github.com/wiki/dancannon/gorethink/gopher-and-thinker-s.png "Golang Gopher and RethinkDB Thinker")
 
@@ -91,7 +91,7 @@ See the [documentation](http://godoc.org/github.com/dancannon/gorethink#Connect)
 
 The driver uses a connection pool at all times, by default it creates and frees connections automatically. It's safe for concurrent use by multiple goroutines.
 
-To configure the connection pool `InitlaCap`, `MaxOpen` and `Timeout` can be specified during connection. If you wish to change the value of `InitlaCap` or `MaxOpen` during runtime then the functions `SetInitalPoolCap` and `SetMaxOpenConns` can be used.
+To configure the connection pool `InitialCap`, `MaxOpen` and `Timeout` can be specified during connection. If you wish to change the value of `InitialCap` or `MaxOpen` during runtime then the functions `SetInitialPoolCap` and `SetMaxOpenConns` can be used.
 
 [embedmd]:# (example_connect_test.go go /func ExampleConnect_connectionPool\(\) {/ /(?m)^}/)
 ```go
@@ -391,7 +391,7 @@ The mocking implementation is based on amazing https://github.com/stretchr/testi
 
 ## Benchmarks
 
-Everyone wants their project's benchmarks to be speedy. And while we know that rethinkDb and the gorethink driver are quite fast, our primary goal is for our benchmarks to be correct. They are designed to give you, the user, an accurate picture of writes per second (w/s). If you come up with a accurate test that meets this aim, submit a pull request please. 
+Everyone wants their project's benchmarks to be speedy. And while we know that rethinkDb and the gorethink driver are quite fast, our primary goal is for our benchmarks to be correct. They are designed to give you, the user, an accurate picture of writes per second (w/s). If you come up with a accurate test that meets this aim, submit a pull request please.
 
 Thanks to @jaredfolkins for the contribution.
 
@@ -399,12 +399,12 @@ Thanks to @jaredfolkins for the contribution.
 | --- | --- |
 | **Model Name** | MacBook Pro |
 | **Model Identifier** | MacBookPro11,3 |
-| **Processor Name** | Intel Core i7 | 
-| **Processor Speed** | 2.3 GHz | 
+| **Processor Name** | Intel Core i7 |
+| **Processor Speed** | 2.3 GHz |
 | **Number of Processors** | 1 |
 | **Total Number of Cores** | 4 |
-| **L2 Cache (per Core)** | 256 KB | 
-| **L3 Cache** | 6 MB | 
+| **L2 Cache (per Core)** | 256 KB |
+| **L3 Cache** | 6 MB |
 | **Memory** | 16 GB |
 
 ```bash
@@ -451,4 +451,4 @@ limitations under the License.
 
 ## Donations
 
-[![Donations](https://pledgie.com/campaigns/29517.png "Donations")](https://pledgie.com/campaigns/29517) 
+[![Donations](https://pledgie.com/campaigns/29517.png "Donations")](https://pledgie.com/campaigns/29517)

--- a/cluster.go
+++ b/cluster.go
@@ -123,10 +123,10 @@ func (c *Cluster) Server() (response ServerResponse, err error) {
 	return response, err
 }
 
-// SetInitalPoolCap sets the initial capacity of the connection pool.
-func (c *Cluster) SetInitalPoolCap(n int) {
+// SetInitialPoolCap sets the initial capacity of the connection pool.
+func (c *Cluster) SetInitialPoolCap(n int) {
 	for _, node := range c.GetNodes() {
-		node.SetInitalPoolCap(n)
+		node.SetInitialPoolCap(n)
 	}
 }
 

--- a/encoding/decoder_test.go
+++ b/encoding/decoder_test.go
@@ -464,3 +464,32 @@ func jsonEqual(a, b interface{}) bool {
 
 	return bytes.Compare(ba, bb) == 0
 }
+
+func TestMergeStruct(t *testing.T) {
+	var dst struct {
+		Field        string
+		AnotherField string
+	}
+	dst.Field = "change me"
+	dst.AnotherField = "don't blank me"
+	err := Merge(&dst, map[string]interface{}{"Field": "Changed!"})
+	if err != nil {
+		t.Error("Cannot merge:", err)
+	}
+	if dst.AnotherField == "" {
+		t.Error("Field has been wiped")
+	}
+}
+
+func TestMergeMap(t *testing.T) {
+	var dst = make(map[string]string)
+	dst["field"] = "change me"
+	dst["another_field"] = "don't blank me"
+	err := Merge(&dst, map[string]interface{}{"field": "Changed!"})
+	if err != nil {
+		t.Error("Cannot merge:", err)
+	}
+	if dst["another_field"] == "" {
+		t.Error("Field has been wiped")
+	}
+}

--- a/encoding/decoder_types.go
+++ b/encoding/decoder_types.go
@@ -189,7 +189,7 @@ func interfaceAsTypeDecoder(dv, sv reflect.Value) {
 		dv = indirect(dv, false)
 		dv.Set(reflect.Zero(dv.Type()))
 
-		decode(dv, sv.Elem())
+		decodeValue(dv, sv.Elem(), true)
 	}
 }
 

--- a/encoding/decoder_types.go
+++ b/encoding/decoder_types.go
@@ -8,14 +8,14 @@ import (
 )
 
 // newTypeDecoder constructs an decoderFunc for a type.
-func newTypeDecoder(dt, st reflect.Type) decoderFunc {
+func newTypeDecoder(dt, st reflect.Type, blank bool) decoderFunc {
 	if reflect.PtrTo(dt).Implements(unmarshalerType) ||
 		dt.Implements(unmarshalerType) {
 		return unmarshalerDecoder
 	}
 
 	if st.Kind() == reflect.Interface {
-		return interfaceAsTypeDecoder
+		return newInterfaceAsTypeDecoder(blank)
 	}
 
 	switch dt.Kind() {
@@ -101,7 +101,7 @@ func newTypeDecoder(dt, st reflect.Type) decoderFunc {
 
 		return interfaceDecoder
 	case reflect.Ptr:
-		return newPtrDecoder(dt, st)
+		return newPtrDecoder(dt, st, blank)
 	case reflect.Map:
 		if st.AssignableTo(dt) {
 			return interfaceDecoder
@@ -109,7 +109,7 @@ func newTypeDecoder(dt, st reflect.Type) decoderFunc {
 
 		switch st.Kind() {
 		case reflect.Map:
-			return newMapAsMapDecoder(dt, st)
+			return newMapAsMapDecoder(dt, st, blank)
 		default:
 			return decodeTypeError
 		}
@@ -124,7 +124,7 @@ func newTypeDecoder(dt, st reflect.Type) decoderFunc {
 				return newDecodeTypeError(fmt.Errorf("map needs string keys"))
 			}
 
-			return newMapAsStructDecoder(dt, st)
+			return newMapAsStructDecoder(dt, st, blank)
 		default:
 			return decodeTypeError
 		}
@@ -135,7 +135,7 @@ func newTypeDecoder(dt, st reflect.Type) decoderFunc {
 
 		switch st.Kind() {
 		case reflect.Array, reflect.Slice:
-			return newSliceDecoder(dt, st)
+			return newSliceDecoder(dt, st, blank)
 		default:
 			return decodeTypeError
 		}
@@ -146,7 +146,7 @@ func newTypeDecoder(dt, st reflect.Type) decoderFunc {
 
 		switch st.Kind() {
 		case reflect.Array, reflect.Slice:
-			return newArrayDecoder(dt, st)
+			return newArrayDecoder(dt, st, blank)
 		default:
 			return decodeTypeError
 		}
@@ -184,12 +184,15 @@ func interfaceDecoder(dv, sv reflect.Value) {
 	dv.Set(sv)
 }
 
-func interfaceAsTypeDecoder(dv, sv reflect.Value) {
-	if !sv.IsNil() {
-		dv = indirect(dv, false)
-		dv.Set(reflect.Zero(dv.Type()))
-
-		decodeValue(dv, sv.Elem(), true)
+func newInterfaceAsTypeDecoder(blank bool) decoderFunc {
+	return func(dv, sv reflect.Value) {
+		if !sv.IsNil() {
+			dv = indirect(dv, false)
+			if blank {
+				dv.Set(reflect.Zero(dv.Type()))
+			}
+			decodeValue(dv, sv.Elem(), blank)
+		}
 	}
 }
 
@@ -203,8 +206,8 @@ func (d *ptrDecoder) decode(dv, sv reflect.Value) {
 	dv.Set(v)
 }
 
-func newPtrDecoder(dt, st reflect.Type) decoderFunc {
-	dec := &ptrDecoder{typeDecoder(dt.Elem(), st)}
+func newPtrDecoder(dt, st reflect.Type, blank bool) decoderFunc {
+	dec := &ptrDecoder{typeDecoder(dt.Elem(), st, blank)}
 
 	return dec.decode
 }
@@ -370,12 +373,12 @@ func (d *sliceDecoder) decode(dv, sv reflect.Value) {
 	}
 }
 
-func newSliceDecoder(dt, st reflect.Type) decoderFunc {
+func newSliceDecoder(dt, st reflect.Type, blank bool) decoderFunc {
 	// Byte slices get special treatment; arrays don't.
 	// if t.Elem().Kind() == reflect.Uint8 {
 	// 	return decodeByteSlice
 	// }
-	dec := &sliceDecoder{newArrayDecoder(dt, st)}
+	dec := &sliceDecoder{newArrayDecoder(dt, st, blank)}
 	return dec.decode
 }
 
@@ -426,8 +429,8 @@ func (d *arrayDecoder) decode(dv, sv reflect.Value) {
 	}
 }
 
-func newArrayDecoder(dt, st reflect.Type) decoderFunc {
-	dec := &arrayDecoder{typeDecoder(dt.Elem(), st.Elem())}
+func newArrayDecoder(dt, st reflect.Type, blank bool) decoderFunc {
+	dec := &arrayDecoder{typeDecoder(dt.Elem(), st.Elem(), blank)}
 	return dec.decode
 }
 
@@ -472,8 +475,8 @@ func (d *mapAsMapDecoder) decode(dv, sv reflect.Value) {
 	}
 }
 
-func newMapAsMapDecoder(dt, st reflect.Type) decoderFunc {
-	d := &mapAsMapDecoder{typeDecoder(dt.Key(), st.Key()), typeDecoder(dt.Elem(), st.Elem())}
+func newMapAsMapDecoder(dt, st reflect.Type, blank bool) decoderFunc {
+	d := &mapAsMapDecoder{typeDecoder(dt.Key(), st.Key(), blank), typeDecoder(dt.Elem(), st.Elem(), blank)}
 	return d.decode
 }
 
@@ -516,14 +519,14 @@ func (d *mapAsStructDecoder) decode(dv, sv reflect.Value) {
 	}
 }
 
-func newMapAsStructDecoder(dt, st reflect.Type) decoderFunc {
+func newMapAsStructDecoder(dt, st reflect.Type, blank bool) decoderFunc {
 	fields := cachedTypeFields(dt)
 	se := &mapAsStructDecoder{
 		fields:    fields,
 		fieldDecs: make([]decoderFunc, len(fields)),
 	}
 	for i, f := range fields {
-		se.fieldDecs[i] = typeDecoder(typeByIndex(dt, f.index), st.Elem())
+		se.fieldDecs[i] = typeDecoder(typeByIndex(dt, f.index), st.Elem(), blank)
 	}
 	return se.decode
 }

--- a/node.go
+++ b/node.go
@@ -63,9 +63,9 @@ func (n *Node) Close(optArgs ...CloseOpts) error {
 	return nil
 }
 
-// SetInitalPoolCap sets the initial capacity of the connection pool.
-func (n *Node) SetInitalPoolCap(idleConns int) {
-	n.pool.SetInitalPoolCap(idleConns)
+// SetInitialPoolCap sets the initial capacity of the connection pool.
+func (n *Node) SetInitialPoolCap(idleConns int) {
+	n.pool.SetInitialPoolCap(idleConns)
 }
 
 // SetMaxIdleConns sets the maximum number of connections in the idle

--- a/pool.go
+++ b/pool.go
@@ -111,10 +111,10 @@ func (p *Pool) conn() (*Connection, *pool.PoolConn, error) {
 	return conn, pc, nil
 }
 
-// SetInitalPoolCap sets the initial capacity of the connection pool.
+// SetInitialPoolCap sets the initial capacity of the connection pool.
 //
 // Deprecated: This value should only be set when connecting
-func (p *Pool) SetInitalPoolCap(n int) {
+func (p *Pool) SetInitialPoolCap(n int) {
 	return
 }
 

--- a/query_aggregation.go
+++ b/query_aggregation.go
@@ -169,7 +169,7 @@ func (t Term) MaxIndex(index interface{}, args ...interface{}) Term {
 // FoldOpts contains the optional arguments for the Fold term
 type FoldOpts struct {
 	Emit      interface{} `gorethink:"emit,omitempty"`
-	FinalEmit interface{} `gorethink:"finalEmit,omitempty"`
+	FinalEmit interface{} `gorethink:"final_emit,omitempty"`
 }
 
 func (o *FoldOpts) toMap() map[string]interface{} {

--- a/query_aggregation.go
+++ b/query_aggregation.go
@@ -94,7 +94,7 @@ func (t Term) Ungroup(args ...interface{}) Term {
 // or if functions are provided instead, returns whether or not a sequence
 // contains values matching all the specified functions.
 func (t Term) Contains(args ...interface{}) Term {
-	return constructMethodTerm(t, "Contains", p.Term_CONTAINS, args, map[string]interface{}{})
+	return constructMethodTerm(t, "Contains", p.Term_CONTAINS, funcWrapArgs(args), map[string]interface{}{})
 }
 
 // Aggregators

--- a/query_table.go
+++ b/query_table.go
@@ -9,7 +9,7 @@ type TableCreateOpts struct {
 	PrimaryKey        interface{} `gorethink:"primary_key,omitempty"`
 	Durability        interface{} `gorethink:"durability,omitempty"`
 	Shards            interface{} `gorethink:"shards,omitempty"`
-	DataCenter        interface{} `gorethink:"replicas,omitempty"`
+	Replicas          interface{} `gorethink:"replicas,omitempty"`
 	PrimaryReplicaTag interface{} `gorethink:"primary_replica_tag,omitempty"`
 }
 

--- a/query_transformation.go
+++ b/query_transformation.go
@@ -16,7 +16,7 @@ func Map(args ...interface{}) Term {
 		args = append(args[:len(args)-1], funcWrapArgs(args[len(args)-1:])...)
 	}
 
-	return constructRootTerm("Map", p.Term_MAP, funcWrapArgs(args), map[string]interface{}{})
+	return constructRootTerm("Map", p.Term_MAP, args, map[string]interface{}{})
 }
 
 // Map transforms each element of the sequence by applying the given mapping

--- a/query_transformation_test.go
+++ b/query_transformation_test.go
@@ -18,8 +18,23 @@ func (s *RethinkSuite) TestTransformationMapImplicit(c *test.C) {
 }
 
 func (s *RethinkSuite) TestTransformationMapFunc(c *test.C) {
-	query := Expr(arr).Map(func(row Term) Term {
+	query := Expr(arr).Map(func(row Term) interface{} {
 		return row.Add(1)
+	})
+
+	var response []interface{}
+	res, err := query.Run(session)
+	c.Assert(err, test.IsNil)
+
+	err = res.All(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, jsonEquals, []interface{}{2, 3, 4, 5, 6, 7, 8, 9, 10})
+}
+
+func (s *RethinkSuite) TestTransformationMapImplicitFunc(c *test.C) {
+	query := Expr(arr).Map(func(row interface{}) interface{} {
+		return Row.Add(1)
 	})
 
 	var response []interface{}

--- a/query_transformation_test.go
+++ b/query_transformation_test.go
@@ -32,21 +32,6 @@ func (s *RethinkSuite) TestTransformationMapFunc(c *test.C) {
 	c.Assert(response, jsonEquals, []interface{}{2, 3, 4, 5, 6, 7, 8, 9, 10})
 }
 
-func (s *RethinkSuite) TestTransformationMapImplicitFunc(c *test.C) {
-	query := Expr(arr).Map(func(row interface{}) interface{} {
-		return Row.Add(1)
-	})
-
-	var response []interface{}
-	res, err := query.Run(session)
-	c.Assert(err, test.IsNil)
-
-	err = res.All(&response)
-
-	c.Assert(err, test.IsNil)
-	c.Assert(response, jsonEquals, []interface{}{2, 3, 4, 5, 6, 7, 8, 9, 10})
-}
-
 func (s *RethinkSuite) TestTransformationWithFields(c *test.C) {
 	query := Expr(objList).WithFields("id", "num").OrderBy("id")
 

--- a/session.go
+++ b/session.go
@@ -220,13 +220,13 @@ func (s *Session) Close(optArgs ...CloseOpts) error {
 	return nil
 }
 
-// SetInitalPoolCap sets the initial capacity of the connection pool.
-func (s *Session) SetInitalPoolCap(n int) {
+// SetInitialPoolCap sets the initial capacity of the connection pool.
+func (s *Session) SetInitialPoolCap(n int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.opts.InitialCap = n
-	s.cluster.SetInitalPoolCap(n)
+	s.cluster.SetInitialPoolCap(n)
 }
 
 // SetMaxIdleConns sets the maximum number of connections in the idle

--- a/utils.go
+++ b/utils.go
@@ -102,8 +102,9 @@ func makeFunc(f interface{}) Term {
 		argNums[i] = varID
 
 		// make sure all input arguments are of type Term
-		if valueType.In(i).String() != "gorethink.Term" {
-			panic("Function argument is not of type Term")
+		argValueTypeName := valueType.In(i).String()
+		if argValueTypeName != "gorethink.Term" && argValueTypeName != "interface {}" {
+			panic("Function argument is not of type Term or interface {}")
 		}
 	}
 


### PR DESCRIPTION
Created a `encoding.Merge` method that decodedes structs and maps without blanking them.

It allows to apply the changes of an update to a struct or a map: see https://github.com/dancannon/gorethink/issues/352
