### PR TITLE
Make Pool safe for use by multiple goroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ go:
 
 go_import_path: gopkg.in/rethinkdb/rethinkdb-go.v6
 
-install: go get -t ./...
-
 before_script:
-  - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-  - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+  - source /etc/lsb-release && echo "deb https://download.rethinkdb.com/repository/ubuntu-$TRAVIS_DIST $TRAVIS_DIST main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+  - wget -qO- https://download.rethinkdb.com/repository/raw/pubkey.gpg | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install rethinkdb
   - rethinkdb > /dev/null 2>&1 &
@@ -20,6 +18,7 @@ before_script:
   - rethinkdb --port-offset 3 --directory rethinkdb_data3 --join localhost:29016 > /dev/null 2>&1 &
 
 script:
-  - go test -race .
-  - go test -tags='cluster' -short -race -v ./...
-  - GOMODULE111=off go test .
+  - GO111MODULE=on go test -race .
+  - GO111MODULE=on go test -tags='cluster' -short -race -v ./...
+  - GO111MODULE=on go test .
+

--- a/cluster.go
+++ b/cluster.go
@@ -78,7 +78,8 @@ func (c *Cluster) run() error {
 	return nil
 }
 
-// Query executes a ReQL query using the cluster to connect to the database
+// Query executes a ReQL query using the cluster to connect to the database.
+// The returned cursor should be closed (either directly or indirectly) when it is no longer needed.
 func (c *Cluster) Query(ctx context.Context, q Query) (cursor *Cursor, err error) {
 	for i := 0; i < c.numRetries(); i++ {
 		var node *Node

--- a/cluster.go
+++ b/cluster.go
@@ -46,11 +46,13 @@ type Cluster struct {
 // NewCluster creates a new cluster by connecting to the given hosts.
 func NewCluster(hosts []Host, opts *ConnectOpts) (*Cluster, error) {
 	c := &Cluster{
-		hp:          newHostPool(opts),
-		seeds:       hosts,
-		opts:        opts,
-		closed:      clusterWorking,
-		connFactory: NewConnection,
+		hp:     newHostPool(opts),
+		seeds:  hosts,
+		opts:   opts,
+		closed: clusterWorking,
+		connFactory: func(host string, opts *ConnectOpts) (connection, error) {
+			return NewConnection(host, opts)
+		},
 	}
 
 	err := c.run()

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -5,13 +5,14 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"time"
+
 	"github.com/stretchr/testify/mock"
 	test "gopkg.in/check.v1"
 	"gopkg.in/rethinkdb/rethinkdb-go.v6/encoding"
 	p "gopkg.in/rethinkdb/rethinkdb-go.v6/ql2"
-	"io"
-	"net"
-	"time"
 )
 
 type ClusterSuite struct{}
@@ -360,20 +361,20 @@ type mockDial struct {
 }
 
 func mockedConnectionFactory(dial *mockDial) connFactory {
-	return func(host string, opts *ConnectOpts) (connection *Connection, err error) {
+	return func(host string, opts *ConnectOpts) (connection, error) {
 		args := dial.MethodCalled("Dial", host)
-		err = args.Error(1)
+		err := args.Error(1)
 		if err != nil {
 			return nil, err
 		}
 
-		connection = newConnection(args.Get(0).(net.Conn), host, opts)
-		done := runConnection(connection)
+		conn := newConnection(args.Get(0).(net.Conn), host, opts)
+		done := runConnection(conn)
 
 		m := args.Get(0).(*connMock)
 		m.setDone(done)
 
-		return connection, nil
+		return conn, nil
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -1,21 +1,21 @@
 package rethinkdb
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
-	"bytes"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	p "gopkg.in/rethinkdb/rethinkdb-go.v6/ql2"
-	"sync"
 )
 
 const (
@@ -60,6 +60,8 @@ type Connection struct {
 	stopProcessingChan chan struct{}
 	mu                 sync.Mutex
 }
+
+type connFactory func(host string, opts *ConnectOpts) (*Connection, error)
 
 type responseAndError struct {
 	response *Response

--- a/connection.go
+++ b/connection.go
@@ -61,7 +61,15 @@ type Connection struct {
 	mu                 sync.Mutex
 }
 
-type connFactory func(host string, opts *ConnectOpts) (*Connection, error)
+type connection interface {
+	Server() (ServerResponse, error)
+	Query(context.Context, Query) (*Response, *Cursor, error)
+	Close() error
+	isBad() bool
+	isClosed() bool
+}
+
+type connFactory func(host string, opts *ConnectOpts) (connection, error)
 
 type responseAndError struct {
 	response *Response

--- a/cursor.go
+++ b/cursor.go
@@ -61,7 +61,7 @@ func newCursor(ctx context.Context, conn *Connection, cursorType string, token i
 type Cursor struct {
 	releaseConn func() error
 
-	conn       *Connection
+	conn       connection
 	connOpts   *ConnectOpts
 	token      int64
 	cursorType string

--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,13 @@ require (
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/silentred/gid v1.0.1
 	github.com/sirupsen/logrus v1.0.6
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/cenkalti/backoff.v2 v2.2.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
@@ -23,4 +25,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
-go 1.14
+go 1.12

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsq
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/silentred/gid v1.0.1 h1:yiTiT3hpcyOsAU+QyeDjHKAfHxRvayjml9PWxZI80tw=
+github.com/silentred/gid v1.0.1/go.mod h1:DMQPn66uY+3ed7rWfzOVET7VbDBAhjz+6AmmlixUK08=
 github.com/sirupsen/logrus v1.0.6 h1:hcP1GmhGigz/O7h1WVUM5KklBp1JoNS9FggWKdj/j3s=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -50,6 +52,7 @@ golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/integration/reql_tests/common.go
+++ b/internal/integration/reql_tests/common.go
@@ -53,6 +53,10 @@ func runAndAssert(suite suite.Suite, expected, v interface{}, session *r.Session
 	}
 
 	assertExpected(suite, expected, cursor, err)
+
+	if cursor != nil {
+		cursor.Close()
+	}
 }
 
 func fetchAndAssert(suite suite.Suite, expected, result interface{}, count int) {
@@ -81,6 +85,16 @@ func fetchAndAssert(suite suite.Suite, expected, result interface{}, count int) 
 	}
 
 	assertExpected(suite, expected, cursor, err)
+
+	if cursor != nil {
+		/* Cursors should ordinarily be closed when they are no longer needed, otherwise an application using
+		   multiple goroutines might hang waiting for a free connection in the pool.  However, some of the
+		   generated changefeed tests expect the cursor will return additional changes after fetchAndAssert()
+		   is called.  This means we must leave test cursors hanging open for these tests to pass.
+		*/
+
+		//cursor.Close()
+	}
 }
 
 func maybeLen(v interface{}) interface{} {

--- a/internal/integration/reql_tests/reql_changefeeds_edge_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_edge_test.go
@@ -53,6 +53,14 @@ func (suite *ChangefeedsEdgeSuite) TearDownSuite() {
 	suite.T().Log("Tearing down ChangefeedsEdgeSuite")
 
 	if suite.session != nil {
+		/* TearDownSuite() will block if a cursor is left open by a test, because:
+		     * the pool only contains one connection by default,
+		     * that connection can only be used by the goroutine that acquired it (until it's released), and
+			 * stretchr/testify/suite runs SetupTest() and TestCases() in a different goroutine than TearDownSuite().
+		*/
+		err := suite.session.Reconnect()
+		suite.Require().NoError(err, "Error returned when reconnecting to server")
+
 		r.DB("rethinkdb").Table("_debug_scratch").Delete().Exec(suite.session)
 		r.DB("db_feed_edge").TableDrop("table_test_changefeed_edge").Exec(suite.session)
 		r.DBDrop("db_feed_edge").Exec(suite.session)

--- a/internal/integration/reql_tests/reql_changefeeds_include_states_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_include_states_test.go
@@ -53,6 +53,14 @@ func (suite *ChangefeedsIncludeStatesSuite) TearDownSuite() {
 	suite.T().Log("Tearing down ChangefeedsIncludeStatesSuite")
 
 	if suite.session != nil {
+		/* TearDownSuite() will block if a cursor is left open by a test, because:
+		     * the pool only contains one connection by default,
+		     * that connection can only be used by the goroutine that acquired it (until it's released), and
+			 * stretchr/testify/suite runs SetupTest() and TestCases() in a different goroutine than TearDownSuite().
+		*/
+		err := suite.session.Reconnect()
+		suite.Require().NoError(err, "Error returned when reconnecting to server")
+
 		r.DB("rethinkdb").Table("_debug_scratch").Delete().Exec(suite.session)
 		r.DB("db_feed_include").TableDrop("table_test_changefeed_include").Exec(suite.session)
 		r.DBDrop("db_feed_include").Exec(suite.session)

--- a/internal/integration/reql_tests/reql_changefeeds_point_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_point_test.go
@@ -53,6 +53,14 @@ func (suite *ChangefeedsPointSuite) TearDownSuite() {
 	suite.T().Log("Tearing down ChangefeedsPointSuite")
 
 	if suite.session != nil {
+		/* TearDownSuite() will block if a cursor is left open by a test, because:
+		     * the pool only contains one connection by default,
+		     * that connection can only be used by the goroutine that acquired it (until it's released), and
+			 * stretchr/testify/suite runs SetupTest() and TestCases() in a different goroutine than TearDownSuite().
+		*/
+		err := suite.session.Reconnect()
+		suite.Require().NoError(err, "Error returned when reconnecting to server")
+
 		r.DB("rethinkdb").Table("_debug_scratch").Delete().Exec(suite.session)
 		r.DB("db_feed_point").TableDrop("table_test_changefeed_point").Exec(suite.session)
 		r.DBDrop("db_feed_point").Exec(suite.session)

--- a/internal/integration/reql_tests/reql_changefeeds_table_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_table_test.go
@@ -53,6 +53,14 @@ func (suite *ChangefeedsTableSuite) TearDownSuite() {
 	suite.T().Log("Tearing down ChangefeedsTableSuite")
 
 	if suite.session != nil {
+		/* TearDownSuite() will block if a cursor is left open by a test, because:
+		     * the pool only contains one connection by default,
+		     * that connection can only be used by the goroutine that acquired it (until it's released), and
+			 * stretchr/testify/suite runs SetupTest() and TestCases() in a different goroutine than TearDownSuite().
+		*/
+		err := suite.session.Reconnect()
+		suite.Require().NoError(err, "Error returned when reconnecting to server")
+
 		r.DB("rethinkdb").Table("_debug_scratch").Delete().Exec(suite.session)
 		r.DB("db_feed_table").TableDrop("table_test_changefeed_table").Exec(suite.session)
 		r.DBDrop("db_feed_table").Exec(suite.session)

--- a/internal/integration/reql_tests/template.go.tpl
+++ b/internal/integration/reql_tests/template.go.tpl
@@ -51,9 +51,17 @@ func (suite *${module_name}Suite) TearDownSuite() {
 	suite.T().Log("Tearing down ${module_name}Suite")
 
 	if suite.session != nil {
+		/* TearDownSuite() will block if a cursor is left open by a test, because:
+		     * the pool only contains one connection by default,
+		     * that connection can only be used by the goroutine that acquired it (until it's released), and
+			 * stretchr/testify/suite runs SetupTest() and TestCases() in a different goroutine than TearDownSuite().
+		*/
+		err := suite.session.Reconnect()
+		suite.Require().NoError(err, "Error returned when reconnecting to server")
+
 		r.DB("rethinkdb").Table("_debug_scratch").Delete().Exec(suite.session)
 		%for var_name in table_var_names:
-		 r.DB("test").TableDrop("${var_name}").Exec(suite.session)
+		r.DB("test").TableDrop("${var_name}").Exec(suite.session)
 		%endfor
 		r.DBDrop("test").Exec(suite.session)
 

--- a/internal/integration/tests/example_query_table_test.go
+++ b/internal/integration/tests/example_query_table_test.go
@@ -2,13 +2,14 @@ package tests
 
 import (
 	"fmt"
+
 	r "gopkg.in/rethinkdb/rethinkdb-go.v6"
 )
 
 // Create a table named "table" with the default settings.
 func ExampleTerm_TableCreate() {
 	// Setup database
-	r.DB("examples").TableDrop("table").Run(session)
+	r.DB("examples").TableDrop("table").Exec(session)
 
 	response, err := r.DB("examples").TableCreate("table").RunWrite(session)
 	if err != nil {
@@ -24,8 +25,8 @@ func ExampleTerm_TableCreate() {
 // Create a simple index based on the field name.
 func ExampleTerm_IndexCreate() {
 	// Setup database
-	r.DB("examples").TableDrop("table").Run(session)
-	r.DB("examples").TableCreate("table").Run(session)
+	r.DB("examples").TableDrop("table").Exec(session)
+	r.DB("examples").TableCreate("table").Exec(session)
 
 	response, err := r.DB("examples").Table("table").IndexCreate("name").RunWrite(session)
 	if err != nil {
@@ -41,8 +42,8 @@ func ExampleTerm_IndexCreate() {
 // Create a compound index based on the fields first_name and last_name.
 func ExampleTerm_IndexCreate_compound() {
 	// Setup database
-	r.DB("examples").TableDrop("table").Run(session)
-	r.DB("examples").TableCreate("table").Run(session)
+	r.DB("examples").TableDrop("table").Exec(session)
+	r.DB("examples").TableCreate("table").Exec(session)
 
 	response, err := r.DB("examples").Table("table").IndexCreateFunc("full_name", func(row r.Term) interface{} {
 		return []interface{}{row.Field("first_name"), row.Field("last_name")}

--- a/internal/integration/tests/query_test.go
+++ b/internal/integration/tests/query_test.go
@@ -485,6 +485,9 @@ func (s *RethinkSuite) TestTableChanges(c *test.C) {
 	wg.Wait()
 
 	c.Assert(n, test.Equals, 10)
+
+	err = res.Close()
+	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestTableChangesExit(c *test.C) {
@@ -599,6 +602,9 @@ func (s *RethinkSuite) TestTableChangesIncludeInitial(c *test.C) {
 	wg.Wait()
 
 	c.Assert(n, test.Equals, 10)
+
+	err = res.Close()
+	c.Assert(err, test.IsNil)
 }
 
 func (s *RethinkSuite) TestWriteReference(c *test.C) {
@@ -773,5 +779,6 @@ func (s *RethinkSuite) TestSelectManyRows(c *test.C) {
 	c.Assert(res.Err(), test.IsNil)
 	c.Assert(n, test.Equals, 10000)
 
-	res.Close()
+	err = res.Close()
+	c.Assert(err, test.IsNil)
 }

--- a/internal/integration/tests/rethinkdb_test.go
+++ b/internal/integration/tests/rethinkdb_test.go
@@ -75,12 +75,12 @@ func testBenchmarkSetup() {
 	r.DBDrop("benchmarks").Exec(session)
 	r.DBCreate("benchmarks").Exec(session)
 
-	r.DB("benchmarks").TableDrop("benchmarks").Run(session)
-	r.DB("benchmarks").TableCreate("benchmarks").Run(session)
+	r.DB("benchmarks").TableDrop("benchmarks").Exec(session)
+	r.DB("benchmarks").TableCreate("benchmarks").Exec(session)
 }
 
 func testBenchmarkTeardown() {
-	r.DBDrop("benchmarks").Run(session)
+	r.DBDrop("benchmarks").Exec(session)
 }
 
 func TestMain(m *testing.M) {
@@ -274,7 +274,7 @@ func (s *RethinkSuite) BenchmarkGet(c *test.C) {
 			"id": i,
 		})
 	}
-	r.DB("testb1").Table("TestManyBench1").Insert(data).Run(session)
+	r.DB("testb1").Table("TestManyBench1").Insert(data).Exec(session)
 
 	for i := 0; i < c.N; i++ {
 		n := rand.Intn(100)
@@ -310,7 +310,7 @@ func (s *RethinkSuite) BenchmarkGetStruct(c *test.C) {
 			}},
 		})
 	}
-	r.DB("testb2").Table("TestManyBench2").Insert(data).Run(session)
+	r.DB("testb2").Table("TestManyBench2").Insert(data).Exec(session)
 
 	for i := 0; i < c.N; i++ {
 		n := rand.Intn(100)
@@ -340,7 +340,7 @@ func (s *RethinkSuite) BenchmarkSelectMany(c *test.C) {
 			"id": i,
 		})
 	}
-	r.DB("testb3").Table("TestManyBench3").Insert(data).Run(session)
+	r.DB("testb3").Table("TestManyBench3").Insert(data).Exec(session)
 
 	for i := 0; i < c.N; i++ {
 		// Test query
@@ -373,7 +373,7 @@ func (s *RethinkSuite) BenchmarkSelectManyStruct(c *test.C) {
 			}},
 		})
 	}
-	r.DB("testb4").Table("TestManyBench4").Insert(data).Run(session)
+	r.DB("testb4").Table("TestManyBench4").Insert(data).Exec(session)
 
 	for i := 0; i < c.N; i++ {
 		// Test query

--- a/node.go
+++ b/node.go
@@ -87,7 +87,8 @@ func (n *Node) NoReplyWait() error {
 	})
 }
 
-// Query executes a ReQL query using this nodes connection pool.
+// Query executes a ReQL query using this node's connection pool.
+// The returned cursor should be closed (either directly or indirectly) when it is no longer needed.
 func (n *Node) Query(ctx context.Context, q Query) (cursor *Cursor, err error) {
 	if n.Closed() {
 		return nil, ErrInvalidNode

--- a/pool.go
+++ b/pool.go
@@ -42,7 +42,7 @@ type Pool struct {
 }
 
 type countedConn struct {
-	conn        *Connection
+	conn        connection
 	mu          int64
 	refCount    int64
 	goroutineID int64
@@ -50,7 +50,9 @@ type countedConn struct {
 
 // NewPool creates a new connection pool for the given host
 func NewPool(host Host, opts *ConnectOpts) (*Pool, error) {
-	return newPool(host, opts, NewConnection)
+	return newPool(host, opts, func(host string, opts *ConnectOpts) (connection, error) {
+		return NewConnection(host, opts)
+	})
 }
 
 func newPool(host Host, opts *ConnectOpts, connFactory connFactory) (*Pool, error) {
@@ -232,7 +234,7 @@ func (p *Pool) Server() (ServerResponse, error) {
 }
 
 // getConnection returns a valid (usable) connection from the pool having the given index.
-func (p *Pool) getConnection(pos int) (*Connection, error) {
+func (p *Pool) getConnection(pos int) (connection, error) {
 	conn := &p.countedConns[pos].conn
 	var err error
 

--- a/pool.go
+++ b/pool.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/silentred/gid"
 	"golang.org/x/net/context"
 )
 
@@ -17,20 +19,33 @@ const (
 	poolIsClosed    int32 = 1
 )
 
-type connFactory func(host string, opts *ConnectOpts) (*Connection, error)
+// PoolBusyWaitFunc is called by the internal connection pool to wait when
+// every connection in the pool is already in use.  If an error is returned
+// the pool will give up.
+type PoolBusyWaitFunc func(ctx context.Context, attempt int) error
 
 // A Pool is used to store a pool of connections to a single RethinkDB server
 type Pool struct {
 	host Host
 	opts *ConnectOpts
 
-	conns   []*Connection
-	pointer int32
-	closed  int32
+	mu           sync.Mutex // protects lazy creating connections
+	countedConns []countedConn
+	busyWait     PoolBusyWaitFunc
+
+	closed int32
 
 	connFactory connFactory
 
-	mu sync.Mutex // protects lazy creating connections
+	afterAcquire  func(pos int)
+	beforeRelease func(pos int)
+}
+
+type countedConn struct {
+	conn        *Connection
+	mu          int64
+	refCount    int64
+	goroutineID int64
 }
 
 // NewPool creates a new connection pool for the given host
@@ -51,30 +66,54 @@ func newPool(host Host, opts *ConnectOpts, connFactory connFactory) (*Pool, erro
 		maxOpen = 1
 	}
 
-	conns := make([]*Connection, maxOpen)
+	busyWait := opts.BusyPoolWait
+	if busyWait == nil {
+		busyWait = func(ctx context.Context, attempt int) error {
+			time.Sleep(500 * time.Millisecond)
+
+			if ctx != nil && ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			return nil
+		}
+	}
+
+	countedConns := make([]countedConn, maxOpen)
 	var err error
+
 	for i := 0; i < opts.InitialCap; i++ {
-		conns[i], err = connFactory(host.String(), opts)
+		countedConns[i].conn, err = connFactory(host.String(), opts)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	return &Pool{
-		conns:       conns,
-		pointer:     -1,
-		host:        host,
-		opts:        opts,
-		connFactory: connFactory,
-		closed:      poolIsNotClosed,
+		host:         host,
+		opts:         opts,
+		countedConns: countedConns,
+		busyWait:     busyWait,
+		connFactory:  connFactory,
+		closed:       poolIsNotClosed,
 	}, nil
 }
 
 // Ping verifies a connection to the database is still alive,
 // establishing a connection if necessary.
 func (p *Pool) Ping() error {
-	_, err := p.conn()
-	return err
+	pos, err := p.acquire(nil)
+	if err != nil {
+		return err
+	}
+	defer p.release(pos)
+
+	_, err = p.getConnection(pos)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Close closes the database, releasing any open resources.
@@ -82,10 +121,6 @@ func (p *Pool) Ping() error {
 // It is rare to Close a Pool, as the Pool handle is meant to be
 // long-lived and shared between many goroutines.
 func (p *Pool) Close() error {
-	if atomic.LoadInt32(&p.closed) == poolIsClosed {
-		return nil
-	}
-
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -94,9 +129,9 @@ func (p *Pool) Close() error {
 	}
 	p.closed = poolIsClosed
 
-	for _, c := range p.conns {
-		if c != nil {
-			err := c.Close()
+	for _, nConn := range p.countedConns {
+		if nConn.conn != nil {
+			err := nConn.conn.Close()
 			if err != nil {
 				return err
 			}
@@ -104,43 +139,6 @@ func (p *Pool) Close() error {
 	}
 
 	return nil
-}
-
-func (p *Pool) conn() (*Connection, error) {
-	if atomic.LoadInt32(&p.closed) == poolIsClosed {
-		return nil, errPoolClosed
-	}
-
-	pos := atomic.AddInt32(&p.pointer, 1)
-	if pos == int32(len(p.conns)) {
-		atomic.StoreInt32(&p.pointer, 0)
-	}
-	pos = pos % int32(len(p.conns))
-
-	var err error
-
-	if p.conns[pos] == nil {
-		p.mu.Lock()
-		defer p.mu.Unlock()
-
-		if p.conns[pos] == nil {
-			p.conns[pos], err = p.connFactory(p.host.String(), p.opts)
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else if p.conns[pos].isBad() {
-		// connBad connection needs to be reconnected
-		p.mu.Lock()
-		defer p.mu.Unlock()
-
-		p.conns[pos], err = p.connFactory(p.host.String(), p.opts)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return p.conns[pos], nil
 }
 
 // SetInitialPoolCap sets the initial capacity of the connection pool.
@@ -167,25 +165,49 @@ func (p *Pool) SetMaxOpenConns(n int) {
 
 // Query execution functions
 
-// Exec executes a query without waiting for any response.
+// Exec executes a query but does not return the response.
 func (p *Pool) Exec(ctx context.Context, q Query) error {
-	c, err := p.conn()
+	pos, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer p.release(pos)
+
+	conn, err := p.getConnection(pos)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = c.Query(ctx, q)
+	_, _, err = conn.Query(ctx, q)
+
 	return err
 }
 
-// Query executes a query and waits for the response
+// Query executes a query and returns the response.
+// The returned cursor should be closed when it is no longer needed.
 func (p *Pool) Query(ctx context.Context, q Query) (*Cursor, error) {
-	c, err := p.conn()
+	pos, err := p.acquire(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	_, cursor, err := c.Query(ctx, q)
+	conn, err := p.getConnection(pos)
+	if err != nil {
+		p.release(pos)
+		return nil, err
+	}
+
+	_, cursor, err := conn.Query(ctx, q)
+
+	if err == nil && cursor != nil {
+		cursor.releaseConn = func() error {
+			p.release(pos)
+			return nil
+		}
+	} else {
+		p.release(pos)
+	}
+
 	return cursor, err
 }
 
@@ -193,11 +215,110 @@ func (p *Pool) Query(ctx context.Context, q Query) (*Cursor, error) {
 func (p *Pool) Server() (ServerResponse, error) {
 	var response ServerResponse
 
-	c, err := p.conn()
+	pos, err := p.acquire(nil)
+	if err != nil {
+		return response, err
+	}
+	defer p.release(pos)
+
+	conn, err := p.getConnection(pos)
 	if err != nil {
 		return response, err
 	}
 
-	response, err = c.Server()
+	response, err = conn.Server()
+
 	return response, err
+}
+
+// getConnection returns a valid (usable) connection from the pool having the given index.
+func (p *Pool) getConnection(pos int) (*Connection, error) {
+	conn := &p.countedConns[pos].conn
+	var err error
+
+	if *conn == nil || (*conn).isBad() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		if p.closed == poolIsClosed {
+			return nil, errPoolClosed
+		}
+
+		*conn, err = p.connFactory(p.host.String(), p.opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return *conn, nil
+}
+
+// acquire returns the index of a pool entry the caller can use.  This will either be an unused entry or one
+// already claimed by the goroutine.
+func (p *Pool) acquire(ctx context.Context) (pos int, err error) {
+	for attempt := 1; ; attempt++ {
+		pos = p.tryAcquire()
+		if pos >= 0 {
+			return pos, nil
+		}
+
+		if p.busyWait != nil {
+			err = p.busyWait(ctx, attempt)
+			if err != nil {
+				return -1, err
+			}
+		}
+	}
+}
+
+func (p *Pool) tryAcquire() (pos int) {
+	goroutineID := gid.Get()
+
+	for i := range p.countedConns {
+		c := &p.countedConns[i]
+
+		// Prevent two goroutines from claiming the same unused entry if it was previously used by one of them,
+		// ie. c.refCount == 0 && c.goroutineID == gid.Get().
+		if !atomic.CompareAndSwapInt64(&c.mu, 0, 1) {
+			continue
+		}
+
+		if atomic.CompareAndSwapInt64(&c.refCount, 0, 1) {
+			// Unused; claim it for use by this goroutine.
+			atomic.StoreInt64(&c.goroutineID, goroutineID)
+			atomic.StoreInt64(&c.mu, 0)
+
+			if p.afterAcquire != nil {
+				p.afterAcquire(i)
+			}
+
+			return i
+		}
+
+		if atomic.LoadInt64(&c.goroutineID) == goroutineID {
+			// Previously claimed for use by this goroutine.
+			atomic.AddInt64(&c.refCount, 1)
+			atomic.StoreInt64(&c.mu, 0)
+
+			if p.afterAcquire != nil {
+				p.afterAcquire(i)
+			}
+
+			return i
+		}
+
+		// Using this pool entry would break Connection's requirement it "should only be accessed be a single goroutine".
+		atomic.StoreInt64(&c.mu, 0)
+	}
+
+	return -1
+}
+
+// release must be called once for each successful acquire() call but only after the caller no longer needs the connection.
+func (p *Pool) release(pos int) {
+	if p.beforeRelease != nil {
+		p.beforeRelease(pos)
+	}
+
+	atomic.AddInt64(&p.countedConns[pos].refCount, -1)
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,163 @@
+package rethinkdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/silentred/gid"
+	"golang.org/x/sync/errgroup"
+	test "gopkg.in/check.v1"
+)
+
+type PoolSuite struct{}
+
+var _ = test.Suite(&PoolSuite{})
+
+func (s *PoolSuite) TestConcurrency(c *test.C) {
+	if testing.Short() {
+		c.Skip("-short set")
+	}
+
+	const (
+		poolCapacity  = 100
+		numGoroutines = 2000
+		testDuration  = 15 * time.Second
+	)
+
+	connFactory := func(host string, opts *ConnectOpts) (connection, error) {
+		return &fakePoolConn{badProbability: 0.001}, nil
+	}
+
+	p, err := newPool(Host{}, &ConnectOpts{MaxOpen: poolCapacity}, connFactory)
+	c.Assert(p, test.NotNil)
+	c.Assert(err, test.IsNil)
+
+	localState := [poolCapacity]struct {
+		mu          sync.Mutex
+		goroutineID int64
+		refCount    int64
+	}{}
+
+	p.afterAcquire = func(pos int) {
+		s := &localState[pos]
+
+		// Don't use atomics here.  It's more important this test be correct than fast.
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		if s.goroutineID != gid.Get() {
+			if s.refCount == 0 {
+				// First use of a connection, or reuse of an existing but unused connection
+				s.goroutineID = gid.Get()
+			} else {
+				panic(fmt.Sprintf("A connection would be concurrently used by goroutines %v and %v", s.goroutineID, gid.Get()))
+			}
+		}
+
+		s.refCount++
+	}
+
+	p.beforeRelease = func(pos int) {
+		s := &localState[pos]
+
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		s.refCount--
+	}
+
+	q := testQuery(DB("db").Table("table").Get("id"))
+
+	calls := []func(*Pool) error{
+		func(p *Pool) error {
+			return p.Ping()
+		},
+
+		func(p *Pool) error {
+			return p.Exec(context.Background(), q)
+		},
+
+		func(p *Pool) error {
+			cursor, err := p.Query(context.Background(), q)
+			if err != nil {
+				return err
+			}
+
+			// Pretend to read from the cursor
+			time.Sleep(1 * time.Millisecond)
+			cursor.finished = true
+
+			return cursor.Close()
+		},
+
+		func(p *Pool) error {
+			_, err := p.Server()
+			return err
+		},
+	}
+
+	testLoop := func() error {
+		startTime := time.Now()
+		for time.Since(startTime) < testDuration {
+			i := rand.Intn(len(calls))
+			err := calls[i](p)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	g := new(errgroup.Group)
+	for i := 0; i < numGoroutines; i++ {
+		g.Go(testLoop)
+	}
+
+	err = g.Wait()
+	c.Assert(err, test.IsNil)
+}
+
+type fakePoolConn struct {
+	bad            int32
+	badProbability float32
+}
+
+func (c *fakePoolConn) Server() (ServerResponse, error) {
+	if c.isBad() {
+		return ServerResponse{}, errors.New("Server() was called even though the connection is known to be unusable")
+	}
+
+	if rand.Float32() < c.badProbability {
+		atomic.StoreInt32(&c.bad, connBad)
+	}
+
+	return ServerResponse{}, nil
+}
+
+func (c *fakePoolConn) Query(ctx context.Context, q Query) (*Response, *Cursor, error) {
+	if c.isBad() {
+		return nil, nil, errors.New("Query() was called even though the connection is known to be unusable")
+	}
+
+	if rand.Float32() < c.badProbability {
+		atomic.StoreInt32(&c.bad, connBad)
+	}
+
+	cursor := &Cursor{
+		ctx:  context.Background(),
+		conn: c,
+	}
+
+	return nil, cursor, nil
+}
+
+func (c *fakePoolConn) Close() error   { panic("not implemented") }
+func (c *fakePoolConn) isBad() bool    { return atomic.LoadInt32(&c.bad) == connBad }
+func (c *fakePoolConn) isClosed() bool { return false }

--- a/session.go
+++ b/session.go
@@ -82,6 +82,10 @@ type ConnectOpts struct {
 	// the maximum number of connections held in the pool. By default the
 	// maximum number of connections is 1
 	MaxOpen int `rethinkdb:"max_open,omitempty" json:"max_open,omitempty"`
+	// BusyPoolWait is called by the internal connection pool to wait when
+	// every connection in the pool is already in use.  If nil a short
+	// default delay will be used.
+	BusyPoolWait PoolBusyWaitFunc
 
 	// Below options are for cluster discovery, please note there is a high
 	// probability of these changing as the API is still being worked on.
@@ -293,7 +297,8 @@ func (s *Session) Database() string {
 	return s.opts.Database
 }
 
-// Query executes a ReQL query using the session to connect to the database
+// Query executes a ReQL query using the session to connect to the database.
+// The returned cursor should be closed (either directly or indirectly) when it is no longer needed.
 func (s *Session) Query(ctx context.Context, q Query) (*Cursor, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
**Reason for the change**
Fixes #497

**Description**
WARNING: this might be a breaking change for some applications.
To be specific, if an application calls Query() from N goroutines
but doesn't close the returned cursors, and is using a pool with
fewer than N entries, the last call will block forever.
Needless to say README.md already recommends closing cursors to
prevent leaking connections, so developers were warned...

Pool entries are acquired with "non blocking mutexes" to
promote concurrency.

Remote queries are not fast compared to the instructions on the
local processor.  It would be preferable to use sync.Cond so
goroutines waiting for a connection could sleep until one becomes
available.  However, that introduces a race condition I wasn't able
to resolve without a (blocking) mutex.  If every connection is busy,
the pool waits before trying again.

The wait logic can be overridden by the library user, since
applications have different workloads; batch loading is quite
different from individual queries serving a UI.  A developer can
implement a fixed delay, exponential delay, etc. in tandem with
delay constants appropriate for their application.

**Code examples**

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
