### PR TITLE
Display the build query error instead of generic message

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -189,7 +190,7 @@ func (c *Connection) sendQuery(q Query) error {
 	// Build query
 	b, err := json.Marshal(q.Build())
 	if err != nil {
-		return RQLDriverError{rqlError("Error building query")}
+		return RQLDriverError{rqlError(fmt.Sprintf("Error building query: %s", err.Error()))}
 	}
 
 	// Set timeout


### PR DESCRIPTION
Hello,

Imho, Explicit is better than implicit. The message from the json marshal error seems too generic.

I try to use a the RawQuery (dirty way) and it's was very hard to debug my query with this message.

In this part of the code, the real error message is mostly used. 

Thanks