### PR TITLE
Don't convert nil slices into empty, non-nil slices

### DIFF
--- a/encoding/decoder_test.go
+++ b/encoding/decoder_test.go
@@ -147,6 +147,10 @@ type Ambig struct {
 	Second int `gorethink:"Hello"`
 }
 
+type SliceStruct struct {
+	X []string
+}
+
 // Decode test helper vars
 var (
 	sampleInt = 2
@@ -451,6 +455,20 @@ func TestDecodeCompoundKey(t *testing.T) {
 	want := Compound{"1", "2", "3", "4", "5"}
 
 	out := Compound{}
+	err := Decode(&out, input)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestDecodeNilSlice(t *testing.T) {
+	input := map[string]interface{}{"X": nil}
+	want := SliceStruct{}
+
+	out := SliceStruct{}
 	err := Decode(&out, input)
 	if err != nil {
 		t.Errorf("got error %v, expected nil", err)

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -407,3 +407,16 @@ func TestEncodeCompoundRef(t *testing.T) {
 		t.Errorf("got %q, want %q", out, want)
 	}
 }
+
+func TestEncodeNilSlice(t *testing.T) {
+	input := SliceStruct{}
+	want := map[string]interface{}{"X": []string(nil)}
+
+	out, err := Encode(input)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -89,7 +89,7 @@ var optionalsExpected = map[string]interface{}{
 	"sr":        "",
 	"omitempty": int64(0),
 	"tr":        map[string]interface{}{"$reql_type$": "TIME", "epoch_time": 0, "timezone": "+00:00"},
-	"slr":       []interface{}{},
+	"slr":       []interface{}(nil),
 	"mr":        map[string]interface{}{},
 }
 

--- a/encoding/encoder_types.go
+++ b/encoding/encoder_types.go
@@ -284,7 +284,7 @@ type sliceEncoder struct {
 
 func (se *sliceEncoder) encode(v reflect.Value) interface{} {
 	if v.IsNil() {
-		return []interface{}{}
+		return []interface{}(nil)
 	}
 	return se.arrayEnc(v)
 }


### PR DESCRIPTION
If a slice is nil, the json package marshals it into `null`. If it's
empty, but non-nil, json marshals it into `[]`. Similarly, the json
package unmarshals `null` into `[]interface{}(nil)`, but `[]` into
`[]interface{}{}`, which are unequal.

As a result, the previous functionality created a weird situation where
the object that was unmarshaled after a round-trip to rethink was
unequal to the original object. That behavior is unusual as we should
expect that the objects would be equal.

This commit ensures that nil slices retain their nil-ness when encoded
by gorethink, which ensures that json encodes them as `null` and then
decodes them as `[]inteface{}(nil)`, which is the same value they had
before encoding.