### PR TITLE
Cancelling queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ r.Table("test").Insert(doc, r.InsertOpts{
 
 As shown above in the Between example optional arguments are passed to the function as a struct. Each function that has optional arguments as a related struct. This structs are named in the format FunctionNameOpts, for example BetweenOpts is the related struct for Between.
 
+#### Cancelling queries
+
+For query cancellation use `Context` argument at `RunOpts`. If `Context` is `nil` and `ReadTimeout` or `WriteTimeout` is not 0 from `ConnectionOpts`, `Context` will be formed by summation of these timeouts.
+
+For unlimited timeouts for `Changes()` pass `context.Background()`.
+
 ## Results
 
 Different result types are returned depending on what function is used to execute the query.

--- a/connection.go
+++ b/connection.go
@@ -177,7 +177,7 @@ func (c *Connection) Query(ctx context.Context, q Query) (*Response, *Cursor, er
 		return response, cursor, err
 	case <-ctx.Done():
 		if q.Type != p.Query_STOP {
-			stopQuery := formStopQuery(q.Token)
+			stopQuery := newStopQuery(q.Token)
 			c.Query(c.contextFromConnectionOpts(), stopQuery)
 		}
 		return nil, nil, ErrQueryTimeout

--- a/connection.go
+++ b/connection.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	p "gopkg.in/gorethink/gorethink.v3/ql2"
 	"golang.org/x/net/context"
+	p "gopkg.in/gorethink/gorethink.v3/ql2"
 )
 
 const (

--- a/connection_helper.go
+++ b/connection_helper.go
@@ -1,6 +1,9 @@
 package gorethink
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"golang.org/x/net/context"
+)
 
 // Write 'data' to conn
 func (c *Connection) writeData(data []byte) error {
@@ -38,4 +41,13 @@ func (c *Connection) writeQuery(token int64, q []byte) error {
 	pos += copy(data[pos:], q)
 
 	return c.writeData(data)
+}
+
+func (c *Connection) contextFromConnectionOpts() context.Context {
+	sum := c.opts.ReadTimeout + c.opts.WriteTimeout
+	if sum == 0 {
+		return context.Background()
+	}
+	ctx, _ := context.WithTimeout(context.Background(), sum)
+	return ctx
 }

--- a/cursor.go
+++ b/cursor.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"sync"
 
+	"golang.org/x/net/context"
 	"gopkg.in/gorethink/gorethink.v3/encoding"
 	p "gopkg.in/gorethink/gorethink.v3/ql2"
-	"golang.org/x/net/context"
 )
 
 var (
@@ -36,7 +36,7 @@ func newCursor(ctx context.Context, conn *Connection, cursorType string, token i
 		opts:       opts,
 		buffer:     make([]interface{}, 0),
 		responses:  make([]json.RawMessage, 0),
-		ctx: ctx,
+		ctx:        ctx,
 	}
 
 	return cursor
@@ -66,7 +66,7 @@ type Cursor struct {
 	cursorType string
 	term       *Term
 	opts       map[string]interface{}
-	ctx context.Context
+	ctx        context.Context
 
 	mu            sync.RWMutex
 	lastErr       error

--- a/cursor.go
+++ b/cursor.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/gorethink/gorethink.v3/encoding"
 	p "gopkg.in/gorethink/gorethink.v3/ql2"
+	"golang.org/x/net/context"
 )
 
 var (
@@ -16,7 +17,7 @@ var (
 	errCursorClosed = errors.New("connection closed, cannot read cursor")
 )
 
-func newCursor(conn *Connection, cursorType string, token int64, term *Term, opts map[string]interface{}) *Cursor {
+func newCursor(ctx context.Context, conn *Connection, cursorType string, token int64, term *Term, opts map[string]interface{}) *Cursor {
 	if cursorType == "" {
 		cursorType = "Cursor"
 	}
@@ -35,6 +36,7 @@ func newCursor(conn *Connection, cursorType string, token int64, term *Term, opt
 		opts:       opts,
 		buffer:     make([]interface{}, 0),
 		responses:  make([]json.RawMessage, 0),
+		ctx: ctx,
 	}
 
 	return cursor
@@ -64,6 +66,7 @@ type Cursor struct {
 	cursorType string
 	term       *Term
 	opts       map[string]interface{}
+	ctx context.Context
 
 	mu            sync.RWMutex
 	lastErr       error
@@ -145,15 +148,7 @@ func (c *Cursor) Close() error {
 
 	// Stop any unfinished queries
 	if !c.finished {
-		q := Query{
-			Type:  p.Query_STOP,
-			Token: c.token,
-			Opts: map[string]interface{}{
-				"noreply": true,
-			},
-		}
-
-		_, _, err = conn.Query(q)
+		_, _, err = conn.Query(c.ctx, formStopQuery(c.token))
 	}
 
 	if c.releaseConn != nil {
@@ -552,7 +547,7 @@ func (c *Cursor) fetchMore() error {
 		}
 
 		c.mu.Unlock()
-		_, _, err = c.conn.Query(q)
+		_, _, err = c.conn.Query(c.ctx, q)
 		c.mu.Lock()
 	}
 

--- a/cursor.go
+++ b/cursor.go
@@ -148,7 +148,7 @@ func (c *Cursor) Close() error {
 
 	// Stop any unfinished queries
 	if !c.finished {
-		_, _, err = conn.Query(c.ctx, formStopQuery(c.token))
+		_, _, err = conn.Query(c.ctx, newStopQuery(c.token))
 	}
 
 	if c.releaseConn != nil {

--- a/errors.go
+++ b/errors.go
@@ -25,6 +25,8 @@ var (
 	// ErrConnectionClosed is returned when trying to send a query with a closed
 	// connection.
 	ErrConnectionClosed = errors.New("gorethink: the connection is closed")
+	// ErrQueryTimeout is returned when query context deadline exceeded.
+	ErrQueryTimeout = errors.New("gorethink: query timeout")
 )
 
 func printCarrots(t Term, frames []*p.Frame) string {

--- a/mock.go
+++ b/mock.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	p "gopkg.in/gorethink/gorethink.v3/ql2"
 	"golang.org/x/net/context"
+	p "gopkg.in/gorethink/gorethink.v3/ql2"
 )
 
 // Mocking is based on the amazing package github.com/stretchr/testify

--- a/mock.go
+++ b/mock.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	p "gopkg.in/gorethink/gorethink.v3/ql2"
+	"golang.org/x/net/context"
 )
 
 // Mocking is based on the amazing package github.com/stretchr/testify
@@ -290,7 +291,7 @@ func (m *Mock) IsConnected() bool {
 	return true
 }
 
-func (m *Mock) Query(q Query) (*Cursor, error) {
+func (m *Mock) Query(ctx context.Context, q Query) (*Cursor, error) {
 	found, query := m.findExpectedQuery(q)
 
 	if found < 0 {
@@ -328,7 +329,7 @@ func (m *Mock) Query(q Query) (*Cursor, error) {
 	}
 
 	// Build cursor and return
-	c := newCursor(nil, "", query.Query.Token, query.Query.Term, query.Query.Opts)
+	c := newCursor(ctx, nil, "", query.Query.Token, query.Query.Term, query.Query.Opts)
 	c.finished = true
 	c.fetching = false
 	c.isAtom = true
@@ -345,8 +346,8 @@ func (m *Mock) Query(q Query) (*Cursor, error) {
 	return c, nil
 }
 
-func (m *Mock) Exec(q Query) error {
-	_, err := m.Query(q)
+func (m *Mock) Exec(ctx context.Context, q Query) error {
+	_, err := m.Query(ctx, q)
 
 	return err
 }

--- a/node.go
+++ b/node.go
@@ -3,8 +3,8 @@ package gorethink
 import (
 	"sync"
 
-	p "gopkg.in/gorethink/gorethink.v3/ql2"
 	"golang.org/x/net/context"
+	p "gopkg.in/gorethink/gorethink.v3/ql2"
 )
 
 // Node represents a database server in the cluster

--- a/node.go
+++ b/node.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	p "gopkg.in/gorethink/gorethink.v3/ql2"
+	"golang.org/x/net/context"
 )
 
 // Node represents a database server in the cluster
@@ -83,27 +84,27 @@ func (n *Node) SetMaxOpenConns(openConns int) {
 // processed by the server. Note that this guarantee only applies to queries
 // run on the given connection
 func (n *Node) NoReplyWait() error {
-	return n.pool.Exec(Query{
+	return n.pool.Exec(nil, Query{ // nil = connection opts' timeout
 		Type: p.Query_NOREPLY_WAIT,
 	})
 }
 
 // Query executes a ReQL query using this nodes connection pool.
-func (n *Node) Query(q Query) (cursor *Cursor, err error) {
+func (n *Node) Query(ctx context.Context, q Query) (cursor *Cursor, err error) {
 	if n.Closed() {
 		return nil, ErrInvalidNode
 	}
 
-	return n.pool.Query(q)
+	return n.pool.Query(ctx, q)
 }
 
 // Exec executes a ReQL query using this nodes connection pool.
-func (n *Node) Exec(q Query) (err error) {
+func (n *Node) Exec(ctx context.Context, q Query) (err error) {
 	if n.Closed() {
 		return ErrInvalidNode
 	}
 
-	return n.pool.Exec(q)
+	return n.pool.Exec(ctx, q)
 }
 
 // Server returns the server name and server UUID being used by a connection.

--- a/pool.go
+++ b/pool.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"sync"
 
-	"gopkg.in/fatih/pool.v2"
 	"golang.org/x/net/context"
+	"gopkg.in/fatih/pool.v2"
 )
 
 var (

--- a/pool.go
+++ b/pool.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"gopkg.in/fatih/pool.v2"
+	"golang.org/x/net/context"
 )
 
 var (
@@ -136,14 +137,14 @@ func (p *Pool) SetMaxOpenConns(n int) {
 // Query execution functions
 
 // Exec executes a query without waiting for any response.
-func (p *Pool) Exec(q Query) error {
+func (p *Pool) Exec(ctx context.Context, q Query) error {
 	c, pc, err := p.conn()
 	if err != nil {
 		return err
 	}
 	defer pc.Close()
 
-	_, _, err = c.Query(q)
+	_, _, err = c.Query(ctx, q)
 
 	if c.isBad() {
 		pc.MarkUnusable()
@@ -153,13 +154,13 @@ func (p *Pool) Exec(q Query) error {
 }
 
 // Query executes a query and waits for the response
-func (p *Pool) Query(q Query) (*Cursor, error) {
+func (p *Pool) Query(ctx context.Context, q Query) (*Cursor, error) {
 	c, pc, err := p.conn()
 	if err != nil {
 		return nil, err
 	}
 
-	_, cursor, err := c.Query(q)
+	_, cursor, err := c.Query(ctx, q)
 
 	if err == nil {
 		cursor.releaseConn = releaseConn(c, pc)

--- a/query.go
+++ b/query.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	p "gopkg.in/gorethink/gorethink.v3/ql2"
 	"golang.org/x/net/context"
+	p "gopkg.in/gorethink/gorethink.v3/ql2"
 )
 
 // A Query represents a query ready to be sent to the database, A Query differs

--- a/query.go
+++ b/query.go
@@ -338,9 +338,7 @@ func (t Term) Run(s QueryExecutor, optArgs ...RunOpts) (*Cursor, error) {
 	var ctx context.Context = nil // if it's nil connection will form context from connection opts
 	if len(optArgs) >= 1 {
 		opts = optArgs[0].toMap()
-		if optArgs[0].Context != nil {
-			ctx = optArgs[0].Context
-		}
+		ctx = optArgs[0].Context
 	}
 
 	if s == nil || !s.IsConnected() {
@@ -450,9 +448,7 @@ func (t Term) Exec(s QueryExecutor, optArgs ...ExecOpts) error {
 	var ctx context.Context = nil // if it's nil connection will form context from connection opts
 	if len(optArgs) >= 1 {
 		opts = optArgs[0].toMap()
-		if optArgs[0].Context != nil {
-			ctx = optArgs[0].Context
-		}
+		ctx = optArgs[0].Context
 	}
 
 	if s == nil || !s.IsConnected() {

--- a/query_helpers.go
+++ b/query_helpers.go
@@ -4,7 +4,7 @@ import (
 	p "gopkg.in/gorethink/gorethink.v3/ql2"
 )
 
-func formStopQuery(token int64) Query {
+func newStopQuery(token int64) Query {
 	return Query{
 		Type:  p.Query_STOP,
 		Token: token,

--- a/query_helpers.go
+++ b/query_helpers.go
@@ -1,0 +1,15 @@
+package gorethink
+
+import (
+	p "gopkg.in/gorethink/gorethink.v3/ql2"
+)
+
+func formStopQuery(token int64) Query {
+	return Query{
+		Type:  p.Query_STOP,
+		Token: token,
+		Opts: map[string]interface{}{
+			"noreply": true,
+		},
+	}
+}

--- a/session.go
+++ b/session.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	p "gopkg.in/gorethink/gorethink.v3/ql2"
+	"golang.org/x/net/context"
 )
 
 // A Session represents a connection to a RethinkDB cluster and should be used
@@ -265,7 +266,7 @@ func (s *Session) NoReplyWait() error {
 		return ErrConnectionClosed
 	}
 
-	return s.cluster.Exec(Query{
+	return s.cluster.Exec(nil, Query{ // nil = connection opts' defaults
 		Type: p.Query_NOREPLY_WAIT,
 	})
 }
@@ -287,7 +288,7 @@ func (s *Session) Database() string {
 }
 
 // Query executes a ReQL query using the session to connect to the database
-func (s *Session) Query(q Query) (*Cursor, error) {
+func (s *Session) Query(ctx context.Context, q Query) (*Cursor, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -295,11 +296,11 @@ func (s *Session) Query(q Query) (*Cursor, error) {
 		return nil, ErrConnectionClosed
 	}
 
-	return s.cluster.Query(q)
+	return s.cluster.Query(ctx, q)
 }
 
 // Exec executes a ReQL query using the session to connect to the database
-func (s *Session) Exec(q Query) error {
+func (s *Session) Exec(ctx context.Context, q Query) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -307,7 +308,7 @@ func (s *Session) Exec(q Query) error {
 		return ErrConnectionClosed
 	}
 
-	return s.cluster.Exec(q)
+	return s.cluster.Exec(ctx, q)
 }
 
 // Server returns the server name and server UUID being used by a connection.

--- a/session.go
+++ b/session.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	p "gopkg.in/gorethink/gorethink.v3/ql2"
 	"golang.org/x/net/context"
+	p "gopkg.in/gorethink/gorethink.v3/ql2"
 )
 
 // A Session represents a connection to a RethinkDB cluster and should be used


### PR DESCRIPTION
As discussed in #420 , now `RunOpts` contains `Context` param, which affects all the query including reading from cursor. If context deadline exceeds stop-query will be sent.
If there is no context, then it will be formed from `ConnectionOpts` socket timeouts.