### PR TITLE
Add ability to create compound key using struct tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ r.DB("examples").Table("heroes").GetAll("man_of_steel").OptArgs(r.GetAllOpts{
     Index: "code_name",
 })
 ```
+ 
+ - Added ability to create compound keys from structs, for example:
+
+```
+type User struct {
+  Company string `gorethink:"id[0]"`
+  Name    string `gorethink:"id[1]"`
+  Age     int    `gorethink:"age"`
+}
+// Creates
+{"id": [COMPANY, NAME], "age": AGE}
+```
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,10 @@ Field int `gorethink:"myName,omitempty"`
 // the field is skipped if empty.
 // Note the leading comma.
 Field int `gorethink:",omitempty"`
+// When the tag name includes an index expression
+// a compound field is created
+Field1 int `gorethink:"myName[0]"`
+Field2 int `gorethink:"myName[1]"`
 ```
 
 **NOTE:** It is strongly recommended that struct tags are used to explicitly define the mapping between your Go type and how the data is stored by RethinkDB. This is especially important when using an `Id` field as by default RethinkDB will create a field named `id` as the primary key (note that the RethinkDB field is lowercase but the Go version starts with a capital letter).

--- a/encoding/cache.go
+++ b/encoding/cache.go
@@ -148,6 +148,7 @@ func typeFields(t reflect.Type) []field {
 						typ:           ft,
 						omitEmpty:     opts.Contains("omitempty"),
 						reference:     opts.Contains("reference"),
+						refName:       ref,
 						compound:      isCompound,
 						compoundIndex: compoundIndex,
 					}))

