### PR TITLE
Added Close method to QueryExecutor interface and Mock implementation

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -352,6 +352,10 @@ func (m *Mock) Exec(ctx context.Context, q Query) error {
 	return err
 }
 
+func (m *Mock) Close(optArgs ...CloseOpts) error {
+	return nil
+}
+
 func (m *Mock) newQuery(t Term, opts map[string]interface{}) (Query, error) {
 	return newQuery(t, opts, &m.opts)
 }

--- a/query.go
+++ b/query.go
@@ -259,6 +259,7 @@ type QueryExecutor interface {
 	IsConnected() bool
 	Query(context.Context, Query) (*Cursor, error)
 	Exec(context.Context, Query) error
+	Close(optArgs ...CloseOpts) error
 
 	newQuery(t Term, opts map[string]interface{}) (Query, error)
 }


### PR DESCRIPTION
I added `Close()` method to `Mock`, because without it it's impossible to use `Mock` as `QueryExecutor` interface.