### PR TITLE
fix noreply memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## v5.0.1 - 2018-10-18
+
+- Fix noreply queries memory leak due unnecessary for responses
+
 ## v5.0.0 - 2018-09-12
 
 - Moved to rethinkdb organization

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![RethinkDB-go Logo](https://raw.github.com/wiki/rethinkdb/rethinkdb-go/gopher-and-thinker-s.png "Golang Gopher and RethinkDB Thinker")
 
-Current version: v5.0.0 (RethinkDB v2.3)
+Current version: v5.0.1 (RethinkDB v2.3)
 
 Please note that this version of the driver only supports versions of RethinkDB using the v0.4 protocol (any versions of the driver older than RethinkDB 2.0 will not work).
 

--- a/connection.go
+++ b/connection.go
@@ -209,12 +209,7 @@ func (c *Connection) Query(ctx context.Context, q Query) (*Response, *Cursor, er
 	}
 
 	if noreply, ok := q.Opts["noreply"]; ok && noreply.(bool) {
-		select {
-		case c.readRequestsChan <- tokenAndPromise{ctx: ctx, query: &q, span: fetchingSpan}:
-			return nil, nil, nil
-		case <-ctx.Done():
-			return c.stopQuery(&q)
-		}
+		return nil, nil, nil
 	}
 
 	promise := make(chan responseAndCursor, 1)


### PR DESCRIPTION
closes #451 
If noreply option is specified, it isn't needed to wait for any reply from server even asynchronously. It was a memory leak storing `Term`'s in waiting for replies.