### PR TITLE
Fixes infinite loop seekCursor

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -214,6 +214,10 @@ func (c *Cursor) nextLocked(dest interface{}, progressCursor bool) (bool, error)
 			return false, err
 		}
 
+		if c.closed {
+			return false, nil
+		}
+
 		if len(c.buffer) == 0 && c.finished {
 			return false, nil
 		}
@@ -615,6 +619,9 @@ func (c *Cursor) seekCursor(bufferResponse bool) error {
 			//  We skipped all of our data, load some more
 			if err := c.fetchMore(); err != nil {
 				return err
+			}
+			if c.closed {
+				return nil
 			}
 			continue // go around the loop again to re-apply pending skips
 		}


### PR DESCRIPTION
I managed to resolve the problem of the 100% CPU usage due to a infinite loop in ```seekCursor()```. The problem was happening because when the cursor was being closed from another thread, sometimes the function ```seekCursor()``` wasn't returning a nil value.

I tested this change in our production system, and it has been working properly for 4 days. Before this change, I had to restart the server two times per day.