### PR TITLE
changes can return "error" along with "new_val" and "old_val"

### DIFF
--- a/query.go
+++ b/query.go
@@ -288,6 +288,7 @@ type WriteResponse struct {
 // ChangeResponse is a helper type used when dealing with changefeeds. The type
 // contains both the value before the query and the new value.
 type ChangeResponse struct {
+	Error    string      `gorethink:"error"`
 	NewValue interface{} `gorethink:"new_val"`
 	OldValue interface{} `gorethink:"old_val"`
 }


### PR DESCRIPTION
I added error to `ChangeResponse`

```
r.db("db").table("table").get("id").update({
    "field": r.branch(
        r.row("field").default(0).eq(0),
        r.error("oh no!"),
        "value"
    )
},
{
    "returnChanges":"always"
})
```

will print:

```
"changes": [
    {
        "error": "oh no!" ,
    "new_val": ...
```
