### PR TITLE
Fix failing Travis CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ go:
 go_import_path: gopkg.in/rethinkdb/rethinkdb-go.v6
 
 before_script:
-  - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-  - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+  - source /etc/lsb-release && echo "deb https://download.rethinkdb.com/repository/ubuntu-$TRAVIS_DIST $TRAVIS_DIST main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+  - wget -qO- https://download.rethinkdb.com/repository/raw/pubkey.gpg | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install rethinkdb
   - rethinkdb > /dev/null 2>&1 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ go:
 
 go_import_path: gopkg.in/rethinkdb/rethinkdb-go.v6
 
-install: go get -t ./...
-
 before_script:
   - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
   - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
@@ -20,6 +18,7 @@ before_script:
   - rethinkdb --port-offset 3 --directory rethinkdb_data3 --join localhost:29016 > /dev/null 2>&1 &
 
 script:
-  - go test -race .
-  - go test -tags='cluster' -short -race -v ./...
-  - GOMODULE111=off go test .
+  - GO111MODULE=on go test -race .
+  - GO111MODULE=on go test -tags='cluster' -short -race -v ./...
+  - GO111MODULE=on go test .
+

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
-go 1.14
+go 1.12
+


### PR DESCRIPTION
**Reason for the change**
Travis CI builds were working last year, but as of a few months ago they no longer work.

**Description**
The Go 1.12 build was failing because Travis clones the source code under GOPATH and uses GOMODULE111=auto by default. GOMODULE111=on is necessary for 1.12 and is of no consequence for the more recent versions of Go.

Also, the old apt Rethink package was removed for some reason. The binary releases for Ubuntu are still available, so these are now used because Travis builds within Ubuntu.

**Code examples**

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
