### PR TITLE
Introduce github actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+template: |
+  ## General Changes
+
+  $CHANGES
+
+categories:
+- title: '🚀 Features'
+  labels:
+  - 'feature'
+  - 'enhancement'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+
+version-resolver:
+  major:
+    labels:
+    - 'major'
+  minor:
+    labels:
+    - 'minor'
+  patch:
+    labels:
+    - 'patch'
+  default: patch

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,15 @@
+---
+name: Release Drafter Action
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: release-drafter/release-drafter@v6
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,56 @@
+---
+name: Test
+on:
+  pull_request:
+    branches:
+      - master
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    name: Docker Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+        cache: false
+
+    # - name: Lint
+    #   uses: golangci/golangci-lint-action@v6
+    #   with:
+    #     args: --build-tags integration -p bugs -p unused -D protogetter --timeout=5m
+
+    - name: Run unit tests
+      run: |
+        make test
+  
+
+  # integration:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+
+  #   - name: Setup Go
+  #     uses: actions/setup-go@v5
+  #     with:
+  #       go-version-file: 'go.mod'
+
+  #   - name: Run integration tests
+  #     run: |
+  #       make integration


### PR DESCRIPTION
This introduces CI on Github Actions which executes `make test` on every PR. This is required to see the results of the integration tests of #511 and following PRs.

@gabor-boros this would be nice to have first.