### PR TITLE
Session.IsConnected: use RLock instead of Lock to improve performance

### DIFF
--- a/session.go
+++ b/session.go
@@ -170,8 +170,8 @@ func (o CloseOpts) toMap() map[string]interface{} {
 
 // IsConnected returns true if session has a valid connection.
 func (s *Session) IsConnected() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	if s.cluster == nil || s.closed {
 		return false


### PR DESCRIPTION
single inserts go up from ~100 to more than 4000 on my dualcore system.
(100 goroutines concurrently inserting single values in local rethinkdb)