### PR TITLE
External custom marshalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v4.1.0 - 2018-08-29
+
+### Fixed
+
+ - Rare `Connection` leaks if socket errors occurred
+ - Updated `ql2.proto` file from rethinkdb repo
+ 
+### Added
+
+ - Support for independent custom type marshalers 
+
 ## v4.0.0 - 2017-12-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ![GoRethink Logo](https://raw.github.com/wiki/gorethink/gorethink/gopher-and-thinker-s.png "Golang Gopher and RethinkDB Thinker")
 
-Current version: v4.0.0 (RethinkDB v2.3)
+Current version: v4.1.0 (RethinkDB v2.3)
 
 <!-- This project is no longer maintained, for more information see the [v3.0.0 release](https://github.com/gorethink/gorethink/releases/tag/v3.0.0)-->
 
@@ -40,7 +40,7 @@ import (
 
 func Example() {
 	session, err := r.Connect(r.ConnectOpts{
-		Address: url,
+		Address: url, // endpoint without http
 	})
 	if err != nil {
 		log.Fatalln(err)
@@ -399,6 +399,8 @@ r.Table("books").Get("book_1").Merge(func(p r.Term) interface{} {
 Sometimes the default behaviour for converting Go types to and from ReQL is not desired, for these situations the driver allows you to implement both the [`Marshaler`](https://godoc.org/github.com/gorethink/gorethink/encoding#Marshaler) and [`Unmarshaler`](https://godoc.org/github.com/gorethink/gorethink/encoding#Unmarshaler) interfaces. These interfaces might look familiar if you are using to using the `encoding/json` package however instead of dealing with `[]byte` the interfaces deal with `interface{}` values (which are later encoded by the `encoding/json` package when communicating with the database).
 
 An good example of how to use these interfaces is in the [`types`](https://github.com/gorethink/gorethink/blob/master/types/geometry.go#L84-L106) package, in this package the `Point` type is encoded as the `GEOMETRY` pseudo-type instead of a normal JSON object.
+
+On the other side, you can implement external encode/decode functions with [`SetTypeEncoding`](https://godoc.org/github.com/gorethink/gorethink/encoding#SetTypeEncoding) function.
 
 ## Logging
 

--- a/cluster.go
+++ b/cluster.go
@@ -7,9 +7,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	"github.com/hailocab/go-hostpool"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 

--- a/connection.go
+++ b/connection.go
@@ -9,13 +9,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/net/context"
-	p "gopkg.in/gorethink/gorethink.v4/ql2"
-	"sync"
+	"bytes"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
-	"bytes"
+	"golang.org/x/net/context"
+	p "gopkg.in/gorethink/gorethink.v4/ql2"
+	"sync"
 )
 
 const (

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,15 +1,15 @@
 package gorethink
 
 import (
-	test "gopkg.in/check.v1"
-	p "gopkg.in/gorethink/gorethink.v4/ql2"
-	"golang.org/x/net/context"
 	"encoding/binary"
 	"encoding/json"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"golang.org/x/net/context"
+	test "gopkg.in/check.v1"
+	p "gopkg.in/gorethink/gorethink.v4/ql2"
 	"io"
 	"time"
-	"github.com/opentracing/opentracing-go/mocktracer"
-	"github.com/opentracing/opentracing-go"
 )
 
 type ConnectionSuite struct{}
@@ -52,7 +52,7 @@ func (s *ConnectionSuite) TestConnection_Query_Ok(c *test.C) {
 func (s *ConnectionSuite) TestConnection_Query_DefaultDBOk(c *test.C) {
 	ctx := context.Background()
 	token := int64(1)
-	q := testQuery(Table("table").Get("id"),)
+	q := testQuery(Table("table").Get("id"))
 	q2 := q
 	q2.Opts["db"], _ = DB("db").Build()
 	writeData := serializeQuery(token, q2)
@@ -134,7 +134,7 @@ func (s *ConnectionSuite) TestConnection_Query_NoReplyOk(c *test.C) {
 	connection := newConnection(conn, "addr", &ConnectOpts{})
 	connection.runConnection()
 	response, cursor, err := connection.Query(nil, q)
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	connection.Close()
 
 	c.Assert(response, test.IsNil)
@@ -247,9 +247,9 @@ func (s *ConnectionSuite) TestConnection_processResponses_SocketErr(c *test.C) {
 	connection.readRequestsChan <- tokenAndPromise{query: &Query{Token: 1}, promise: promise1}
 	connection.readRequestsChan <- tokenAndPromise{query: &Query{Token: 2}, promise: promise2}
 	connection.readRequestsChan <- tokenAndPromise{query: &Query{Token: 2}, promise: promise3}
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	connection.responseChan <- responseAndError{err: io.EOF}
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 
 	select {
 	case f := <-promise1:
@@ -284,9 +284,9 @@ func (s *ConnectionSuite) TestConnection_processResponses_StopOk(c *test.C) {
 
 	connection.readRequestsChan <- tokenAndPromise{query: &Query{Token: 1}, promise: promise1}
 	close(connection.responseChan)
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	close(connection.stopReadChan)
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 
 	select {
 	case f := <-promise1:
@@ -299,7 +299,7 @@ func (s *ConnectionSuite) TestConnection_processResponses_StopOk(c *test.C) {
 
 func (s *ConnectionSuite) TestConnection_processResponses_ResponseFirst(c *test.C) {
 	promise1 := make(chan responseAndCursor, 1)
-	response1 := &Response{Token:1, Type: p.Response_RUNTIME_ERROR, ErrorType: p.Response_INTERNAL}
+	response1 := &Response{Token: 1, Type: p.Response_RUNTIME_ERROR, ErrorType: p.Response_INTERNAL}
 
 	conn := &connMock{}
 	conn.On("Close").Return(nil)
@@ -309,11 +309,11 @@ func (s *ConnectionSuite) TestConnection_processResponses_ResponseFirst(c *test.
 	go connection.processResponses()
 
 	connection.responseChan <- responseAndError{response: response1}
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	connection.readRequestsChan <- tokenAndPromise{query: &Query{Token: 1}, promise: promise1}
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	connection.Close()
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 
 	select {
 	case f := <-promise1:
@@ -437,8 +437,8 @@ func (s *ConnectionSuite) TestConnection_processResponse_FirstPartialOk(c *test.
 	ctx := context.Background()
 	token := int64(3)
 	q := Query{Token: token}
-	rawResponse1 := json.RawMessage{1,2,3}
-	rawResponse2 := json.RawMessage{3,4,5}
+	rawResponse1 := json.RawMessage{1, 2, 3}
+	rawResponse2 := json.RawMessage{3, 4, 5}
 	response := &Response{Token: token, Type: p.Response_SUCCESS_PARTIAL, Responses: []json.RawMessage{rawResponse1, rawResponse2}}
 
 	connection := newConnection(nil, "addr", &ConnectOpts{})
@@ -463,8 +463,8 @@ func (s *ConnectionSuite) TestConnection_processResponse_PartialOk(c *test.C) {
 	token := int64(3)
 	term := Table("test")
 	q := Query{Token: token}
-	rawResponse1 := json.RawMessage{1,2,3}
-	rawResponse2 := json.RawMessage{3,4,5}
+	rawResponse1 := json.RawMessage{1, 2, 3}
+	rawResponse2 := json.RawMessage{3, 4, 5}
 	response := &Response{Token: token, Type: p.Response_SUCCESS_PARTIAL, Responses: []json.RawMessage{rawResponse1, rawResponse2}}
 
 	connection := newConnection(nil, "addr", &ConnectOpts{})
@@ -491,8 +491,8 @@ func (s *ConnectionSuite) TestConnection_processResponse_SequenceOk(c *test.C) {
 
 	token := int64(3)
 	q := Query{Token: token}
-	rawResponse1 := json.RawMessage{1,2,3}
-	rawResponse2 := json.RawMessage{3,4,5}
+	rawResponse1 := json.RawMessage{1, 2, 3}
+	rawResponse2 := json.RawMessage{3, 4, 5}
 	response := &Response{Token: token, Type: p.Response_SUCCESS_SEQUENCE, Responses: []json.RawMessage{rawResponse1, rawResponse2}}
 
 	connection := newConnection(nil, "addr", &ConnectOpts{})

--- a/cursor.go
+++ b/cursor.go
@@ -7,10 +7,10 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"gopkg.in/gorethink/gorethink.v4/encoding"
 	p "gopkg.in/gorethink/gorethink.v4/ql2"
-	"github.com/opentracing/opentracing-go"
 )
 
 var (

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 )
 
-type encoderFunc func(v reflect.Value) interface{}
+type encoderFunc func(v reflect.Value) (interface{}, error)
 
 // Encode returns the encoded value of v.
 //
@@ -30,10 +30,10 @@ func Encode(v interface{}) (ev interface{}, err error) {
 		}
 	}()
 
-	return encode(reflect.ValueOf(v)), nil
+	return encode(reflect.ValueOf(v))
 }
 
-func encode(v reflect.Value) interface{} {
+func encode(v reflect.Value) (interface{}, error) {
 	return valueEncoder(v)(v)
 }
 
@@ -65,7 +65,7 @@ func typeEncoder(t reflect.Type) encoderFunc {
 	encoderCache.Lock()
 	var wg sync.WaitGroup
 	wg.Add(1)
-	encoderCache.m[t] = func(v reflect.Value) interface{} {
+	encoderCache.m[t] = func(v reflect.Value) (interface{}, error) {
 		wg.Wait()
 		return f(v)
 	}

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -80,10 +80,3 @@ func typeEncoder(t reflect.Type) encoderFunc {
 	encoderCache.Unlock()
 	return f
 }
-
-// IgnoreType causes the encoder to ignore a type when encoding
-func IgnoreType(t reflect.Type) {
-	encoderCache.Lock()
-	encoderCache.m[t] = doNothingEncoder
-	encoderCache.Unlock()
-}

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -436,7 +436,7 @@ func TestEncodeCustomTypeEncodingValue(t *testing.T) {
 	}
 
 	SetTypeEncoding(reflect.TypeOf(innerType{}),
-		func (v interface{}) interface{}{
+		func(v interface{}) interface{} {
 			return map[string]interface{}{"someval": v.(innerType).Val}
 		}, nil)
 
@@ -464,7 +464,7 @@ func TestEncodeCustomTypeEncodingPointer(t *testing.T) {
 	}
 
 	SetTypeEncoding(reflect.TypeOf((*innerType)(nil)),
-		func (v interface{}) interface{}{
+		func(v interface{}) interface{} {
 			return map[string]interface{}{"someval": v.(*innerType).Val}
 		}, nil)
 
@@ -488,7 +488,7 @@ func TestEncodeCustomRootTypeEncodingValue(t *testing.T) {
 	}
 
 	SetTypeEncoding(reflect.TypeOf(cType{}),
-		func (v interface{}) interface{}{
+		func(v interface{}) interface{} {
 			return map[string]interface{}{"someval": v.(cType).Val}
 		}, nil)
 
@@ -512,7 +512,7 @@ func TestEncodeCustomRootTypeEncodingPointer(t *testing.T) {
 	}
 
 	SetTypeEncoding(reflect.TypeOf((*cType)(nil)),
-		func (v interface{}) interface{}{
+		func(v interface{}) interface{} {
 			return map[string]interface{}{"someval": v.(*cType).Val}
 		}, nil)
 

--- a/encoding/encoder_test.go
+++ b/encoding/encoder_test.go
@@ -420,3 +420,107 @@ func TestEncodeNilSlice(t *testing.T) {
 		t.Errorf("got %q, want %q", out, want)
 	}
 }
+
+func TestEncodeCustomTypeEncodingValue(t *testing.T) {
+	type innerType struct {
+		Val int
+	}
+
+	outer := struct {
+		Inner innerType `gorethink:"inner"`
+	}{Inner: innerType{Val: 5}}
+	want := map[string]interface{}{
+		"inner": map[string]interface{}{
+			"someval": 5,
+		},
+	}
+
+	SetTypeEncoding(reflect.TypeOf(innerType{}),
+		func (v interface{}) interface{}{
+			return map[string]interface{}{"someval": v.(innerType).Val}
+		}, nil)
+
+	out, err := Encode(outer)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestEncodeCustomTypeEncodingPointer(t *testing.T) {
+	type innerType struct {
+		Val int
+	}
+
+	outer := struct {
+		Inner *innerType `gorethink:"inner"`
+	}{Inner: &innerType{Val: 5}}
+	want := map[string]interface{}{
+		"inner": map[string]interface{}{
+			"someval": 5,
+		},
+	}
+
+	SetTypeEncoding(reflect.TypeOf((*innerType)(nil)),
+		func (v interface{}) interface{}{
+			return map[string]interface{}{"someval": v.(*innerType).Val}
+		}, nil)
+
+	out, err := Encode(outer)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestEncodeCustomRootTypeEncodingValue(t *testing.T) {
+	type cType struct {
+		Val int
+	}
+	in := cType{Val: 5}
+
+	want := map[string]interface{}{
+		"someval": 5,
+	}
+
+	SetTypeEncoding(reflect.TypeOf(cType{}),
+		func (v interface{}) interface{}{
+			return map[string]interface{}{"someval": v.(cType).Val}
+		}, nil)
+
+	out, err := Encode(in)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+func TestEncodeCustomRootTypeEncodingPointer(t *testing.T) {
+	type cType struct {
+		Val int
+	}
+	in := cType{Val: 5}
+
+	want := map[string]interface{}{
+		"someval": 5,
+	}
+
+	SetTypeEncoding(reflect.TypeOf((*cType)(nil)),
+		func (v interface{}) interface{}{
+			return map[string]interface{}{"someval": v.(*cType).Val}
+		}, nil)
+
+	out, err := Encode(&in)
+	if err != nil {
+		t.Errorf("got error %v, expected nil", err)
+	}
+	if !jsonEqual(out, want) {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -43,11 +43,11 @@ func IgnoreType(t reflect.Type) {
 
 func SetTypeEncoding(
 	t reflect.Type,
-	encode func(value interface{}) interface{},
+	encode func(value interface{}) (interface{}, error),
 	decode func(encoded interface{}, value reflect.Value) error,
 ) {
 	encoderCache.Lock()
-	encoderCache.m[t] = func(v reflect.Value) interface{} {
+	encoderCache.m[t] = func(v reflect.Value) (interface{}, error) {
 		return encode(v.Interface())
 	}
 	encoderCache.Unlock()

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -14,7 +14,7 @@ var (
 	unmarshalerType = reflect.TypeOf(new(Unmarshaler)).Elem()
 
 	emptyInterfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
-	mapInterfaceType = reflect.TypeOf((map[string]interface{})(nil))
+	mapInterfaceType   = reflect.TypeOf((map[string]interface{})(nil))
 )
 
 // Marshaler is the interface implemented by objects that

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -12,16 +12,19 @@ var (
 
 	marshalerType   = reflect.TypeOf(new(Marshaler)).Elem()
 	unmarshalerType = reflect.TypeOf(new(Unmarshaler)).Elem()
+
+	emptyInterfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
+	mapInterfaceType = reflect.TypeOf((map[string]interface{})(nil))
 )
 
 // Marshaler is the interface implemented by objects that
-// can marshal themselves into a valid RQL psuedo-type.
+// can marshal themselves into a valid RQL pseudo-type.
 type Marshaler interface {
 	MarshalRQL() (interface{}, error)
 }
 
 // Unmarshaler is the interface implemented by objects
-// that can unmarshal a psuedo-type object of themselves.
+// that can unmarshal a pseudo-type object of themselves.
 type Unmarshaler interface {
 	UnmarshalRQL(interface{}) error
 }
@@ -29,4 +32,38 @@ type Unmarshaler interface {
 func init() {
 	encoderCache.m = make(map[reflect.Type]encoderFunc)
 	decoderCache.m = make(map[decoderCacheKey]decoderFunc)
+}
+
+// IgnoreType causes the encoder to ignore a type when encoding
+func IgnoreType(t reflect.Type) {
+	encoderCache.Lock()
+	encoderCache.m[t] = doNothingEncoder
+	encoderCache.Unlock()
+}
+
+func SetTypeEncoding(
+	t reflect.Type,
+	encode func(value interface{}) interface{},
+	decode func(encoded interface{}, value reflect.Value) error,
+) {
+	encoderCache.Lock()
+	encoderCache.m[t] = func(v reflect.Value) interface{} {
+		return encode(v.Interface())
+	}
+	encoderCache.Unlock()
+
+	dec := func(dv reflect.Value, sv reflect.Value) error {
+		return decode(sv.Interface(), dv)
+	}
+	decoderCache.Lock()
+	// decode as pointer
+	decoderCache.m[decoderCacheKey{dt: t, st: emptyInterfaceType}] = dec
+	// decode as value
+	decoderCache.m[decoderCacheKey{dt: t, st: mapInterfaceType}] = dec
+
+	if t.Kind() == reflect.Ptr {
+		decoderCache.m[decoderCacheKey{dt: t.Elem(), st: emptyInterfaceType}] = dec
+		decoderCache.m[decoderCacheKey{dt: t.Elem(), st: mapInterfaceType}] = dec
+	}
+	decoderCache.Unlock()
 }

--- a/encoding/errors.go
+++ b/encoding/errors.go
@@ -42,7 +42,6 @@ func (e *DecodeTypeError) Error() string {
 		return "gorethink: could not decode type " + e.SrcType.String() + " into Go value of type " + e.DestType.String() + ": " + e.Reason
 	} else {
 		return "gorethink: could not decode type " + e.SrcType.String() + " into Go value of type " + e.DestType.String()
-
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,19 @@
+module gopkg.in/gorethink/gorethink.v4
+
+require (
+	github.com/cenkalti/backoff v2.0.0+incompatible
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.2.0
+	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.0.2
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.0.6
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac
+	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
+	golang.org/x/sys v0.0.0-20180828065106-d99a578cf41b // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+	gopkg.in/fatih/pool.v2 v2.0.0
+)

--- a/internal/integration/tests/benchmarks_test.go
+++ b/internal/integration/tests/benchmarks_test.go
@@ -1,12 +1,12 @@
 package tests
 
 import (
+	r "gopkg.in/gorethink/gorethink.v4"
 	"math/rand"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
-	r "gopkg.in/gorethink/gorethink.v4"
 )
 
 func BenchmarkBatch200RandomWrites(b *testing.B) {

--- a/internal/integration/tests/cluster_integration_test.go
+++ b/internal/integration/tests/cluster_integration_test.go
@@ -8,8 +8,8 @@ import (
 
 	test "gopkg.in/check.v1"
 	r "gopkg.in/gorethink/gorethink.v4"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 func (s *RethinkSuite) TestClusterDetectNewNode(c *test.C) {

--- a/internal/integration/tests/testdata_test.go
+++ b/internal/integration/tests/testdata_test.go
@@ -1,6 +1,8 @@
 package tests
 
-import (r "gopkg.in/gorethink/gorethink.v4")
+import (
+	r "gopkg.in/gorethink/gorethink.v4"
+)
 
 func setupTestData() {
 	if *testdata {

--- a/mock_test.go
+++ b/mock_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	test "gopkg.in/check.v1"
-	"testing"
 	"gopkg.in/gorethink/gorethink.v4/internal/integration/tests"
+	"testing"
 )
 
 // Hook up gocheck into the gotest runner.

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -2,15 +2,15 @@ package gorethink
 
 import (
 	"github.com/stretchr/testify/mock"
-	"time"
 	"net"
+	"time"
 )
 
 type connMock struct {
 	mock.Mock
 }
 
-func (m* connMock) Read(b []byte) (n int, err error) {
+func (m *connMock) Read(b []byte) (n int, err error) {
 	args := m.Called(len(b))
 	rbuf, ok := args.Get(0).([]byte)
 	if ok {
@@ -19,37 +19,37 @@ func (m* connMock) Read(b []byte) (n int, err error) {
 	return args.Int(1), args.Error(2)
 }
 
-func (m* connMock) Write(b []byte) (n int, err error) {
+func (m *connMock) Write(b []byte) (n int, err error) {
 	args := m.Called(b)
 	return args.Int(0), args.Error(1)
 }
 
-func (m* connMock) Close() error {
+func (m *connMock) Close() error {
 	args := m.Called()
 	return args.Error(0)
 }
 
-func (m* connMock) LocalAddr() net.Addr {
+func (m *connMock) LocalAddr() net.Addr {
 	args := m.Called()
 	return args.Get(0).(net.Addr)
 }
 
-func (m* connMock) RemoteAddr() net.Addr {
+func (m *connMock) RemoteAddr() net.Addr {
 	args := m.Called()
 	return args.Get(0).(net.Addr)
 }
 
-func (m* connMock) SetDeadline(t time.Time) error {
+func (m *connMock) SetDeadline(t time.Time) error {
 	args := m.Called()
 	return args.Error(0)
 }
 
-func (m* connMock) SetReadDeadline(t time.Time) error {
+func (m *connMock) SetReadDeadline(t time.Time) error {
 	args := m.Called()
 	return args.Error(0)
 }
 
-func (m* connMock) SetWriteDeadline(t time.Time) error {
+func (m *connMock) SetWriteDeadline(t time.Time) error {
 	args := m.Called()
 	return args.Error(0)
 }


### PR DESCRIPTION
For case if you can't define `MarshalRQL` methods on structs.