### PR TITLE
Verify the Pool connection is not nil before attempting to close it

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -86,9 +86,11 @@ func (p *Pool) Close() error {
 	p.closed = poolIsClosed
 
 	for _, c := range p.conns {
-		err := c.Close()
-		if err != nil {
-			return err
+		if c != nil {
+			err := c.Close()
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This checks to make sure the Pool's connection is not nil before attempting to close it (previously it was not checking so could get a panic for a nil deference.  If looking at the Pool connection initialization code in `pool.go`:

```
// NewPool creates a new connection pool for the given host
func NewPool(host Host, opts *ConnectOpts) (*Pool, error) {
	initialCap := opts.InitialCap
	if initialCap <= 0 {
		// Fallback to MaxIdle if InitialCap is zero, this should be removed
		// when MaxIdle is removed
		initialCap = opts.MaxIdle
	}

	maxOpen := opts.MaxOpen
	if maxOpen <= 0 {
		maxOpen = 1
	}

	conns := make([]*Connection, maxOpen)
	var err error
	for i := 0; i < opts.InitialCap; i++ {
		conns[i], err = NewConnection(host.String(), opts)
		if err != nil {
			return nil, err
		}
	}

	return &Pool{
		conns:   conns,
		pointer: -1,
		host:    host,
		opts:    opts,
		closed:  poolIsNotClosed,
	}, nil
}
```

It can be seen that if the opts.InitialCap < opts.MaxOpen, then we allocate a connection slice of size `opts.MaxOpen` where only `opts.InitialCap` are initially initialized.  If we then close it later, it will cause the panic referred to above (can see stack trace in issue).


Addresses: #479 