### PR TITLE
Make it easier for new contributors to regenerate the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Folders
 _obj
 _test
+__pycache__
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ go:
 
 go_import_path: gopkg.in/rethinkdb/rethinkdb-go.v6
 
-install: go get -t ./...
-
 before_script:
-  - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-  - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+  - source /etc/lsb-release && echo "deb https://download.rethinkdb.com/repository/ubuntu-$TRAVIS_DIST $TRAVIS_DIST main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+  - wget -qO- https://download.rethinkdb.com/repository/raw/pubkey.gpg | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install rethinkdb
   - rethinkdb > /dev/null 2>&1 &
@@ -20,6 +18,7 @@ before_script:
   - rethinkdb --port-offset 3 --directory rethinkdb_data3 --join localhost:29016 > /dev/null 2>&1 &
 
 script:
-  - go test -race .
-  - go test -tags='cluster' -short -race -v ./...
-  - GOMODULE111=off go test .
+  - GO111MODULE=on go test -race .
+  - GO111MODULE=on go test -tags='cluster' -short -race -v ./...
+  - GO111MODULE=on go test .
+

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,7 @@ integration:
 
 benchpool:
 	go test -v -cpu 1,2,4,8,16,24,32,64,128,256 -bench=BenchmarkConnectionPool -run ^$ ./internal/integration/tests/
+
+generate:
+	go generate ./internal/...
+

--- a/internal/gen_tests/gen_tests.sh
+++ b/internal/gen_tests/gen_tests.sh
@@ -2,13 +2,15 @@
 
 set -e
 
-if [[ $REQL_TEST_DIR == "" ]]
+if [[ ! -d $REQL_TEST_DIR ]]
 then
-    echo "\$REQL_TEST_DIR must be specified"
+    echo "REQL_TEST_DIR must be set to the local copy of the https://github.com/rethinkdb/rethinkdb/tree/next/test/rql_test/src/ directory."
     exit 1
 fi
 
-../gen_tests/gen_tests.py --test-dir=$REQL_TEST_DIR
+SCRIPT_DIR=$(dirname "$0")
+
+$SCRIPT_DIR/gen_tests.py --test-dir=$REQL_TEST_DIR
 
 goimports -w . > /dev/null
 

--- a/internal/integration/reql_tests/gorethink_test.go
+++ b/internal/integration/reql_tests/gorethink_test.go
@@ -1,4 +1,4 @@
-//go:generate ../gen_tests/gen_tests.sh
+//go:generate ../../gen_tests/gen_tests.sh
 
 package reql_tests
 


### PR DESCRIPTION
`make generate` will now regenerate the ReQL test code.  If the path to the Rethink working directory isn't set, it will now give the developer more explanation what to do.

**Reason for the change**
I wanted to regenerate the tests but it wasn't clear from the code why it wouldn't work. For a long time I figured the main developers had generated the tests from YAML files they hadn't committed, and since then the tests had been updated by hand. I finally found the solution in this comment: https://github.com/rethinkdb/rethinkdb-go/issues/343#issuecomment-238709800

**Description**
There is now a Make recipe `generate` that runs `go generate`. By itself this isn't much improvement, since the command that's run is quite simple, but it serves as "code as documentation" in a place developers would naturally look.

Also, the error that's printed when `REQL_TEST_DIR` isn't set now refers to the Rethink GitHub repository where the test YAML files are kept.

Note: this includes the `.travis.yml` fix from #494.

**Code examples**

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
