### PR TITLE
Return unconnected session from r.Connect()

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -170,7 +170,7 @@ func (mq *MockQuery) On(t Term) *MockQuery {
 // passing this when running your queries instead of a session. For example:
 //
 //     mock := r.NewMock()
-//     mock.on(r.Table("test")).Return([]interface{}{data}, nil)
+//     mock.On(r.Table("test")).Return([]interface{}{data}, nil)
 //
 //     cursor, err := r.Table("test").Run(mock)
 //

--- a/session.go
+++ b/session.go
@@ -148,7 +148,12 @@ func Connect(opts ConnectOpts) (*Session, error) {
 
 	err := s.Reconnect()
 	if err != nil {
-		return s, err
+		// note: s.Reconnect() will initialize cluster information which
+		// will cause the .IsConnected() method to be caught in a loop
+		return &Session{
+			hosts: hosts,
+			opts: &opts,
+		}, err
 	}
 
 	return s, nil

--- a/session.go
+++ b/session.go
@@ -148,7 +148,7 @@ func Connect(opts ConnectOpts) (*Session, error) {
 
 	err := s.Reconnect()
 	if err != nil {
-		return nil, err
+		return s, err
 	}
 
 	return s, nil


### PR DESCRIPTION
Firstly, many thanks for this great library. I just have one small change request.

Currently the method r.Connect() will return nil if the connection to the database cannot established. If execution is not stopped after this, subsequent calls such as r.Expr("Hello World").Run(session) will result in a panic.

In contrast if an empty session (&r.Session{}) is passed to to r.Expr("Hello World").Run(session), then there will correctly result an error that the database is not connected.

By changing the return value from r.Connect() to an unconnected session, subsequent calls to r.Expr("Hello World").Run(session) will correctly return an error if the database is not available and run as expected if the database did become available by now. 

This will allow to start services in parallel with the database and implement custom methods to wait for the database to be accessible (or just hope that it will become accessible at a later point). In my opinion, this would make sense, as one should not trust the database to be always available just because it is available on startup and on the other side should not hinder to startup a service only because the database is currently not available.