### PR TITLE
change logrus import name to lower-case one

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ An good example of how to use these interfaces is in the [`types`](https://githu
 
 By default the driver logs are disabled however when enabled the driver will log errors when it fails to connect to the database. If you would like more verbose error logging you can call `r.SetVerbose(true)`.
 
-Alternatively if you wish to modify the logging behaviour you can modify the logger provided by `github.com/Sirupsen/logrus`. For example the following code completely disable the logger:
+Alternatively if you wish to modify the logging behaviour you can modify the logger provided by `github.com/sirupsen/logrus`. For example the following code completely disable the logger:
 
 ```go
 // Enabled

--- a/cluster.go
+++ b/cluster.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	"github.com/hailocab/go-hostpool"
 	"golang.org/x/net/context"

--- a/gorethink.go
+++ b/gorethink.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"reflect"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"gopkg.in/gorethink/gorethink.v3/encoding"
 )


### PR DESCRIPTION
Logrus changed their organization name from "Sirupsen" to "sirupsen" (https://github.com/sirupsen/logrus#case-sensitivity),  and importing gorethink in a project already using github.com/sirupsen/logrus is causing import conflicts.

I changed the logrus imports to the lower case organization.