### PR TITLE
Add ability to block cursors when testing with mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Current version: v5.0.1 (RethinkDB v2.3)
 
 Please note that this version of the driver only supports versions of RethinkDB using the v0.4 protocol (any versions of the driver older than RethinkDB 2.0 will not work).
 
-If you need any help you can find me on the [RethinkDB slack](http://slack.rethinkdb.com/) in the #gorethink channel.
+If you need any help you can find me on the [RethinkDB slack](https://rethinkdb.slack.com/) in the #gorethink channel.
 
 ## Installation
 

--- a/cursor.go
+++ b/cursor.go
@@ -208,6 +208,13 @@ func (c *Cursor) Next(dest interface{}) bool {
 	return hasMore
 }
 
+// This can be used for testing.  Typically the function would block to simulate
+// network lag and test concurrency.
+type delayedData struct {
+	f    func() interface{} // This function produces the data
+	data interface{}        // This is initially nil, then equal to f()
+}
+
 func (c *Cursor) nextLocked(dest interface{}, progressCursor bool) (bool, error) {
 	for {
 		if err := c.seekCursor(true); err != nil {
@@ -227,7 +234,17 @@ func (c *Cursor) nextLocked(dest interface{}, progressCursor bool) (bool, error)
 			if progressCursor {
 				c.buffer = c.buffer[1:]
 			}
+			if dd, ok := data.(delayedData); ok {
+				if dd.data == nil {
 
+					// Here we remove the lock as in c.fetchMore() because the
+					// function is likely to block.
+					c.mu.Unlock()
+					dd.data = dd.f()
+					c.mu.Lock()
+				}
+				data = dd.data
+			}
 			err := encoding.Decode(dest, data)
 			if err != nil {
 				return false, err
@@ -494,7 +511,6 @@ func (c *Cursor) Listen(channel interface{}) {
 			if !c.Next(elemp.Interface()) {
 				break
 			}
-
 			channelv.Send(elemp.Elem())
 		}
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -368,27 +368,3 @@ func (t *simpleTestingT) FailNow() {
 func (t *simpleTestingT) Failed() bool {
 	return t.failed
 }
-
-func TestSomething(t *testing.T) {
-	mock := NewMock()
-	ch := make(chan interface{})
-	mock.On(Table("people")).Return([]interface{}{ch, ch}, nil)
-	go func() {
-		ch <- map[string]interface{}{"id": 1, "name": "John Smith"}
-		ch <- map[string]interface{}{"id": 2, "name": "Jane Smith"}
-	}()
-	cursor, err := Table("people").Run(mock)
-	if err != nil {
-		t.Errorf("err is: %v", err)
-	}
-
-	var rows []interface{}
-	err = cursor.All(&rows)
-	if err != nil {
-		t.Errorf("err is: %v", err)
-	}
-
-	// Test result of rows
-
-	mock.AssertExpectations(t)
-}

--- a/mock_test.go
+++ b/mock_test.go
@@ -3,9 +3,10 @@ package rethinkdb
 import (
 	"fmt"
 
+	"testing"
+
 	test "gopkg.in/check.v1"
 	"gopkg.in/rethinkdb/rethinkdb-go.v5/internal/integration/tests"
-	"testing"
 )
 
 // Hook up gocheck into the gotest runner.
@@ -74,6 +75,48 @@ func (s *MockSuite) TestMockRunSuccessMultipleResults(c *test.C) {
 
 	c.Assert(err, test.IsNil)
 	c.Assert(response, tests.JsonEquals, []interface{}{map[string]interface{}{"id": "mocked"}})
+	mock.AssertExpectations(c)
+
+	res.Close()
+}
+
+func (s *MockSuite) TestMockRunSuccessChannel(c *test.C) {
+	mock := NewMock()
+	ch := make(chan interface{})
+	mock.On(DB("test").Table("test")).Return([]interface{}{ch, ch}, nil)
+	go func() {
+		ch <- 1
+		ch <- 2
+	}()
+	res, err := DB("test").Table("test").Run(mock)
+	c.Assert(err, test.IsNil)
+
+	var response []interface{}
+	err = res.All(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, tests.JsonEquals, []interface{}{1, 2})
+	mock.AssertExpectations(c)
+
+	res.Close()
+}
+
+func (s *MockSuite) TestMockRunSuccessFunction(c *test.C) {
+	mock := NewMock()
+	n := 0
+	f := func() interface{} {
+		n++
+		return n
+	}
+	mock.On(DB("test").Table("test")).Return([]interface{}{f, f, 3}, nil)
+	res, err := DB("test").Table("test").Run(mock)
+	c.Assert(err, test.IsNil)
+
+	var response []interface{}
+	err = res.All(&response)
+
+	c.Assert(err, test.IsNil)
+	c.Assert(response, tests.JsonEquals, []interface{}{1, 2, 3})
 	mock.AssertExpectations(c)
 
 	res.Close()
@@ -324,4 +367,28 @@ func (t *simpleTestingT) FailNow() {
 }
 func (t *simpleTestingT) Failed() bool {
 	return t.failed
+}
+
+func TestSomething(t *testing.T) {
+	mock := NewMock()
+	ch := make(chan interface{})
+	mock.On(Table("people")).Return([]interface{}{ch, ch}, nil)
+	go func() {
+		ch <- map[string]interface{}{"id": 1, "name": "John Smith"}
+		ch <- map[string]interface{}{"id": 2, "name": "Jane Smith"}
+	}()
+	cursor, err := Table("people").Run(mock)
+	if err != nil {
+		t.Errorf("err is: %v", err)
+	}
+
+	var rows []interface{}
+	err = cursor.All(&rows)
+	if err != nil {
+		t.Errorf("err is: %v", err)
+	}
+
+	// Test result of rows
+
+	mock.AssertExpectations(t)
 }

--- a/query_control.go
+++ b/query_control.go
@@ -223,8 +223,8 @@ func Error(args ...interface{}) Term {
 	return constructRootTerm("Error", p.Term_ERROR, args, map[string]interface{}{})
 }
 
-// Args is a special term usd to splice an array of arguments into another term.
-// This is useful when you want to call a varadic term such as GetAll with a set
+// Args is a special term used to splice an array of arguments into another term.
+// This is useful when you want to call a variadic term such as GetAll with a set
 // of arguments provided at runtime.
 func Args(args ...interface{}) Term {
 	return constructRootTerm("Args", p.Term_ARGS, args, map[string]interface{}{})


### PR DESCRIPTION
If you want the cursor to block on some of the response values, you can pass in
a value of type `chan interface{}` to `MockQuery.Return()` and the cursor will block until a value is
available to read on the channel.  Or you can pass in a function with signature
`func() interface{}`: the cursor will call the function (which may block).  Here
is the example above adapted to use a channel.