### PR TITLE
Added helper func to check if err is PK too long error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -190,3 +190,13 @@ func IsTypeErr(err error) bool {
 
 	return strings.HasPrefix(err.Error(), "Expected type")
 }
+
+// IsPKTooLongErr returns true if the error is non-nil and the
+// query failed due to PK too long error.
+func IsPKTooLongErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.HasPrefix(err.Error(), "Primary key too long (max 127 characters)")
+}


### PR DESCRIPTION
Signed-off-by: Wahab Ali <wahabalimk@gmail.com>

**Reason for the change**
Ease of use for users consuming go-rethink API.

**Description**
This PR adds a helper function that checks if error returned by RethinkDB is a Primary Key too long error. RethinkDB has a unique limitation on length of PK, so I think having this helper useful for consumers of go-rethink API, especially if they are new to RethinkDB.

**Code examples**
N/A

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
N/A
