### PR TITLE
Add float32 encoder

### DIFF
--- a/encoding/encoder_types.go
+++ b/encoding/encoder_types.go
@@ -33,7 +33,9 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 		return intEncoder
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return uintEncoder
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float32:
+		return float32Encoder
+	case reflect.Float64:
 		return floatEncoder
 	case reflect.String:
 		return stringEncoder
@@ -113,6 +115,10 @@ func uintEncoder(v reflect.Value) (interface{}, error) {
 
 func floatEncoder(v reflect.Value) (interface{}, error) {
 	return v.Float(), nil
+}
+
+func float32Encoder(v reflect.Value) (interface{}, error) {
+	return float32(v.Float()), nil
 }
 
 func stringEncoder(v reflect.Value) (interface{}, error) {


### PR DESCRIPTION
Currently float32 and float64 use the same encoder.  This ends up calling the reflect.Value.Float(https://golang.org/pkg/reflect/#Value.Float) which essentially converts it to a float64, increasing the precision and creating non-zero trailing values at the end of the value when examining the database. Functionally that does not cause any problems (encoding as float64) since when it is read and serialized back into a struct, it then gets converted back to a float32 and drops the extra precision values, however when examining the database it seems like invalid values. Here's a simple go playground to show the issue with precision:
https://play.golang.org/p/E4wb66bWHi0