--- a/encoding/cache.go
+++ b/encoding/cache.go
@@ -15,13 +15,15 @@ type field struct {
 	nameBytes []byte // []byte(name)
 	equalFold func(s, t []byte) bool
 
-	tag       bool
-	index     []int
-	typ       reflect.Type
-	omitEmpty bool
-	quoted    bool
-	reference bool
-	refName   string
+	tag           bool
+	index         []int
+	typ           reflect.Type
+	omitEmpty     bool
+	quoted        bool
+	reference     bool
+	refName       string
+	compound      bool
+	compoundIndex int
 }
 
 func fillField(f field) field {
@@ -112,6 +114,7 @@ func typeFields(t reflect.Type) []field {
 					continue
 				}
 				name, opts := parseTag(tag)
+				name, compoundIndex, isCompound := parseCompoundIndex(name)
 				if !isValidTag(name) {
 					name = ""
 				}
@@ -121,6 +124,7 @@ func typeFields(t reflect.Type) []field {
 				if !isValidTag(ref) {
 					ref = ""
 				}
+
 				index := make([]int, len(f.index)+1)
 				copy(index, f.index)
 				index[len(f.index)] = i
@@ -138,13 +142,14 @@ func typeFields(t reflect.Type) []field {
 						name = sf.Name
 					}
 					fields = append(fields, fillField(field{
-						name:      name,
-						tag:       tagged,
-						index:     index,
-						typ:       ft,
-						omitEmpty: opts.Contains("omitempty"),
-						reference: opts.Contains("reference"),
-						refName:   ref,
+						name:          name,
+						tag:           tagged,
+						index:         index,
+						typ:           ft,
+						omitEmpty:     opts.Contains("omitempty"),
+						reference:     opts.Contains("reference"),
+						compound:      isCompound,
+						compoundIndex: compoundIndex,
 					}))
 					if count[f.typ] > 1 {
 						// If there were multiple instances, add a second,
@@ -178,12 +183,15 @@ func typeFields(t reflect.Type) []field {
 		// One iteration per name.
 		// Find the sequence of fields with the name of this first field.
 		fi := fields[i]
-		name := fi.name
 		for advance = 1; i+advance < len(fields); advance++ {
 			fj := fields[i+advance]
-			if fj.name != name {
+			if fj.name != fi.name {
 				break
 			}
+			if fi.compound && fj.compound && fi.compoundIndex != fj.compoundIndex {
+				break
+			}
+
 		}
 		if advance == 1 { // Only one field with this name
 			out = append(out, fi)

--- a/encoding/decoder_test.go
+++ b/encoding/decoder_test.go
@@ -446,6 +446,20 @@ func TestDecodeMapIntKeys(t *testing.T) {
 	}
 }
 
+func TestDecodeCompoundKey(t *testing.T) {
+	input := map[string]interface{}{"id": []string{"1", "2"}, "err_a[]": "3", "err_b[": "4", "err_c]": "5"}
+	want := Compound{"1", "2", "3", "4", "5"}
+
+	out := Compound{}
+	err := Decode(&out, input)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
 func jsonEqual(a, b interface{}) bool {
 	// First check using reflect.DeepEqual
 	if reflect.DeepEqual(a, b) {

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -368,3 +368,21 @@ func TestEncodeCompound(t *testing.T) {
 		t.Errorf("got %q, want %q", out, want)
 	}
 }
+
+type CompoundRef struct {
+	PartA string `gorethink:"id[0]"`
+	PartB *RefB  `gorethink:"id[1],reference" gorethink_ref:"id"`
+}
+
+func TestEncodeCompoundRef(t *testing.T) {
+	input := CompoundRef{"1", &RefB{"2", "Name"}}
+	want := map[string]interface{}{"id": []string{"1", "2"}}
+
+	out, err := Encode(input)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -347,3 +347,24 @@ func TestReferenceFieldArray(t *testing.T) {
 		t.Errorf("got %q, want %q", out, want)
 	}
 }
+
+type Compound struct {
+	PartA string `gorethink:"id[0]"`
+	PartB string `gorethink:"id[1]"`
+	ErrA  string `gorethink:"err_a[]"`
+	ErrB  string `gorethink:"err_b["`
+	ErrC  string `gorethink:"err_c]"`
+}
+
+func TestEncodeCompound(t *testing.T) {
+	input := Compound{"1", "2", "3", "4", "5"}
+	want := map[string]interface{}{"id": []string{"1", "2"}, "err_a[]": "3", "err_b[": "4", "err_c]": "5"}
+
+	out, err := Encode(input)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}

--- a/encoding/encoder_types.go
+++ b/encoding/encoder_types.go
@@ -162,6 +162,20 @@ func (se *structEncoder) encode(v reflect.Value) interface{} {
 			encField = getReferenceField(f, v, encField)
 		}
 
+		if f.compound {
+			compoundField, ok := m[f.name].([]interface{})
+			if !ok {
+				compoundField = make([]interface{}, f.compoundIndex+1)
+			} else if len(compoundField) < f.compoundIndex+1 {
+				tmp := make([]interface{}, f.compoundIndex+1)
+				copy(tmp, compoundField)
+				compoundField = tmp
+			}
+
+			compoundField[f.compoundIndex] = encField
+			encField = compoundField
+		}
+
 		m[f.name] = encField
 	}
 

--- a/encoding/tags.go
+++ b/encoding/tags.go
@@ -4,6 +4,7 @@ package encoding
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -47,6 +48,18 @@ func parseTag(tag string) (string, tagOptions) {
 		return tag[:idx], tagOptions(tag[idx+1:])
 	}
 	return tag, tagOptions("")
+}
+
+func parseCompoundIndex(tag string) (string, int, bool) {
+	lIdx := strings.Index(tag, "[")
+	rIdx := strings.Index(tag, "]")
+	if lIdx > 1 && rIdx > lIdx+1 {
+		if elemIndex_, err := strconv.ParseInt(tag[lIdx+1:rIdx], 10, 64); err == nil {
+			return tag[:lIdx], int(elemIndex_), true
+		}
+	}
+
+	return tag, 0, false
 }
 
 func isValidTag(s string) bool {


### PR DESCRIPTION
As suggested in #342 this PR adds the ability to create compound keys using struct tags. If a struct tag includes an index expression then the driver creates and array of fields when encoding and then attempts to decode this array back when decoding.
