### PR TITLE
Fix: ST1023: should omit type Err from declaration

### DIFF
--- a/internal/integration/reql_tests/reql_aggregation_test.go
+++ b/internal/integration/reql_tests/reql_aggregation_test.go
@@ -94,7 +94,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #6
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* r.range(100).for_each(tbl.insert({'id':r.row, 'a':r.row.mod(4)})) */
 
 		suite.T().Log("About to run line #6: r.Range(100).ForEach(tbl.Insert(map[interface{}]interface{}{'id': r.Row, 'a': r.Row.Mod(4), }))")
@@ -109,7 +109,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #10
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* r.range(100).for_each(tbl2.insert({'id':r.row, 'a':r.row.mod(4)})) */
 
 		suite.T().Log("About to run line #10: r.Range(100).ForEach(tbl2.Insert(map[interface{}]interface{}{'id': r.Row, 'a': r.Row.Mod(4), }))")
@@ -124,7 +124,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #14
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* r.range(100).for_each(tbl3.insert({'id':r.row, 'a':r.row.mod(4), 'b':{'c':r.row.mod(5)}})) */
 
 		suite.T().Log("About to run line #14: r.Range(100).ForEach(tbl3.Insert(map[interface{}]interface{}{'id': r.Row, 'a': r.Row.Mod(4), 'b': map[interface{}]interface{}{'c': r.Row.Mod(5), }, }))")
@@ -153,7 +153,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #27
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
 		/* tbl4.insert({'id':0, 'time':r.epoch_time(time1)}) */
 
 		suite.T().Log("About to run line #27: tbl4.Insert(map[interface{}]interface{}{'id': 0, 'time': r.EpochTime(time1), })")
@@ -168,7 +168,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #28
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
 		/* tbl4.insert({'id':1, 'time':r.epoch_time(time2)}) */
 
 		suite.T().Log("About to run line #28: tbl4.Insert(map[interface{}]interface{}{'id': 1, 'time': r.EpochTime(time2), })")
@@ -183,7 +183,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #33
 		/* 150 */
-		var expected_ int = 150
+		var expected_ = 150
 		/* tbl.sum('a') */
 
 		suite.T().Log("About to run line #33: tbl.Sum('a')")
@@ -198,7 +198,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #36
 		/* 150 */
-		var expected_ int = 150
+		var expected_ = 150
 		/* tbl.map(lambda row:row['a']).sum() */
 
 		suite.T().Log("About to run line #36: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Sum()")
@@ -213,7 +213,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #39
 		/* ({0:1200, 1:1225, 2:1250, 3:1275}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 1200, 1: 1225, 2: 1250, 3: 1275}
+		var expected_ = map[interface{}]interface{}{0: 1200, 1: 1225, 2: 1250, 3: 1275}
 		/* tbl.group('a').sum('id') */
 
 		suite.T().Log("About to run line #39: tbl.Group('a').Sum('id')")
@@ -228,7 +228,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #43
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* tbl.avg('a') */
 
 		suite.T().Log("About to run line #43: tbl.Avg('a')")
@@ -243,7 +243,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #46
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* tbl.map(lambda row:row['a']).avg() */
 
 		suite.T().Log("About to run line #46: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Avg()")
@@ -258,7 +258,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #49
 		/* {0:48, 1:49, 2:50, 3:51} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 48, 1: 49, 2: 50, 3: 51}
+		var expected_ = map[interface{}]interface{}{0: 48, 1: 49, 2: 50, 3: 51}
 		/* tbl.group('a').avg('id') */
 
 		suite.T().Log("About to run line #49: tbl.Group('a').Avg('id')")
@@ -273,7 +273,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #53
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.min('a')['a'] */
 
 		suite.T().Log("About to run line #53: tbl.Min('a').AtIndex('a')")
@@ -288,7 +288,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #56
 		/* {'a':0, 'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0, "id": 0}
+		var expected_ = map[interface{}]interface{}{"a": 0, "id": 0}
 		/* tbl.order_by('id').min('a') */
 
 		suite.T().Log("About to run line #56: tbl.OrderBy('id').Min('a')")
@@ -303,7 +303,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #59
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.map(lambda row:row['a']).min() */
 
 		suite.T().Log("About to run line #59: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Min()")
@@ -318,7 +318,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #62
 		/* {0:{'a':0, 'id':0}, 1:{'a':1, 'id':1}, 2:{'a':2, 'id':2}, 3:{'a':3, 'id':3}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 0}, 1: map[interface{}]interface{}{"a": 1, "id": 1}, 2: map[interface{}]interface{}{"a": 2, "id": 2}, 3: map[interface{}]interface{}{"a": 3, "id": 3}}
+		var expected_ = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 0}, 1: map[interface{}]interface{}{"a": 1, "id": 1}, 2: map[interface{}]interface{}{"a": 2, "id": 2}, 3: map[interface{}]interface{}{"a": 3, "id": 3}}
 		/* tbl.group('a').min('id') */
 
 		suite.T().Log("About to run line #62: tbl.Group('a').Min('id')")
@@ -333,7 +333,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #66
 		/* {'a':3, 'id':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 3, "id": 3}
+		var expected_ = map[interface{}]interface{}{"a": 3, "id": 3}
 		/* tbl.order_by('id').max('a') */
 
 		suite.T().Log("About to run line #66: tbl.OrderBy('id').Max('a')")
@@ -348,7 +348,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #69
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.map(lambda row:row['a']).max() */
 
 		suite.T().Log("About to run line #69: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Max()")
@@ -363,7 +363,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #72
 		/* {0:{'a':0, 'id':96}, 1:{'a':1, 'id':97}, 2:{'a':2, 'id':98}, 3:{'a':3, 'id':99}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 96}, 1: map[interface{}]interface{}{"a": 1, "id": 97}, 2: map[interface{}]interface{}{"a": 2, "id": 98}, 3: map[interface{}]interface{}{"a": 3, "id": 99}}
+		var expected_ = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 96}, 1: map[interface{}]interface{}{"a": 1, "id": 97}, 2: map[interface{}]interface{}{"a": 2, "id": 98}, 3: map[interface{}]interface{}{"a": 3, "id": 99}}
 		/* tbl.group('a').max('id') */
 
 		suite.T().Log("About to run line #72: tbl.Group('a').Max('id')")
@@ -378,7 +378,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #77
 		/* {"a":0, "id":0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0, "id": 0}
+		var expected_ = map[interface{}]interface{}{"a": 0, "id": 0}
 		/* tbl.min() */
 
 		suite.T().Log("About to run line #77: tbl.Min()")
@@ -393,7 +393,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #79
 		/* {0:{"a":0, "id":0}, 1:{"a":1, "id":1}, 2:{"a":2, "id":2}, 3:{"a":3, "id":3}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 0}, 1: map[interface{}]interface{}{"a": 1, "id": 1}, 2: map[interface{}]interface{}{"a": 2, "id": 2}, 3: map[interface{}]interface{}{"a": 3, "id": 3}}
+		var expected_ = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 0}, 1: map[interface{}]interface{}{"a": 1, "id": 1}, 2: map[interface{}]interface{}{"a": 2, "id": 2}, 3: map[interface{}]interface{}{"a": 3, "id": 3}}
 		/* tbl.group('a').min() */
 
 		suite.T().Log("About to run line #79: tbl.Group('a').Min()")
@@ -408,7 +408,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #83
 		/* {"a":3, "id":99} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 3, "id": 99}
+		var expected_ = map[interface{}]interface{}{"a": 3, "id": 99}
 		/* tbl.max() */
 
 		suite.T().Log("About to run line #83: tbl.Max()")
@@ -423,7 +423,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #85
 		/* {0:{'a':0, 'id':96}, 1:{'a':1, 'id':97}, 2:{'a':2, 'id':98}, 3:{'a':3, 'id':99}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 96}, 1: map[interface{}]interface{}{"a": 1, "id": 97}, 2: map[interface{}]interface{}{"a": 2, "id": 98}, 3: map[interface{}]interface{}{"a": 3, "id": 99}}
+		var expected_ = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 96}, 1: map[interface{}]interface{}{"a": 1, "id": 97}, 2: map[interface{}]interface{}{"a": 2, "id": 98}, 3: map[interface{}]interface{}{"a": 3, "id": 99}}
 		/* tbl.group('a').max() */
 
 		suite.T().Log("About to run line #85: tbl.Group('a').Max()")
@@ -438,7 +438,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #92
 		/* 150 */
-		var expected_ int = 150
+		var expected_ = 150
 		/* tbl.sum(lambda row:row['a']) */
 
 		suite.T().Log("About to run line #92: tbl.Sum(func(row r.Term) interface{} { return row.AtIndex('a')})")
@@ -453,7 +453,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #93
 		/* 150 */
-		var expected_ int = 150
+		var expected_ = 150
 		/* tbl.sum(r.row['a']) */
 
 		suite.T().Log("About to run line #93: tbl.Sum(r.Row.AtIndex('a'))")
@@ -468,7 +468,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #99
 		/* 150 */
-		var expected_ int = 150
+		var expected_ = 150
 		/* tbl.map(lambda row:row['a']).sum() */
 
 		suite.T().Log("About to run line #99: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Sum()")
@@ -483,7 +483,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #103
 		/* {0:1200, 1:1225, 2:1250, 3:1275} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 1200, 1: 1225, 2: 1250, 3: 1275}
+		var expected_ = map[interface{}]interface{}{0: 1200, 1: 1225, 2: 1250, 3: 1275}
 		/* tbl.group(lambda row:row['a']).sum(lambda row:row['id']) */
 
 		suite.T().Log("About to run line #103: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Sum(func(row r.Term) interface{} { return row.AtIndex('id')})")
@@ -498,7 +498,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #111
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* tbl.avg(lambda row:row['a']) */
 
 		suite.T().Log("About to run line #111: tbl.Avg(func(row r.Term) interface{} { return row.AtIndex('a')})")
@@ -513,7 +513,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #112
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* tbl.avg(r.row['a']) */
 
 		suite.T().Log("About to run line #112: tbl.Avg(r.Row.AtIndex('a'))")
@@ -528,7 +528,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #118
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* tbl.map(lambda row:row['a']).avg() */
 
 		suite.T().Log("About to run line #118: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Avg()")
@@ -543,7 +543,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #122
 		/* {0:48, 1:49, 2:50, 3:51} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 48, 1: 49, 2: 50, 3: 51}
+		var expected_ = map[interface{}]interface{}{0: 48, 1: 49, 2: 50, 3: 51}
 		/* tbl.group(lambda row:row['a']).avg(lambda row:row['id']) */
 
 		suite.T().Log("About to run line #122: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Avg(func(row r.Term) interface{} { return row.AtIndex('id')})")
@@ -558,7 +558,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #129
 		/* {'a':0, 'id':96} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0, "id": 96}
+		var expected_ = map[interface{}]interface{}{"a": 0, "id": 96}
 		/* tbl.order_by(r.desc('id')).min(lambda row:row['a']) */
 
 		suite.T().Log("About to run line #129: tbl.OrderBy(r.Desc('id')).Min(func(row r.Term) interface{} { return row.AtIndex('a')})")
@@ -573,7 +573,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #130
 		/* {'a':0, 'id':96} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0, "id": 96}
+		var expected_ = map[interface{}]interface{}{"a": 0, "id": 96}
 		/* tbl.order_by(r.desc('id')).min(r.row['a']) */
 
 		suite.T().Log("About to run line #130: tbl.OrderBy(r.Desc('id')).Min(r.Row.AtIndex('a'))")
@@ -588,7 +588,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #138
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.order_by(r.desc('id')).min(lambda row:row['a'])['a'] */
 
 		suite.T().Log("About to run line #138: tbl.OrderBy(r.Desc('id')).Min(func(row r.Term) interface{} { return row.AtIndex('a')}).AtIndex('a')")
@@ -603,7 +603,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #139
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.order_by(r.desc('id')).min(r.row['a'])['a'] */
 
 		suite.T().Log("About to run line #139: tbl.OrderBy(r.Desc('id')).Min(r.Row.AtIndex('a')).AtIndex('a')")
@@ -618,7 +618,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #145
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.map(lambda row:row['a']).min() */
 
 		suite.T().Log("About to run line #145: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Min()")
@@ -633,7 +633,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #149
 		/* {0:0, 1:1, 2:2, 3:3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 0, 1: 1, 2: 2, 3: 3}
+		var expected_ = map[interface{}]interface{}{0: 0, 1: 1, 2: 2, 3: 3}
 		/* tbl.group(lambda row:row['a']).min(lambda row:row['id'])['id'] */
 
 		suite.T().Log("About to run line #149: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Min(func(row r.Term) interface{} { return row.AtIndex('id')}).AtIndex('id')")
@@ -648,7 +648,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #157
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.max(lambda row:row['a'])['a'] */
 
 		suite.T().Log("About to run line #157: tbl.Max(func(row r.Term) interface{} { return row.AtIndex('a')}).AtIndex('a')")
@@ -663,7 +663,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #158
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.max(r.row['a'])['a'] */
 
 		suite.T().Log("About to run line #158: tbl.Max(r.Row.AtIndex('a')).AtIndex('a')")
@@ -678,7 +678,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #164
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.map(lambda row:row['a']).max() */
 
 		suite.T().Log("About to run line #164: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Max()")
@@ -693,7 +693,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #168
 		/* {0:96, 1:97, 2:98, 3:99} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 96, 1: 97, 2: 98, 3: 99}
+		var expected_ = map[interface{}]interface{}{0: 96, 1: 97, 2: 98, 3: 99}
 		/* tbl.group(lambda row:row['a']).max(lambda row:row['id'])['id'] */
 
 		suite.T().Log("About to run line #168: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Max(func(row r.Term) interface{} { return row.AtIndex('id')}).AtIndex('id')")
@@ -708,7 +708,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #175
 		/* {0:1200, 1:1225, 2:1250, 3:1275} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 1200, 1: 1225, 2: 1250, 3: 1275}
+		var expected_ = map[interface{}]interface{}{0: 1200, 1: 1225, 2: 1250, 3: 1275}
 		/* tbl.group(lambda row:row['a']).map(lambda row:row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #175: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -723,7 +723,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #185
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 1200], [1, 1225], [2, 1250], [3, 1275]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
 		/* tbl.group(lambda row:row['a']).map(lambda row:row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #185: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -738,7 +738,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #186
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 1200], [1, 1225], [2, 1250], [3, 1275]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
 		/* tbl.group(r.row['a']).map(r.row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #186: tbl.Group(r.Row.AtIndex('a')).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -753,7 +753,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #192
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[1, [{'a':1}]]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{1, []interface{}{map[interface{}]interface{}{"a": 1}}}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{1, []interface{}{map[interface{}]interface{}{"a": 1}}}}}
 		/* r.expr([{'a':1}]).filter(true).limit(1).group('a') */
 
 		suite.T().Log("About to run line #192: r.Expr([]interface{}{map[interface{}]interface{}{'a': 1, }}).Filter(true).Limit(1).Group('a')")
@@ -768,7 +768,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #198
 		/* "GROUPED_STREAM" */
-		var expected_ string = "GROUPED_STREAM"
+		var expected_ = "GROUPED_STREAM"
 		/* tbl.group('a').type_of() */
 
 		suite.T().Log("About to run line #198: tbl.Group('a').TypeOf()")
@@ -783,7 +783,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #200
 		/* "GROUPED_DATA" */
-		var expected_ string = "GROUPED_DATA"
+		var expected_ = "GROUPED_DATA"
 		/* tbl.group('a').count().type_of() */
 
 		suite.T().Log("About to run line #200: tbl.Group('a').Count().TypeOf()")
@@ -798,7 +798,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #202
 		/* "GROUPED_DATA" */
-		var expected_ string = "GROUPED_DATA"
+		var expected_ = "GROUPED_DATA"
 		/* tbl.group('a').coerce_to('ARRAY').type_of() */
 
 		suite.T().Log("About to run line #202: tbl.Group('a').CoerceTo('ARRAY').TypeOf()")
@@ -813,7 +813,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #206
 		/* {0:[0,4,8],1:[1,5,9],2:[2,6],3:[3,7]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: []interface{}{0, 4, 8}, 1: []interface{}{1, 5, 9}, 2: []interface{}{2, 6}, 3: []interface{}{3, 7}}
+		var expected_ = map[interface{}]interface{}{0: []interface{}{0, 4, 8}, 1: []interface{}{1, 5, 9}, 2: []interface{}{2, 6}, 3: []interface{}{3, 7}}
 		/* tbl.order_by(index='id').filter(lambda row:row['id'] < 10).group('a').map(lambda row:row['id']).coerce_to('ARRAY') */
 
 		suite.T().Log("About to run line #206: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Filter(func(row r.Term) interface{} { return row.AtIndex('id').Lt(10)}).Group('a').Map(func(row r.Term) interface{} { return row.AtIndex('id')}).CoerceTo('ARRAY')")
@@ -828,7 +828,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #213
 		/* {0:9,1:9,2:4,3:4} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 9, 1: 9, 2: 4, 3: 4}
+		var expected_ = map[interface{}]interface{}{0: 9, 1: 9, 2: 4, 3: 4}
 		/* tbl.filter(lambda row:row['id'] < 10).group('a').count().do(lambda x:x*x) */
 
 		suite.T().Log("About to run line #213: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('id').Lt(10)}).Group('a').Count().Do(func(x r.Term) interface{} { return r.Mul(x, x)})")
@@ -843,7 +843,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #223
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 2400], [1, 2450], [2, 2500], [3, 2550]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
 		/* tbl.union(tbl).group(lambda row:row['a']).map(lambda row:row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #223: tbl.Union(tbl).Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -858,7 +858,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #224
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 2400], [1, 2450], [2, 2500], [3, 2550]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
 		/* tbl.union(tbl).group(r.row['a']).map(r.row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #224: tbl.Union(tbl).Group(r.Row.AtIndex('a')).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -873,7 +873,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #235
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 2400], [1, 2450], [2, 2500], [3, 2550]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
 		/* tbl.coerce_to("array").union(tbl).group(lambda row:row['a']).map(lambda row:row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #235: tbl.CoerceTo('array').Union(tbl).Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -888,7 +888,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #236
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 2400], [1, 2450], [2, 2500], [3, 2550]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
 		/* tbl.coerce_to("array").union(tbl).group(r.row['a']).map(r.row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #236: tbl.CoerceTo('array').Union(tbl).Group(r.Row.AtIndex('a')).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -903,7 +903,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #247
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 2400], [1, 2450], [2, 2500], [3, 2550]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
 		/* tbl.union(tbl.coerce_to("array")).group(lambda row:row['a']).map(lambda row:row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #247: tbl.Union(tbl.CoerceTo('array')).Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -918,7 +918,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #248
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 2400], [1, 2450], [2, 2500], [3, 2550]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 2400}, []interface{}{1, 2450}, []interface{}{2, 2500}, []interface{}{3, 2550}}}
 		/* tbl.union(tbl.coerce_to("array")).group(r.row['a']).map(r.row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #248: tbl.Union(tbl.CoerceTo('array')).Group(r.Row.AtIndex('a')).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -933,7 +933,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #255
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 1200], [1, 1225], [2, 1250], [3, 1275]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
 		/* tbl.group(lambda row:row['a']).map(lambda row:row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #255: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('a')}).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -948,7 +948,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #256
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 1200], [1, 1225], [2, 1250], [3, 1275]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
 		/* tbl.group(r.row['a']).map(r.row['id']).reduce(lambda a,b:a + b) */
 
 		suite.T().Log("About to run line #256: tbl.Group(r.Row.AtIndex('a')).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -963,7 +963,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #286
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 25], [1, 25], [2, 25], [3, 25]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 25}, []interface{}{1, 25}, []interface{}{2, 25}, []interface{}{3, 25}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 25}, []interface{}{1, 25}, []interface{}{2, 25}, []interface{}{3, 25}}}
 		/* tbl.group('a').count() */
 
 		suite.T().Log("About to run line #286: tbl.Group('a').Count()")
@@ -978,7 +978,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #292
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 1200], [1, 1225], [2, 1250], [3, 1275]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1200}, []interface{}{1, 1225}, []interface{}{2, 1250}, []interface{}{3, 1275}}}
 		/* tbl.group('a').sum('id') */
 
 		suite.T().Log("About to run line #292: tbl.Group('a').Sum('id')")
@@ -993,7 +993,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #298
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 48], [1, 49], [2, 50], [3, 51]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 48}, []interface{}{1, 49}, []interface{}{2, 50}, []interface{}{3, 51}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 48}, []interface{}{1, 49}, []interface{}{2, 50}, []interface{}{3, 51}}}
 		/* tbl.group('a').avg('id') */
 
 		suite.T().Log("About to run line #298: tbl.Group('a').Avg('id')")
@@ -1008,7 +1008,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #305
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 20], [1, 20], [2, 20], [3, 20], [4, 20]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 20}, []interface{}{1, 20}, []interface{}{2, 20}, []interface{}{3, 20}, []interface{}{4, 20}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 20}, []interface{}{1, 20}, []interface{}{2, 20}, []interface{}{3, 20}, []interface{}{4, 20}}}
 		/* tbl3.group(lambda row:row['b']['c']).count() */
 
 		suite.T().Log("About to run line #305: tbl3.Group(func(row r.Term) interface{} { return row.AtIndex('b').AtIndex('c')}).Count()")
@@ -1023,7 +1023,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #313
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[[0, 0], 9], [[0, 1], 8], [[0, 2], 8], [[1, 0], 8], [[1, 1], 9], [[1, 2], 8], [[2, 0], 8], [[2, 1], 8], [[2, 2], 9], [[3, 0], 9], [[3, 1], 8], [[3, 2], 8]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, 0}, 9}, []interface{}{[]interface{}{0, 1}, 8}, []interface{}{[]interface{}{0, 2}, 8}, []interface{}{[]interface{}{1, 0}, 8}, []interface{}{[]interface{}{1, 1}, 9}, []interface{}{[]interface{}{1, 2}, 8}, []interface{}{[]interface{}{2, 0}, 8}, []interface{}{[]interface{}{2, 1}, 8}, []interface{}{[]interface{}{2, 2}, 9}, []interface{}{[]interface{}{3, 0}, 9}, []interface{}{[]interface{}{3, 1}, 8}, []interface{}{[]interface{}{3, 2}, 8}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, 0}, 9}, []interface{}{[]interface{}{0, 1}, 8}, []interface{}{[]interface{}{0, 2}, 8}, []interface{}{[]interface{}{1, 0}, 8}, []interface{}{[]interface{}{1, 1}, 9}, []interface{}{[]interface{}{1, 2}, 8}, []interface{}{[]interface{}{2, 0}, 8}, []interface{}{[]interface{}{2, 1}, 8}, []interface{}{[]interface{}{2, 2}, 9}, []interface{}{[]interface{}{3, 0}, 9}, []interface{}{[]interface{}{3, 1}, 8}, []interface{}{[]interface{}{3, 2}, 8}}}
 		/* tbl.group('a', lambda row:row['id'].mod(3)).count() */
 
 		suite.T().Log("About to run line #313: tbl.Group('a', func(row r.Term) interface{} { return row.AtIndex('id').Mod(3)}).Count()")
@@ -1038,7 +1038,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #329
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* tbl.map(lambda row:row['a']).distinct().count() */
 
 		suite.T().Log("About to run line #329: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('a')}).Distinct().Count()")
@@ -1053,7 +1053,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #334
 		/* "STREAM" */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* tbl.distinct().type_of() */
 
 		suite.T().Log("About to run line #334: tbl.Distinct().TypeOf()")
@@ -1068,7 +1068,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #337
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.distinct().count() */
 
 		suite.T().Log("About to run line #337: tbl.Distinct().Count()")
@@ -1083,7 +1083,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #341
 		/* "STREAM" */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* tbl.distinct(index='id').type_of() */
 
 		suite.T().Log("About to run line #341: tbl.Distinct().OptArgs(r.DistinctOpts{Index: 'id', }).TypeOf()")
@@ -1098,7 +1098,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #345
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.distinct(index='id').count() */
 
 		suite.T().Log("About to run line #345: tbl.Distinct().OptArgs(r.DistinctOpts{Index: 'id', }).Count()")
@@ -1113,7 +1113,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #348
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('a') */
 
 		suite.T().Log("About to run line #348: tbl.IndexCreate('a')")
@@ -1128,7 +1128,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #357
 		/* [{'index':'a','ready':true}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"index": "a", "ready": true}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"index": "a", "ready": true}}
 		/* tbl.index_wait('a').pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #357: tbl.IndexWait('a').Pluck('index', 'ready')")
@@ -1143,7 +1143,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #367
 		/* 25 */
-		var expected_ int = 25
+		var expected_ = 25
 		/* tbl.between(0, 1, index='a').distinct().count() */
 
 		suite.T().Log("About to run line #367: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'a', }).Distinct().Count()")
@@ -1158,7 +1158,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #371
 		/* 25 */
-		var expected_ int = 25
+		var expected_ = 25
 		/* tbl.between(0, 1, index='a').distinct(index='id').count() */
 
 		suite.T().Log("About to run line #371: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'a', }).Distinct().OptArgs(r.DistinctOpts{Index: 'id', }).Count()")
@@ -1173,7 +1173,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #408
 		/* "STREAM" */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* tbl.distinct(index='a').type_of() */
 
 		suite.T().Log("About to run line #408: tbl.Distinct().OptArgs(r.DistinctOpts{Index: 'a', }).TypeOf()")
@@ -1188,7 +1188,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #412
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* tbl.distinct(index='a').count() */
 
 		suite.T().Log("About to run line #412: tbl.Distinct().OptArgs(r.DistinctOpts{Index: 'a', }).Count()")
@@ -1203,7 +1203,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #415
 		/* err('ReqlQueryLogicError', 'Cannot group by nothing.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot group by nothing.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot group by nothing.")
 		/* tbl.group() */
 
 		suite.T().Log("About to run line #415: tbl.Group()")
@@ -1218,7 +1218,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #418
 		/* ({'$reql_type$':'GROUPED_DATA', 'data':[[0, 1], [1, 1], [2, 1], [3, 1], [4, 1], [5, 1], [6, 1], [7, 1], [8, 1], [9, 1], [10, 1], [11, 1], [12, 1], [13, 1], [14, 1], [15, 1], [16, 1], [17, 1], [18, 1], [19, 1], [20, 1], [21, 1], [22, 1], [23, 1], [24, 1], [25, 1], [26, 1], [27, 1], [28, 1], [29, 1], [30, 1], [31, 1], [32, 1], [33, 1], [34, 1], [35, 1], [36, 1], [37, 1], [38, 1], [39, 1], [40, 1], [41, 1], [42, 1], [43, 1], [44, 1], [45, 1], [46, 1], [47, 1], [48, 1], [49, 1], [50, 1], [51, 1], [52, 1], [53, 1], [54, 1], [55, 1], [56, 1], [57, 1], [58, 1], [59, 1], [60, 1], [61, 1], [62, 1], [63, 1], [64, 1], [65, 1], [66, 1], [67, 1], [68, 1], [69, 1], [70, 1], [71, 1], [72, 1], [73, 1], [74, 1], [75, 1], [76, 1], [77, 1], [78, 1], [79, 1], [80, 1], [81, 1], [82, 1], [83, 1], [84, 1], [85, 1], [86, 1], [87, 1], [88, 1], [89, 1], [90, 1], [91, 1], [92, 1], [93, 1], [94, 1], [95, 1], [96, 1], [97, 1], [98, 1], [99, 1]]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}, []interface{}{6, 1}, []interface{}{7, 1}, []interface{}{8, 1}, []interface{}{9, 1}, []interface{}{10, 1}, []interface{}{11, 1}, []interface{}{12, 1}, []interface{}{13, 1}, []interface{}{14, 1}, []interface{}{15, 1}, []interface{}{16, 1}, []interface{}{17, 1}, []interface{}{18, 1}, []interface{}{19, 1}, []interface{}{20, 1}, []interface{}{21, 1}, []interface{}{22, 1}, []interface{}{23, 1}, []interface{}{24, 1}, []interface{}{25, 1}, []interface{}{26, 1}, []interface{}{27, 1}, []interface{}{28, 1}, []interface{}{29, 1}, []interface{}{30, 1}, []interface{}{31, 1}, []interface{}{32, 1}, []interface{}{33, 1}, []interface{}{34, 1}, []interface{}{35, 1}, []interface{}{36, 1}, []interface{}{37, 1}, []interface{}{38, 1}, []interface{}{39, 1}, []interface{}{40, 1}, []interface{}{41, 1}, []interface{}{42, 1}, []interface{}{43, 1}, []interface{}{44, 1}, []interface{}{45, 1}, []interface{}{46, 1}, []interface{}{47, 1}, []interface{}{48, 1}, []interface{}{49, 1}, []interface{}{50, 1}, []interface{}{51, 1}, []interface{}{52, 1}, []interface{}{53, 1}, []interface{}{54, 1}, []interface{}{55, 1}, []interface{}{56, 1}, []interface{}{57, 1}, []interface{}{58, 1}, []interface{}{59, 1}, []interface{}{60, 1}, []interface{}{61, 1}, []interface{}{62, 1}, []interface{}{63, 1}, []interface{}{64, 1}, []interface{}{65, 1}, []interface{}{66, 1}, []interface{}{67, 1}, []interface{}{68, 1}, []interface{}{69, 1}, []interface{}{70, 1}, []interface{}{71, 1}, []interface{}{72, 1}, []interface{}{73, 1}, []interface{}{74, 1}, []interface{}{75, 1}, []interface{}{76, 1}, []interface{}{77, 1}, []interface{}{78, 1}, []interface{}{79, 1}, []interface{}{80, 1}, []interface{}{81, 1}, []interface{}{82, 1}, []interface{}{83, 1}, []interface{}{84, 1}, []interface{}{85, 1}, []interface{}{86, 1}, []interface{}{87, 1}, []interface{}{88, 1}, []interface{}{89, 1}, []interface{}{90, 1}, []interface{}{91, 1}, []interface{}{92, 1}, []interface{}{93, 1}, []interface{}{94, 1}, []interface{}{95, 1}, []interface{}{96, 1}, []interface{}{97, 1}, []interface{}{98, 1}, []interface{}{99, 1}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 1}, []interface{}{1, 1}, []interface{}{2, 1}, []interface{}{3, 1}, []interface{}{4, 1}, []interface{}{5, 1}, []interface{}{6, 1}, []interface{}{7, 1}, []interface{}{8, 1}, []interface{}{9, 1}, []interface{}{10, 1}, []interface{}{11, 1}, []interface{}{12, 1}, []interface{}{13, 1}, []interface{}{14, 1}, []interface{}{15, 1}, []interface{}{16, 1}, []interface{}{17, 1}, []interface{}{18, 1}, []interface{}{19, 1}, []interface{}{20, 1}, []interface{}{21, 1}, []interface{}{22, 1}, []interface{}{23, 1}, []interface{}{24, 1}, []interface{}{25, 1}, []interface{}{26, 1}, []interface{}{27, 1}, []interface{}{28, 1}, []interface{}{29, 1}, []interface{}{30, 1}, []interface{}{31, 1}, []interface{}{32, 1}, []interface{}{33, 1}, []interface{}{34, 1}, []interface{}{35, 1}, []interface{}{36, 1}, []interface{}{37, 1}, []interface{}{38, 1}, []interface{}{39, 1}, []interface{}{40, 1}, []interface{}{41, 1}, []interface{}{42, 1}, []interface{}{43, 1}, []interface{}{44, 1}, []interface{}{45, 1}, []interface{}{46, 1}, []interface{}{47, 1}, []interface{}{48, 1}, []interface{}{49, 1}, []interface{}{50, 1}, []interface{}{51, 1}, []interface{}{52, 1}, []interface{}{53, 1}, []interface{}{54, 1}, []interface{}{55, 1}, []interface{}{56, 1}, []interface{}{57, 1}, []interface{}{58, 1}, []interface{}{59, 1}, []interface{}{60, 1}, []interface{}{61, 1}, []interface{}{62, 1}, []interface{}{63, 1}, []interface{}{64, 1}, []interface{}{65, 1}, []interface{}{66, 1}, []interface{}{67, 1}, []interface{}{68, 1}, []interface{}{69, 1}, []interface{}{70, 1}, []interface{}{71, 1}, []interface{}{72, 1}, []interface{}{73, 1}, []interface{}{74, 1}, []interface{}{75, 1}, []interface{}{76, 1}, []interface{}{77, 1}, []interface{}{78, 1}, []interface{}{79, 1}, []interface{}{80, 1}, []interface{}{81, 1}, []interface{}{82, 1}, []interface{}{83, 1}, []interface{}{84, 1}, []interface{}{85, 1}, []interface{}{86, 1}, []interface{}{87, 1}, []interface{}{88, 1}, []interface{}{89, 1}, []interface{}{90, 1}, []interface{}{91, 1}, []interface{}{92, 1}, []interface{}{93, 1}, []interface{}{94, 1}, []interface{}{95, 1}, []interface{}{96, 1}, []interface{}{97, 1}, []interface{}{98, 1}, []interface{}{99, 1}}}
 		/* tbl.group(index='id').count() */
 
 		suite.T().Log("About to run line #418: tbl.Group().OptArgs(r.GroupOpts{Index: 'id', }).Count()")
@@ -1233,7 +1233,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #425
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[0, 25], [1, 25], [2, 25], [3, 25]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 25}, []interface{}{1, 25}, []interface{}{2, 25}, []interface{}{3, 25}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{0, 25}, []interface{}{1, 25}, []interface{}{2, 25}, []interface{}{3, 25}}}
 		/* tbl.group(index='a').count() */
 
 		suite.T().Log("About to run line #425: tbl.Group().OptArgs(r.GroupOpts{Index: 'a', }).Count()")
@@ -1248,7 +1248,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #432
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[[0, 0], 1], [[0, 4], 1], [[0, 8], 1], [[0, 12], 1], [[0, 16], 1], [[0, 20], 1], [[0, 24], 1], [[0, 28], 1], [[0, 32], 1], [[0, 36], 1], [[0, 40], 1], [[0, 44], 1], [[0, 48], 1], [[0, 52], 1], [[0, 56], 1], [[0, 60], 1], [[0, 64], 1], [[0, 68], 1], [[0, 72], 1], [[0, 76], 1], [[0, 80], 1], [[0, 84], 1], [[0, 88], 1], [[0, 92], 1], [[0, 96], 1], [[1, 1], 1], [[1, 5], 1], [[1, 9], 1], [[1, 13], 1], [[1, 17], 1], [[1, 21], 1], [[1, 25], 1], [[1, 29], 1], [[1, 33], 1], [[1, 37], 1], [[1, 41], 1], [[1, 45], 1], [[1, 49], 1], [[1, 53], 1], [[1, 57], 1], [[1, 61], 1], [[1, 65], 1], [[1, 69], 1], [[1, 73], 1], [[1, 77], 1], [[1, 81], 1], [[1, 85], 1], [[1, 89], 1], [[1, 93], 1], [[1, 97], 1], [[2, 2], 1], [[2, 6], 1], [[2, 10], 1], [[2, 14], 1], [[2, 18], 1], [[2, 22], 1], [[2, 26], 1], [[2, 30], 1], [[2, 34], 1], [[2, 38], 1], [[2, 42], 1], [[2, 46], 1], [[2, 50], 1], [[2, 54], 1], [[2, 58], 1], [[2, 62], 1], [[2, 66], 1], [[2, 70], 1], [[2, 74], 1], [[2, 78], 1], [[2, 82], 1], [[2, 86], 1], [[2, 90], 1], [[2, 94], 1], [[2, 98], 1], [[3, 3], 1], [[3, 7], 1], [[3, 11], 1], [[3, 15], 1], [[3, 19], 1], [[3, 23], 1], [[3, 27], 1], [[3, 31], 1], [[3, 35], 1], [[3, 39], 1], [[3, 43], 1], [[3, 47], 1], [[3, 51], 1], [[3, 55], 1], [[3, 59], 1], [[3, 63], 1], [[3, 67], 1], [[3, 71], 1], [[3, 75], 1], [[3, 79], 1], [[3, 83], 1], [[3, 87], 1], [[3, 91], 1], [[3, 95], 1], [[3, 99], 1]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, 0}, 1}, []interface{}{[]interface{}{0, 4}, 1}, []interface{}{[]interface{}{0, 8}, 1}, []interface{}{[]interface{}{0, 12}, 1}, []interface{}{[]interface{}{0, 16}, 1}, []interface{}{[]interface{}{0, 20}, 1}, []interface{}{[]interface{}{0, 24}, 1}, []interface{}{[]interface{}{0, 28}, 1}, []interface{}{[]interface{}{0, 32}, 1}, []interface{}{[]interface{}{0, 36}, 1}, []interface{}{[]interface{}{0, 40}, 1}, []interface{}{[]interface{}{0, 44}, 1}, []interface{}{[]interface{}{0, 48}, 1}, []interface{}{[]interface{}{0, 52}, 1}, []interface{}{[]interface{}{0, 56}, 1}, []interface{}{[]interface{}{0, 60}, 1}, []interface{}{[]interface{}{0, 64}, 1}, []interface{}{[]interface{}{0, 68}, 1}, []interface{}{[]interface{}{0, 72}, 1}, []interface{}{[]interface{}{0, 76}, 1}, []interface{}{[]interface{}{0, 80}, 1}, []interface{}{[]interface{}{0, 84}, 1}, []interface{}{[]interface{}{0, 88}, 1}, []interface{}{[]interface{}{0, 92}, 1}, []interface{}{[]interface{}{0, 96}, 1}, []interface{}{[]interface{}{1, 1}, 1}, []interface{}{[]interface{}{1, 5}, 1}, []interface{}{[]interface{}{1, 9}, 1}, []interface{}{[]interface{}{1, 13}, 1}, []interface{}{[]interface{}{1, 17}, 1}, []interface{}{[]interface{}{1, 21}, 1}, []interface{}{[]interface{}{1, 25}, 1}, []interface{}{[]interface{}{1, 29}, 1}, []interface{}{[]interface{}{1, 33}, 1}, []interface{}{[]interface{}{1, 37}, 1}, []interface{}{[]interface{}{1, 41}, 1}, []interface{}{[]interface{}{1, 45}, 1}, []interface{}{[]interface{}{1, 49}, 1}, []interface{}{[]interface{}{1, 53}, 1}, []interface{}{[]interface{}{1, 57}, 1}, []interface{}{[]interface{}{1, 61}, 1}, []interface{}{[]interface{}{1, 65}, 1}, []interface{}{[]interface{}{1, 69}, 1}, []interface{}{[]interface{}{1, 73}, 1}, []interface{}{[]interface{}{1, 77}, 1}, []interface{}{[]interface{}{1, 81}, 1}, []interface{}{[]interface{}{1, 85}, 1}, []interface{}{[]interface{}{1, 89}, 1}, []interface{}{[]interface{}{1, 93}, 1}, []interface{}{[]interface{}{1, 97}, 1}, []interface{}{[]interface{}{2, 2}, 1}, []interface{}{[]interface{}{2, 6}, 1}, []interface{}{[]interface{}{2, 10}, 1}, []interface{}{[]interface{}{2, 14}, 1}, []interface{}{[]interface{}{2, 18}, 1}, []interface{}{[]interface{}{2, 22}, 1}, []interface{}{[]interface{}{2, 26}, 1}, []interface{}{[]interface{}{2, 30}, 1}, []interface{}{[]interface{}{2, 34}, 1}, []interface{}{[]interface{}{2, 38}, 1}, []interface{}{[]interface{}{2, 42}, 1}, []interface{}{[]interface{}{2, 46}, 1}, []interface{}{[]interface{}{2, 50}, 1}, []interface{}{[]interface{}{2, 54}, 1}, []interface{}{[]interface{}{2, 58}, 1}, []interface{}{[]interface{}{2, 62}, 1}, []interface{}{[]interface{}{2, 66}, 1}, []interface{}{[]interface{}{2, 70}, 1}, []interface{}{[]interface{}{2, 74}, 1}, []interface{}{[]interface{}{2, 78}, 1}, []interface{}{[]interface{}{2, 82}, 1}, []interface{}{[]interface{}{2, 86}, 1}, []interface{}{[]interface{}{2, 90}, 1}, []interface{}{[]interface{}{2, 94}, 1}, []interface{}{[]interface{}{2, 98}, 1}, []interface{}{[]interface{}{3, 3}, 1}, []interface{}{[]interface{}{3, 7}, 1}, []interface{}{[]interface{}{3, 11}, 1}, []interface{}{[]interface{}{3, 15}, 1}, []interface{}{[]interface{}{3, 19}, 1}, []interface{}{[]interface{}{3, 23}, 1}, []interface{}{[]interface{}{3, 27}, 1}, []interface{}{[]interface{}{3, 31}, 1}, []interface{}{[]interface{}{3, 35}, 1}, []interface{}{[]interface{}{3, 39}, 1}, []interface{}{[]interface{}{3, 43}, 1}, []interface{}{[]interface{}{3, 47}, 1}, []interface{}{[]interface{}{3, 51}, 1}, []interface{}{[]interface{}{3, 55}, 1}, []interface{}{[]interface{}{3, 59}, 1}, []interface{}{[]interface{}{3, 63}, 1}, []interface{}{[]interface{}{3, 67}, 1}, []interface{}{[]interface{}{3, 71}, 1}, []interface{}{[]interface{}{3, 75}, 1}, []interface{}{[]interface{}{3, 79}, 1}, []interface{}{[]interface{}{3, 83}, 1}, []interface{}{[]interface{}{3, 87}, 1}, []interface{}{[]interface{}{3, 91}, 1}, []interface{}{[]interface{}{3, 95}, 1}, []interface{}{[]interface{}{3, 99}, 1}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, 0}, 1}, []interface{}{[]interface{}{0, 4}, 1}, []interface{}{[]interface{}{0, 8}, 1}, []interface{}{[]interface{}{0, 12}, 1}, []interface{}{[]interface{}{0, 16}, 1}, []interface{}{[]interface{}{0, 20}, 1}, []interface{}{[]interface{}{0, 24}, 1}, []interface{}{[]interface{}{0, 28}, 1}, []interface{}{[]interface{}{0, 32}, 1}, []interface{}{[]interface{}{0, 36}, 1}, []interface{}{[]interface{}{0, 40}, 1}, []interface{}{[]interface{}{0, 44}, 1}, []interface{}{[]interface{}{0, 48}, 1}, []interface{}{[]interface{}{0, 52}, 1}, []interface{}{[]interface{}{0, 56}, 1}, []interface{}{[]interface{}{0, 60}, 1}, []interface{}{[]interface{}{0, 64}, 1}, []interface{}{[]interface{}{0, 68}, 1}, []interface{}{[]interface{}{0, 72}, 1}, []interface{}{[]interface{}{0, 76}, 1}, []interface{}{[]interface{}{0, 80}, 1}, []interface{}{[]interface{}{0, 84}, 1}, []interface{}{[]interface{}{0, 88}, 1}, []interface{}{[]interface{}{0, 92}, 1}, []interface{}{[]interface{}{0, 96}, 1}, []interface{}{[]interface{}{1, 1}, 1}, []interface{}{[]interface{}{1, 5}, 1}, []interface{}{[]interface{}{1, 9}, 1}, []interface{}{[]interface{}{1, 13}, 1}, []interface{}{[]interface{}{1, 17}, 1}, []interface{}{[]interface{}{1, 21}, 1}, []interface{}{[]interface{}{1, 25}, 1}, []interface{}{[]interface{}{1, 29}, 1}, []interface{}{[]interface{}{1, 33}, 1}, []interface{}{[]interface{}{1, 37}, 1}, []interface{}{[]interface{}{1, 41}, 1}, []interface{}{[]interface{}{1, 45}, 1}, []interface{}{[]interface{}{1, 49}, 1}, []interface{}{[]interface{}{1, 53}, 1}, []interface{}{[]interface{}{1, 57}, 1}, []interface{}{[]interface{}{1, 61}, 1}, []interface{}{[]interface{}{1, 65}, 1}, []interface{}{[]interface{}{1, 69}, 1}, []interface{}{[]interface{}{1, 73}, 1}, []interface{}{[]interface{}{1, 77}, 1}, []interface{}{[]interface{}{1, 81}, 1}, []interface{}{[]interface{}{1, 85}, 1}, []interface{}{[]interface{}{1, 89}, 1}, []interface{}{[]interface{}{1, 93}, 1}, []interface{}{[]interface{}{1, 97}, 1}, []interface{}{[]interface{}{2, 2}, 1}, []interface{}{[]interface{}{2, 6}, 1}, []interface{}{[]interface{}{2, 10}, 1}, []interface{}{[]interface{}{2, 14}, 1}, []interface{}{[]interface{}{2, 18}, 1}, []interface{}{[]interface{}{2, 22}, 1}, []interface{}{[]interface{}{2, 26}, 1}, []interface{}{[]interface{}{2, 30}, 1}, []interface{}{[]interface{}{2, 34}, 1}, []interface{}{[]interface{}{2, 38}, 1}, []interface{}{[]interface{}{2, 42}, 1}, []interface{}{[]interface{}{2, 46}, 1}, []interface{}{[]interface{}{2, 50}, 1}, []interface{}{[]interface{}{2, 54}, 1}, []interface{}{[]interface{}{2, 58}, 1}, []interface{}{[]interface{}{2, 62}, 1}, []interface{}{[]interface{}{2, 66}, 1}, []interface{}{[]interface{}{2, 70}, 1}, []interface{}{[]interface{}{2, 74}, 1}, []interface{}{[]interface{}{2, 78}, 1}, []interface{}{[]interface{}{2, 82}, 1}, []interface{}{[]interface{}{2, 86}, 1}, []interface{}{[]interface{}{2, 90}, 1}, []interface{}{[]interface{}{2, 94}, 1}, []interface{}{[]interface{}{2, 98}, 1}, []interface{}{[]interface{}{3, 3}, 1}, []interface{}{[]interface{}{3, 7}, 1}, []interface{}{[]interface{}{3, 11}, 1}, []interface{}{[]interface{}{3, 15}, 1}, []interface{}{[]interface{}{3, 19}, 1}, []interface{}{[]interface{}{3, 23}, 1}, []interface{}{[]interface{}{3, 27}, 1}, []interface{}{[]interface{}{3, 31}, 1}, []interface{}{[]interface{}{3, 35}, 1}, []interface{}{[]interface{}{3, 39}, 1}, []interface{}{[]interface{}{3, 43}, 1}, []interface{}{[]interface{}{3, 47}, 1}, []interface{}{[]interface{}{3, 51}, 1}, []interface{}{[]interface{}{3, 55}, 1}, []interface{}{[]interface{}{3, 59}, 1}, []interface{}{[]interface{}{3, 63}, 1}, []interface{}{[]interface{}{3, 67}, 1}, []interface{}{[]interface{}{3, 71}, 1}, []interface{}{[]interface{}{3, 75}, 1}, []interface{}{[]interface{}{3, 79}, 1}, []interface{}{[]interface{}{3, 83}, 1}, []interface{}{[]interface{}{3, 87}, 1}, []interface{}{[]interface{}{3, 91}, 1}, []interface{}{[]interface{}{3, 95}, 1}, []interface{}{[]interface{}{3, 99}, 1}}}
 		/* tbl.group('a', index='id').count() */
 
 		suite.T().Log("About to run line #432: tbl.Group('a').OptArgs(r.GroupOpts{Index: 'id', }).Count()")
@@ -1263,7 +1263,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #439
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[[0, 0], 25], [[1, 1], 25], [[2, 2], 25], [[3, 3], 25]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, 0}, 25}, []interface{}{[]interface{}{1, 1}, 25}, []interface{}{[]interface{}{2, 2}, 25}, []interface{}{[]interface{}{3, 3}, 25}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, 0}, 25}, []interface{}{[]interface{}{1, 1}, 25}, []interface{}{[]interface{}{2, 2}, 25}, []interface{}{[]interface{}{3, 3}, 25}}}
 		/* tbl.group('a', index='a').count() */
 
 		suite.T().Log("About to run line #439: tbl.Group('a').OptArgs(r.GroupOpts{Index: 'a', }).Count()")
@@ -1278,7 +1278,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #447
 		/* {'$reql_type$':'GROUPED_DATA', 'data':[[[0, "f", null, [0]], 25], [[0, "f", null, null], 25], [[0, "f", null, 0], 25], [[0, "f", null, {}], 25], [[1, "f", null, [0]], 25], [[1, "f", null, null], 25], [[1, "f", null, 0], 25], [[1, "f", null, {}], 25], [[2, "f", null, [0]], 25], [[2, "f", null, null], 25], [[2, "f", null, 0], 25], [[2, "f", null, {}], 25], [[3, "f", null, [0]], 25], [[3, "f", null, null], 25], [[3, "f", null, 0], 25], [[3, "f", null, {}], 25]]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{0, "f", nil, nil}, 25}, []interface{}{[]interface{}{0, "f", nil, 0}, 25}, []interface{}{[]interface{}{0, "f", nil, map[interface{}]interface{}{}}, 25}, []interface{}{[]interface{}{1, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{1, "f", nil, nil}, 25}, []interface{}{[]interface{}{1, "f", nil, 0}, 25}, []interface{}{[]interface{}{1, "f", nil, map[interface{}]interface{}{}}, 25}, []interface{}{[]interface{}{2, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{2, "f", nil, nil}, 25}, []interface{}{[]interface{}{2, "f", nil, 0}, 25}, []interface{}{[]interface{}{2, "f", nil, map[interface{}]interface{}{}}, 25}, []interface{}{[]interface{}{3, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{3, "f", nil, nil}, 25}, []interface{}{[]interface{}{3, "f", nil, 0}, 25}, []interface{}{[]interface{}{3, "f", nil, map[interface{}]interface{}{}}, 25}}}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GROUPED_DATA", "data": []interface{}{[]interface{}{[]interface{}{0, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{0, "f", nil, nil}, 25}, []interface{}{[]interface{}{0, "f", nil, 0}, 25}, []interface{}{[]interface{}{0, "f", nil, map[interface{}]interface{}{}}, 25}, []interface{}{[]interface{}{1, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{1, "f", nil, nil}, 25}, []interface{}{[]interface{}{1, "f", nil, 0}, 25}, []interface{}{[]interface{}{1, "f", nil, map[interface{}]interface{}{}}, 25}, []interface{}{[]interface{}{2, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{2, "f", nil, nil}, 25}, []interface{}{[]interface{}{2, "f", nil, 0}, 25}, []interface{}{[]interface{}{2, "f", nil, map[interface{}]interface{}{}}, 25}, []interface{}{[]interface{}{3, "f", nil, []interface{}{0}}, 25}, []interface{}{[]interface{}{3, "f", nil, nil}, 25}, []interface{}{[]interface{}{3, "f", nil, 0}, 25}, []interface{}{[]interface{}{3, "f", nil, map[interface{}]interface{}{}}, 25}}}
 		/* tbl.group('a', lambda row:'f', lambda row:[], lambda row:[{}, [0], null, 0], multi=True).count() */
 
 		suite.T().Log("About to run line #447: tbl.Group('a', func(row r.Term) interface{} { return 'f'}, func(row r.Term) interface{} { return []interface{}{}}, func(row r.Term) interface{} { return []interface{}{map[interface{}]interface{}{}, []interface{}{0}, nil, 0}}).OptArgs(r.GroupOpts{Multi: true, }).Count()")
@@ -1295,7 +1295,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #453
 		/* [{'group':0, 'reduction':25}, {'group':1, 'reduction':25}, {'group':2, 'reduction':25}, {'group':3, 'reduction':25}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"group": 0, "reduction": 25}, map[interface{}]interface{}{"group": 1, "reduction": 25}, map[interface{}]interface{}{"group": 2, "reduction": 25}, map[interface{}]interface{}{"group": 3, "reduction": 25}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"group": 0, "reduction": 25}, map[interface{}]interface{}{"group": 1, "reduction": 25}, map[interface{}]interface{}{"group": 2, "reduction": 25}, map[interface{}]interface{}{"group": 3, "reduction": 25}}
 		/* tbl.group('a').count().ungroup() */
 
 		suite.T().Log("About to run line #453: tbl.Group('a').Count().Ungroup()")
@@ -1310,7 +1310,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #456
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.group('a').ungroup()['group'] */
 
 		suite.T().Log("About to run line #456: tbl.Group('a').Ungroup().AtIndex('group')")
@@ -1325,7 +1325,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #460
 		/* [{'group':[0,0],'reduction':24},{'group':[1,1],'reduction':28},{'group':[2,2],'reduction':32},{'group':[3,3],'reduction':36}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"group": []interface{}{0, 0}, "reduction": 24}, map[interface{}]interface{}{"group": []interface{}{1, 1}, "reduction": 28}, map[interface{}]interface{}{"group": []interface{}{2, 2}, "reduction": 32}, map[interface{}]interface{}{"group": []interface{}{3, 3}, "reduction": 36}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"group": []interface{}{0, 0}, "reduction": 24}, map[interface{}]interface{}{"group": []interface{}{1, 1}, "reduction": 28}, map[interface{}]interface{}{"group": []interface{}{2, 2}, "reduction": 32}, map[interface{}]interface{}{"group": []interface{}{3, 3}, "reduction": 36}}
 		/* tbl.order_by(index='id').limit(16).group('a','a').map(r.row['id']).sum().ungroup() */
 
 		suite.T().Log("About to run line #460: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Limit(16).Group('a', 'a').Map(r.Row.AtIndex('id')).Sum().Ungroup()")
@@ -1340,7 +1340,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #465
 		/* [{'group':[0,null],'reduction':25},{'group':[1,null],'reduction':25},{'group':[2,null],'reduction':25},{'group':[3,null],'reduction':25}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"group": []interface{}{0, nil}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{1, nil}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{2, nil}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{3, nil}, "reduction": 25}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"group": []interface{}{0, nil}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{1, nil}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{2, nil}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{3, nil}, "reduction": 25}}
 		/* tbl.group('a', null).count().ungroup() */
 
 		suite.T().Log("About to run line #465: tbl.Group('a', nil).Count().Ungroup()")
@@ -1355,7 +1355,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #468
 		/* [{'group':[0,1],'reduction':25},{'group':[0,'two'],'reduction':25},{'group':[1,1],'reduction':25},{'group':[1,'two'],'reduction':25},{'group':[2,1],'reduction':25},{'group':[2,'two'],'reduction':25},{'group':[3,1],'reduction':25},{'group':[3,'two'],'reduction':25}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"group": []interface{}{0, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{0, "two"}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{1, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{1, "two"}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{2, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{2, "two"}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{3, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{3, "two"}, "reduction": 25}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"group": []interface{}{0, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{0, "two"}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{1, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{1, "two"}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{2, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{2, "two"}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{3, 1}, "reduction": 25}, map[interface{}]interface{}{"group": []interface{}{3, "two"}, "reduction": 25}}
 		/* tbl.group('a', lambda row:[1,'two'], multi=True).count().ungroup() */
 
 		suite.T().Log("About to run line #468: tbl.Group('a', func(row r.Term) interface{} { return []interface{}{1, 'two'}}).OptArgs(r.GroupOpts{Multi: true, }).Count().Ungroup()")
@@ -1370,7 +1370,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #474
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #474: tbl.Count()")
@@ -1385,7 +1385,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #478
 		/* partial({'errors':0, 'replaced':67}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 67})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 67})
 		/* tbl.filter(r.row['a'].ne(1).and_(r.row['id'].gt(10))).update({'b':r.row['a'] * 10}) */
 
 		suite.T().Log("About to run line #478: tbl.Filter(r.Row.AtIndex('a').Ne(1).And(r.Row.AtIndex('id').Gt(10))).Update(map[interface{}]interface{}{'b': r.Row.AtIndex('a').Mul(10), })")
@@ -1400,7 +1400,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #487
 		/* {0:0, 2:440, 3:690} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 0, 2: 440, 3: 690}
+		var expected_ = map[interface{}]interface{}{0: 0, 2: 440, 3: 690}
 		/* tbl.group('a').sum('b') */
 
 		suite.T().Log("About to run line #487: tbl.Group('a').Sum('b')")
@@ -1415,7 +1415,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #492
 		/* {0:0, 2:20, 3:30} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: 0, 2: 20, 3: 30}
+		var expected_ = map[interface{}]interface{}{0: 0, 2: 20, 3: 30}
 		/* tbl.group('a').avg('b') */
 
 		suite.T().Log("About to run line #492: tbl.Group('a').Avg('b')")
@@ -1430,7 +1430,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #497
 		/* {0:{"a":0, "b":0, "id":12}, 2:{"a":2, "b":20, "id":14}, 3:{"a":3, "b":30, "id":11}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "b": 0, "id": 12}, 2: map[interface{}]interface{}{"a": 2, "b": 20, "id": 14}, 3: map[interface{}]interface{}{"a": 3, "b": 30, "id": 11}}
+		var expected_ = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "b": 0, "id": 12}, 2: map[interface{}]interface{}{"a": 2, "b": 20, "id": 14}, 3: map[interface{}]interface{}{"a": 3, "b": 30, "id": 11}}
 		/* tbl.order_by('id').group('a').min('b') */
 
 		suite.T().Log("About to run line #497: tbl.OrderBy('id').Group('a').Min('b')")
@@ -1445,7 +1445,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #502
 		/* {0:{"a":0, "id":0}, 1:{"a":1, "id":1}, 2:{"a":2, "id":2}, 3:{"a":3, "id":3}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 0}, 1: map[interface{}]interface{}{"a": 1, "id": 1}, 2: map[interface{}]interface{}{"a": 2, "id": 2}, 3: map[interface{}]interface{}{"a": 3, "id": 3}}
+		var expected_ = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "id": 0}, 1: map[interface{}]interface{}{"a": 1, "id": 1}, 2: map[interface{}]interface{}{"a": 2, "id": 2}, 3: map[interface{}]interface{}{"a": 3, "id": 3}}
 		/* tbl.order_by('id').group('a').min('id') */
 
 		suite.T().Log("About to run line #502: tbl.OrderBy('id').Group('a').Min('id')")
@@ -1460,7 +1460,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #507
 		/* {0:{"a":0, "b":0, "id":12}, 2:{"a":2, "b":20, "id":14}, 3:{"a":3, "b":30, "id":11}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "b": 0, "id": 12}, 2: map[interface{}]interface{}{"a": 2, "b": 20, "id": 14}, 3: map[interface{}]interface{}{"a": 3, "b": 30, "id": 11}}
+		var expected_ = map[interface{}]interface{}{0: map[interface{}]interface{}{"a": 0, "b": 0, "id": 12}, 2: map[interface{}]interface{}{"a": 2, "b": 20, "id": 14}, 3: map[interface{}]interface{}{"a": 3, "b": 30, "id": 11}}
 		/* tbl.order_by('id').group('a').max('b') */
 
 		suite.T().Log("About to run line #507: tbl.OrderBy('id').Group('a').Max('b')")
@@ -1475,7 +1475,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #512
 		/* {'a':0,'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0, "id": 0}
+		var expected_ = map[interface{}]interface{}{"a": 0, "id": 0}
 		/* tbl.min() */
 
 		suite.T().Log("About to run line #512: tbl.Min()")
@@ -1490,7 +1490,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #514
 		/* {'a':0,'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0, "id": 0}
+		var expected_ = map[interface{}]interface{}{"a": 0, "id": 0}
 		/* tbl.min(index='id') */
 
 		suite.T().Log("About to run line #514: tbl.Min().OptArgs(r.MinOpts{Index: 'id', })")
@@ -1505,7 +1505,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #518
 		/* {'a':0,'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0, "id": 0}
+		var expected_ = map[interface{}]interface{}{"a": 0, "id": 0}
 		/* tbl.min(index='a') */
 
 		suite.T().Log("About to run line #518: tbl.Min().OptArgs(r.MinOpts{Index: 'a', })")
@@ -1520,7 +1520,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #523
 		/* {'a':3,'id':99} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 3, "id": 99}
+		var expected_ = map[interface{}]interface{}{"a": 3, "id": 99}
 		/* tbl.max().without('b') */
 
 		suite.T().Log("About to run line #523: tbl.Max().Without('b')")
@@ -1535,7 +1535,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #525
 		/* {'a':3,'id':99} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 3, "id": 99}
+		var expected_ = map[interface{}]interface{}{"a": 3, "id": 99}
 		/* tbl.max(index='id').without('b') */
 
 		suite.T().Log("About to run line #525: tbl.Max().OptArgs(r.MaxOpts{Index: 'id', }).Without('b')")
@@ -1550,7 +1550,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #529
 		/* {'a':3,'id':99} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 3, "id": 99}
+		var expected_ = map[interface{}]interface{}{"a": 3, "id": 99}
 		/* tbl.max(index='a').without('b') */
 
 		suite.T().Log("About to run line #529: tbl.Max().OptArgs(r.MaxOpts{Index: 'a', }).Without('b')")
@@ -1565,7 +1565,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #537
 		/* [ {'group': 1, 'reduction': 2}, {'group': 2, 'reduction': 1} ] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"group": 1, "reduction": 2}, map[interface{}]interface{}{"group": 2, "reduction": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"group": 1, "reduction": 2}, map[interface{}]interface{}{"group": 2, "reduction": 1}}
 		/* r.group([ 1, 1, 2 ], r.row).count().ungroup() */
 
 		suite.T().Log("About to run line #537: r.Group([]interface{}{1, 1, 2}, r.Row).Count().Ungroup()")
@@ -1580,7 +1580,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #541
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.count([ 1, 2 ]) */
 
 		suite.T().Log("About to run line #541: r.Count([]interface{}{1, 2})")
@@ -1595,7 +1595,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #542
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.count([ 1, 2 ], r.row.gt(0)) */
 
 		suite.T().Log("About to run line #542: r.Count([]interface{}{1, 2}, r.Row.Gt(0))")
@@ -1610,7 +1610,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #548
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.sum([ 1, 2 ]) */
 
 		suite.T().Log("About to run line #548: r.Sum([]interface{}{1, 2})")
@@ -1625,7 +1625,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #549
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.sum([ 1, 2 ], r.row) */
 
 		suite.T().Log("About to run line #549: r.Sum([]interface{}{1, 2}, r.Row)")
@@ -1640,7 +1640,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #553
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* r.avg([ 1, 2 ]) */
 
 		suite.T().Log("About to run line #553: r.Avg([]interface{}{1, 2})")
@@ -1655,7 +1655,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #554
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* r.avg([ 1, 2 ], r.row) */
 
 		suite.T().Log("About to run line #554: r.Avg([]interface{}{1, 2}, r.Row)")
@@ -1670,7 +1670,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #558
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.min([ 1, 2 ]) */
 
 		suite.T().Log("About to run line #558: r.Min([]interface{}{1, 2})")
@@ -1685,7 +1685,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #559
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.min([ 1, 2 ], r.row) */
 
 		suite.T().Log("About to run line #559: r.Min([]interface{}{1, 2}, r.Row)")
@@ -1700,7 +1700,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #563
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.max([ 1, 2 ]) */
 
 		suite.T().Log("About to run line #563: r.Max([]interface{}{1, 2})")
@@ -1715,7 +1715,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #564
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.max([ 1, 2 ], r.row) */
 
 		suite.T().Log("About to run line #564: r.Max([]interface{}{1, 2}, r.Row)")
@@ -1730,7 +1730,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #567
 		/* [ 1 ] */
-		var expected_ []interface{} = []interface{}{1}
+		var expected_ = []interface{}{1}
 		/* r.distinct([ 1, 1 ]) */
 
 		suite.T().Log("About to run line #567: r.Distinct([]interface{}{1, 1})")
@@ -1745,7 +1745,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #570
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.contains([ 1, 2 ]) */
 
 		suite.T().Log("About to run line #570: r.Contains([]interface{}{1, 2})")
@@ -1760,7 +1760,7 @@ func (suite *AggregationSuite) TestCases() {
 	{
 		// aggregation.yaml line #571
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.contains([ 1, 2 ], r.row.gt(0)) */
 
 		suite.T().Log("About to run line #571: r.Contains([]interface{}{1, 2}, r.Row.Gt(0))")

--- a/internal/integration/reql_tests/reql_arity_test.go
+++ b/internal/integration/reql_tests/reql_arity_test.go
@@ -91,7 +91,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #43
 		/* err("ReqlQueryLogicError", "Empty ERROR term outside a default block.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Empty ERROR term outside a default block.")
+		var expected_ = err("ReqlQueryLogicError", "Empty ERROR term outside a default block.")
 		/* r.error() */
 
 		suite.T().Log("About to run line #43: r.Error()")
@@ -106,7 +106,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #96
 		/* err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:")
 		/* db.table_drop() */
 
 		suite.T().Log("About to run line #96: db.TableDrop()")
@@ -121,7 +121,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #209
 		/* err("ReqlQueryLogicError", "Cannot call `branch` term with an even number of arguments.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot call `branch` term with an even number of arguments.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot call `branch` term with an even number of arguments.")
 		/* r.branch(1,2,3,4) */
 
 		suite.T().Log("About to run line #209: r.Branch(1, 2, 3, 4)")
@@ -136,7 +136,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #220
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* tbl.insert([{'id':0},{'id':1},{'id':2},{'id':3},{'id':4},{'id':5},{'id':6},{'id':7},{'id':8},{'id':9}]).get_field('inserted') */
 
 		suite.T().Log("About to run line #220: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 0, }, map[interface{}]interface{}{'id': 1, }, map[interface{}]interface{}{'id': 2, }, map[interface{}]interface{}{'id': 3, }, map[interface{}]interface{}{'id': 4, }, map[interface{}]interface{}{'id': 5, }, map[interface{}]interface{}{'id': 6, }, map[interface{}]interface{}{'id': 7, }, map[interface{}]interface{}{'id': 8, }, map[interface{}]interface{}{'id': 9, }}).Field('inserted')")
@@ -151,7 +151,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #223
 		/* bag([0, 1, 2]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{0, 1, 2})
+		var expected_ = compare.UnorderedMatch([]interface{}{0, 1, 2})
 		/* tbl.get_all(0, 1, 2).get_field('id') */
 
 		suite.T().Log("About to run line #223: tbl.GetAll(0, 1, 2).Field('id')")
@@ -166,7 +166,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #226
 		/* bag([0, 1, 2]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{0, 1, 2})
+		var expected_ = compare.UnorderedMatch([]interface{}{0, 1, 2})
 		/* tbl.get_all(r.args([]), 0, 1, 2).get_field('id') */
 
 		suite.T().Log("About to run line #226: tbl.GetAll(r.Args([]interface{}{}), 0, 1, 2).Field('id')")
@@ -181,7 +181,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #229
 		/* bag([0, 1, 2]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{0, 1, 2})
+		var expected_ = compare.UnorderedMatch([]interface{}{0, 1, 2})
 		/* tbl.get_all(r.args([0]), 1, 2).get_field('id') */
 
 		suite.T().Log("About to run line #229: tbl.GetAll(r.Args([]interface{}{0}), 1, 2).Field('id')")
@@ -196,7 +196,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #232
 		/* bag([0, 1, 2]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{0, 1, 2})
+		var expected_ = compare.UnorderedMatch([]interface{}{0, 1, 2})
 		/* tbl.get_all(r.args([0, 1]), 2).get_field('id') */
 
 		suite.T().Log("About to run line #232: tbl.GetAll(r.Args([]interface{}{0, 1}), 2).Field('id')")
@@ -211,7 +211,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #235
 		/* bag([0, 1, 2]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{0, 1, 2})
+		var expected_ = compare.UnorderedMatch([]interface{}{0, 1, 2})
 		/* tbl.get_all(r.args([0, 1, 2])).get_field('id') */
 
 		suite.T().Log("About to run line #235: tbl.GetAll(r.Args([]interface{}{0, 1, 2})).Field('id')")
@@ -226,7 +226,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #238
 		/* bag([0, 1, 2]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{0, 1, 2})
+		var expected_ = compare.UnorderedMatch([]interface{}{0, 1, 2})
 		/* tbl.get_all(r.args([0]), 1, r.args([2])).get_field('id') */
 
 		suite.T().Log("About to run line #238: tbl.GetAll(r.Args([]interface{}{0}), 1, r.Args([]interface{}{2})).Field('id')")
@@ -241,7 +241,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #243
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch(true, 1, r.error("a")) */
 
 		suite.T().Log("About to run line #243: r.Branch(true, 1, r.Error('a'))")
@@ -256,7 +256,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #246
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch(r.args([true, 1]), r.error("a")) */
 
 		suite.T().Log("About to run line #246: r.Branch(r.Args([]interface{}{true, 1}), r.Error('a'))")
@@ -271,7 +271,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #249
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(true).branch(1, 2) */
 
 		suite.T().Log("About to run line #249: r.Expr(true).Branch(1, 2)")
@@ -286,7 +286,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #252
 		/* err("ReqlUserError", "a", []) */
-		var expected_ Err = err("ReqlUserError", "a")
+		var expected_ = err("ReqlUserError", "a")
 		/* r.branch(r.args([true, 1, r.error("a")])) */
 
 		suite.T().Log("About to run line #252: r.Branch(r.Args([]interface{}{true, 1, r.Error('a')}))")
@@ -301,7 +301,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #258
 		/* ([{'group':0, 'reduction':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"group": 0, "reduction": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"group": 0, "reduction": 1}}
 		/* tbl.group(lambda row:row['id'].mod(2)).count({'id':0}).ungroup() */
 
 		suite.T().Log("About to run line #258: tbl.Group(func(row r.Term) interface{} { return row.AtIndex('id').Mod(2)}).Count(map[interface{}]interface{}{'id': 0, }).Ungroup()")
@@ -316,7 +316,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #263
 		/* ([{'group':0, 'reduction':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"group": 0, "reduction": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"group": 0, "reduction": 1}}
 		/* tbl.group(r.row['id'].mod(2)).count(r.args([{'id':0}])).ungroup() */
 
 		suite.T().Log("About to run line #263: tbl.Group(r.Row.AtIndex('id').Mod(2)).Count(r.Args([]interface{}{map[interface{}]interface{}{'id': 0, }})).Ungroup()")
@@ -331,7 +331,7 @@ func (suite *AritySuite) TestCases() {
 	{
 		// arity.yaml line #269
 		/* ({'a':{'c':1}}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": map[interface{}]interface{}{"c": 1}}
+		var expected_ = map[interface{}]interface{}{"a": map[interface{}]interface{}{"c": 1}}
 		/* r.expr({'a':{'b':1}}).merge(r.args([{'a':r.literal({'c':1})}])) */
 
 		suite.T().Log("About to run line #269: r.Expr(map[interface{}]interface{}{'a': map[interface{}]interface{}{'b': 1, }, }).Merge(r.Args([]interface{}{map[interface{}]interface{}{'a': r.Literal(map[interface{}]interface{}{'c': 1, }), }}))")

--- a/internal/integration/reql_tests/reql_changefeeds_edge_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_edge_test.go
@@ -77,7 +77,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #8
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('sindex', lambda row:common_prefix.append(row['value'])) */
 
 		suite.T().Log("About to run line #8: tbl.IndexCreateFunc('sindex', func(row r.Term) interface{} { return common_prefix.Append(row.AtIndex('value'))})")
@@ -92,7 +92,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #11
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait('sindex') */
 
 		suite.T().Log("About to run line #11: tbl.IndexWait('sindex')")
@@ -226,7 +226,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #83
 		/* err('ReqlQueryLogicError', 'Cannot call `changes` after a non-deterministic function.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot call `changes` after a non-deterministic function.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot call `changes` after a non-deterministic function.")
 		/* tbl.map(nondetermmap).changes(squash=False) */
 
 		suite.T().Log("About to run line #83: tbl.Map(nondetermmap).Changes().OptArgs(r.ChangesOpts{Squash: false, })")
@@ -248,7 +248,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #92
 		/* err('ReqlQueryLogicError', 'Cannot call `changes` after a non-deterministic function.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot call `changes` after a non-deterministic function.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot call `changes` after a non-deterministic function.")
 		/* tbl.filter(nondetermfilter).changes(squash=False) */
 
 		suite.T().Log("About to run line #92: tbl.Filter(nondetermfilter).Changes().OptArgs(r.ChangesOpts{Squash: false, })")
@@ -270,7 +270,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #100
 		/* ({'skipped':0,'deleted':0,'unchanged':0,'errors':0,'replaced':0,'inserted':101}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"skipped": 0, "deleted": 0, "unchanged": 0, "errors": 0, "replaced": 0, "inserted": 101}
+		var expected_ = map[interface{}]interface{}{"skipped": 0, "deleted": 0, "unchanged": 0, "errors": 0, "replaced": 0, "inserted": 101}
 		/* tbl.insert(r.range(101).map({'id':r.uuid().coerce_to('binary').slice(0,r.random(4,24)).coerce_to('string'),'value':r.row.coerce_to('string')})) */
 
 		suite.T().Log("About to run line #100: tbl.Insert(r.Range(101).Map(map[interface{}]interface{}{'id': r.UUID().CoerceTo('binary').Slice(0, r.Random(4, 24)).CoerceTo('string'), 'value': r.Row.CoerceTo('string'), }))")
@@ -285,7 +285,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #105
 		/* bag(pre) */
-		var expected_ compare.Expected = compare.UnorderedMatch(pre)
+		var expected_ = compare.UnorderedMatch(pre)
 		/* pre_changes */
 
 		suite.T().Log("About to run line #105: pre_changes")
@@ -300,7 +300,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #108
 		/* bag(mid) */
-		var expected_ compare.Expected = compare.UnorderedMatch(mid)
+		var expected_ = compare.UnorderedMatch(mid)
 		/* mid_changes */
 
 		suite.T().Log("About to run line #108: mid_changes")
@@ -315,7 +315,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #111
 		/* bag(post) */
-		var expected_ compare.Expected = compare.UnorderedMatch(post)
+		var expected_ = compare.UnorderedMatch(post)
 		/* post_changes */
 
 		suite.T().Log("About to run line #111: post_changes")
@@ -330,7 +330,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #114
 		/* bag(erroredres) */
-		var expected_ compare.Expected = compare.UnorderedMatch(erroredres)
+		var expected_ = compare.UnorderedMatch(erroredres)
 		/* premap_changes1 */
 
 		suite.T().Log("About to run line #114: premap_changes1")
@@ -345,7 +345,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #117
 		/* bag(erroredres) */
-		var expected_ compare.Expected = compare.UnorderedMatch(erroredres)
+		var expected_ = compare.UnorderedMatch(erroredres)
 		/* premap_changes2 */
 
 		suite.T().Log("About to run line #117: premap_changes2")
@@ -360,7 +360,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #120
 		/* err('ReqlNonExistenceError', "No attribute `dummy` in object:") */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `dummy` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `dummy` in object:")
 		/* postmap_changes1 */
 
 		suite.T().Log("About to run line #120: postmap_changes1")
@@ -375,7 +375,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #123
 		/* err('ReqlNonExistenceError', "Index out of bounds:" + " 1") */
-		var expected_ Err = err("ReqlNonExistenceError", "Index out of bounds:"+" 1")
+		var expected_ = err("ReqlNonExistenceError", "Index out of bounds:"+" 1")
 		/* postmap_changes2 */
 
 		suite.T().Log("About to run line #123: postmap_changes2")
@@ -390,7 +390,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #126
 		/* err('ReqlUserError', "dummy") */
-		var expected_ Err = err("ReqlUserError", "dummy")
+		var expected_ = err("ReqlUserError", "dummy")
 		/* postmap_changes3 */
 
 		suite.T().Log("About to run line #126: postmap_changes3")
@@ -405,7 +405,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #129
 		/* bag(erroredres) */
-		var expected_ compare.Expected = compare.UnorderedMatch(erroredres)
+		var expected_ = compare.UnorderedMatch(erroredres)
 		/* prefilter_changes1 */
 
 		suite.T().Log("About to run line #129: prefilter_changes1")
@@ -420,7 +420,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #132
 		/* bag(erroredres) */
-		var expected_ compare.Expected = compare.UnorderedMatch(erroredres)
+		var expected_ = compare.UnorderedMatch(erroredres)
 		/* prefilter_changes2 */
 
 		suite.T().Log("About to run line #132: prefilter_changes2")
@@ -435,7 +435,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #135
 		/* bag(erroredres) */
-		var expected_ compare.Expected = compare.UnorderedMatch(erroredres)
+		var expected_ = compare.UnorderedMatch(erroredres)
 		/* postfilter_changes1 */
 
 		suite.T().Log("About to run line #135: postfilter_changes1")
@@ -450,7 +450,7 @@ func (suite *ChangefeedsEdgeSuite) TestCases() {
 	{
 		// changefeeds/edge.yaml line #138
 		/* bag(erroredres) */
-		var expected_ compare.Expected = compare.UnorderedMatch(erroredres)
+		var expected_ = compare.UnorderedMatch(erroredres)
 		/* postfilter_changes2 */
 
 		suite.T().Log("About to run line #138: postfilter_changes2")

--- a/internal/integration/reql_tests/reql_changefeeds_idxcopy_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_idxcopy_test.go
@@ -70,7 +70,7 @@ func (suite *ChangefeedsIdxcopySuite) TestCases() {
 	{
 		// changefeeds/idxcopy.yaml line #4
 		/* partial({'created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"created": 1})
 		/* tbl.index_create('a') */
 
 		suite.T().Log("About to run line #4: tbl.IndexCreate('a')")
@@ -85,7 +85,7 @@ func (suite *ChangefeedsIdxcopySuite) TestCases() {
 	{
 		// changefeeds/idxcopy.yaml line #6
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait('a') */
 
 		suite.T().Log("About to run line #6: tbl.IndexWait('a')")
@@ -109,7 +109,7 @@ func (suite *ChangefeedsIdxcopySuite) TestCases() {
 	{
 		// changefeeds/idxcopy.yaml line #15
 		/* partial({'inserted':12, 'errors':0}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"inserted": 12, "errors": 0})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"inserted": 12, "errors": 0})
 		/* tbl.insert(r.range(0, 12).map({'id':r.row, 'a':5})) */
 
 		suite.T().Log("About to run line #15: tbl.Insert(r.Range(0, 12).Map(map[interface{}]interface{}{'id': r.Row, 'a': 5, }))")
@@ -124,7 +124,7 @@ func (suite *ChangefeedsIdxcopySuite) TestCases() {
 	{
 		// changefeeds/idxcopy.yaml line #20
 		/* partial({'deleted':3, 'errors':0}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"deleted": 3, "errors": 0})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"deleted": 3, "errors": 0})
 		/* tbl.get_all(1, 8, 9, index='id').delete() */
 
 		suite.T().Log("About to run line #20: tbl.GetAll(1, 8, 9).OptArgs(r.GetAllOpts{Index: 'id', }).Delete()")
@@ -139,7 +139,7 @@ func (suite *ChangefeedsIdxcopySuite) TestCases() {
 	{
 		// changefeeds/idxcopy.yaml line #26
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* wait(2) */
 
 		suite.T().Log("About to run line #26: wait(2)")

--- a/internal/integration/reql_tests/reql_changefeeds_include_states_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_include_states_test.go
@@ -70,7 +70,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #4
 		/* [{'state':'ready'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "ready"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "ready"}}
 		/* tbl.changes(squash=true, include_states=true).limit(1) */
 
 		suite.T().Log("About to run line #4: tbl.Changes().OptArgs(r.ChangesOpts{Squash: true, IncludeStates: true, }).Limit(1)")
@@ -85,7 +85,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #9
 		/* [{'state':'initializing'}, {'new_val':null}, {'state':'ready'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": nil}, map[interface{}]interface{}{"state": "ready"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": nil}, map[interface{}]interface{}{"state": "ready"}}
 		/* tbl.get(0).changes(squash=true, include_states=true, include_initial=true).limit(3) */
 
 		suite.T().Log("About to run line #9: tbl.Get(0).Changes().OptArgs(r.ChangesOpts{Squash: true, IncludeStates: true, IncludeInitial: true, }).Limit(3)")
@@ -100,7 +100,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #14
 		/* [{'state':'initializing'}, {'state':'ready'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"state": "ready"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"state": "ready"}}
 		/* tbl.order_by(index='id').limit(10).changes(squash=true, include_states=true, include_initial=true).limit(2) */
 
 		suite.T().Log("About to run line #14: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Limit(10).Changes().OptArgs(r.ChangesOpts{Squash: true, IncludeStates: true, IncludeInitial: true, }).Limit(2)")
@@ -115,7 +115,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #19
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.insert({'id':1}) */
 
 		suite.T().Log("About to run line #19: tbl.Insert(map[interface{}]interface{}{'id': 1, })")
@@ -130,7 +130,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #21
 		/* [{'state':'initializing'}, {'new_val':{'id':1}}, {'state':'ready'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"state": "ready"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"state": "ready"}}
 		/* tbl.order_by(index='id').limit(10).changes(squash=true, include_states=true, include_initial=true).limit(3) */
 
 		suite.T().Log("About to run line #21: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Limit(10).Changes().OptArgs(r.ChangesOpts{Squash: true, IncludeStates: true, IncludeInitial: true, }).Limit(3)")
@@ -152,7 +152,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #30
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.insert({'id':2}) */
 
 		suite.T().Log("About to run line #30: tbl.Insert(map[interface{}]interface{}{'id': 2, })")
@@ -167,7 +167,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #32
 		/* [{'state':'ready'},{'new_val':{'id':2},'old_val':null}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 2}, "old_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 2}, "old_val": nil}}
 		/* fetch(tblchanges, 2) */
 
 		suite.T().Log("About to run line #32: fetch(tblchanges, 2)")
@@ -186,7 +186,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #39
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get(2).update({'a':1}) */
 
 		suite.T().Log("About to run line #39: tbl.Get(2).Update(map[interface{}]interface{}{'a': 1, })")
@@ -201,7 +201,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #41
 		/* [{'state':'initializing'}, {'new_val':{'id':2}}, {'state':'ready'}, {'old_val':{'id':2},'new_val':{'id':2,'a':1}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 2}, "new_val": map[interface{}]interface{}{"id": 2, "a": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 2}, "new_val": map[interface{}]interface{}{"id": 2, "a": 1}}}
 		/* fetch(getchanges, 4) */
 
 		suite.T().Log("About to run line #41: fetch(getchanges, 4)")
@@ -227,7 +227,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #52
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.insert({'id':3}) */
 
 		suite.T().Log("About to run line #52: tbl.Insert(map[interface{}]interface{}{'id': 3, })")
@@ -242,7 +242,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #54
 		/* [{'state':'initializing'}, {'new_val':{'id':1}}, {'new_val':{'a':1, 'id':2}}, {'state':'ready'}, {'old_val':null, 'new_val':{'id':3}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 2}}, map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 3}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 2}}, map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 3}}}
 		/* fetch(limitchanges, 5) */
 
 		suite.T().Log("About to run line #54: fetch(limitchanges, 5)")
@@ -254,7 +254,7 @@ func (suite *ChangefeedsIncludeStatesSuite) TestCases() {
 	{
 		// changefeeds/include_states.yaml line #57
 		/* [{'state':'initializing'}, {'new_val':{'a':1, 'id':2}}, {'new_val':{'id':1}}, {'state':'ready'}, {'old_val':null, 'new_val':{'id':3}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 2}}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 3}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"state": "initializing"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 2}}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"state": "ready"}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 3}}}
 		/* fetch(limitchangesdesc, 5) */
 
 		suite.T().Log("About to run line #57: fetch(limitchangesdesc, 5)")

--- a/internal/integration/reql_tests/reql_changefeeds_now_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_now_test.go
@@ -70,7 +70,7 @@ func (suite *ChangefeedsNowSuite) TestCases() {
 	{
 		// changefeeds/now.py_one.yaml line #8
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.merge({'a': r.now()}).changes() */
 
 		suite.T().Log("About to run line #8: tbl.Merge(map[interface{}]interface{}{'a': r.Now(), }).Changes()")

--- a/internal/integration/reql_tests/reql_changefeeds_point_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_point_test.go
@@ -77,7 +77,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #14
 		/* [{'new_val':null}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"new_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"new_val": nil}}
 		/* fetch(basic, 1) */
 
 		suite.T().Log("About to run line #14: fetch(basic, 1)")
@@ -89,7 +89,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #19
 		/* partial({'errors':0, 'inserted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
 		/* tbl.insert({'id':1}) */
 
 		suite.T().Log("About to run line #19: tbl.Insert(map[interface{}]interface{}{'id': 1, })")
@@ -104,7 +104,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #22
 		/* [{'old_val':null, 'new_val':{'id':1}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}}
 		/* fetch(basic, 1) */
 
 		suite.T().Log("About to run line #22: fetch(basic, 1)")
@@ -116,7 +116,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #27
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* tbl.get(1).update({'update':1}) */
 
 		suite.T().Log("About to run line #27: tbl.Get(1).Update(map[interface{}]interface{}{'update': 1, })")
@@ -131,7 +131,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #30
 		/* [{'old_val':{'id':1}, 'new_val':{'id':1,'update':1}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "update": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "update": 1}}}
 		/* fetch(basic, 1) */
 
 		suite.T().Log("About to run line #30: fetch(basic, 1)")
@@ -143,7 +143,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #35
 		/* partial({'errors':0, 'deleted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
 		/* tbl.get(1).delete() */
 
 		suite.T().Log("About to run line #35: tbl.Get(1).Delete()")
@@ -158,7 +158,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #38
 		/* [{'old_val':{'id':1,'update':1}, 'new_val':null}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "update": 1}, "new_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "update": 1}, "new_val": nil}}
 		/* fetch(basic, 1) */
 
 		suite.T().Log("About to run line #38: fetch(basic, 1)")
@@ -177,7 +177,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #53
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.insert({'id':1, 'update':1}) */
 
 		suite.T().Log("About to run line #53: tbl.Insert(map[interface{}]interface{}{'id': 1, 'update': 1, })")
@@ -192,7 +192,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #54
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get(1).update({'update':4}) */
 
 		suite.T().Log("About to run line #54: tbl.Get(1).Update(map[interface{}]interface{}{'update': 4, })")
@@ -207,7 +207,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #55
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get(1).update({'update':1}) */
 
 		suite.T().Log("About to run line #55: tbl.Get(1).Update(map[interface{}]interface{}{'update': 1, })")
@@ -222,7 +222,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #56
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get(1).update({'update':7}) */
 
 		suite.T().Log("About to run line #56: tbl.Get(1).Update(map[interface{}]interface{}{'update': 7, })")
@@ -237,7 +237,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #58
 		/* [4,7] */
-		var expected_ []interface{} = []interface{}{4, 7}
+		var expected_ = []interface{}{4, 7}
 		/* fetch(filter, 2) */
 
 		suite.T().Log("About to run line #58: fetch(filter, 2)")
@@ -256,7 +256,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #67
 		/* partial({'errors':0, 'inserted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
 		/* tbl.insert({'id':3, 'red':1, 'green':1}) */
 
 		suite.T().Log("About to run line #67: tbl.Insert(map[interface{}]interface{}{'id': 3, 'red': 1, 'green': 1, })")
@@ -271,7 +271,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #69
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* tbl.get(3).update({'blue':2, 'green':3}) */
 
 		suite.T().Log("About to run line #69: tbl.Get(3).Update(map[interface{}]interface{}{'blue': 2, 'green': 3, })")
@@ -286,7 +286,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #71
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* tbl.get(3).update({'green':4}) */
 
 		suite.T().Log("About to run line #71: tbl.Get(3).Update(map[interface{}]interface{}{'green': 4, })")
@@ -301,7 +301,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #73
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* tbl.get(3).update({'blue':4}) */
 
 		suite.T().Log("About to run line #73: tbl.Get(3).Update(map[interface{}]interface{}{'blue': 4, })")
@@ -316,7 +316,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #76
 		/* [{'red': 1}, {'blue': 2, 'red': 1}, {'blue': 2, 'red': 1}, {'blue': 4, 'red': 1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"red": 1}, map[interface{}]interface{}{"blue": 2, "red": 1}, map[interface{}]interface{}{"blue": 2, "red": 1}, map[interface{}]interface{}{"blue": 4, "red": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"red": 1}, map[interface{}]interface{}{"blue": 2, "red": 1}, map[interface{}]interface{}{"blue": 2, "red": 1}, map[interface{}]interface{}{"blue": 4, "red": 1}}
 		/* fetch(pluck, 4) */
 
 		suite.T().Log("About to run line #76: fetch(pluck, 4)")
@@ -342,7 +342,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #88
 		/* [{'new_val':null}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"new_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"new_val": nil}}
 		/* fetch(debug, 1) */
 
 		suite.T().Log("About to run line #88: fetch(debug, 1)")
@@ -354,7 +354,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #91
 		/* partial({'errors':0, 'inserted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
 		/* dtbl.insert({'id':1}) */
 
 		suite.T().Log("About to run line #91: dtbl.Insert(map[interface{}]interface{}{'id': 1, })")
@@ -369,7 +369,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #93
 		/* [{'old_val':null, 'new_val':{'id':1}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}}
 		/* fetch(debug, 1) */
 
 		suite.T().Log("About to run line #93: fetch(debug, 1)")
@@ -381,7 +381,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #96
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* dtbl.get(1).update({'update':1}) */
 
 		suite.T().Log("About to run line #96: dtbl.Get(1).Update(map[interface{}]interface{}{'update': 1, })")
@@ -396,7 +396,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #98
 		/* [{'old_val':{'id':1}, 'new_val':{'id':1,'update':1}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "update": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "update": 1}}}
 		/* fetch(debug, 1) */
 
 		suite.T().Log("About to run line #98: fetch(debug, 1)")
@@ -408,7 +408,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #101
 		/* partial({'errors':0, 'deleted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
 		/* dtbl.get(1).delete() */
 
 		suite.T().Log("About to run line #101: dtbl.Get(1).Delete()")
@@ -423,7 +423,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #103
 		/* [{'old_val':{'id':1,'update':1}, 'new_val':null}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "update": 1}, "new_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "update": 1}, "new_val": nil}}
 		/* fetch(debug, 1) */
 
 		suite.T().Log("About to run line #103: fetch(debug, 1)")
@@ -435,7 +435,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #106
 		/* {'skipped':0, 'deleted':0, 'unchanged':0, 'errors':0, 'replaced':0, 'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"skipped": 0, "deleted": 0, "unchanged": 0, "errors": 0, "replaced": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"skipped": 0, "deleted": 0, "unchanged": 0, "errors": 0, "replaced": 0, "inserted": 1}
 		/* dtbl.insert({'id':5, 'red':1, 'green':1}) */
 
 		suite.T().Log("About to run line #106: dtbl.Insert(map[interface{}]interface{}{'id': 5, 'red': 1, 'green': 1, })")
@@ -457,7 +457,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #113
 		/* [{'red':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"red": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"red": 1}}
 		/* fetch(dtblPluck, 1) */
 
 		suite.T().Log("About to run line #113: fetch(dtblPluck, 1)")
@@ -469,7 +469,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #116
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* dtbl.get(5).update({'blue':2, 'green':3}) */
 
 		suite.T().Log("About to run line #116: dtbl.Get(5).Update(map[interface{}]interface{}{'blue': 2, 'green': 3, })")
@@ -484,7 +484,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #119
 		/* [{'blue':2, 'red':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"blue": 2, "red": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"blue": 2, "red": 1}}
 		/* fetch(dtblPluck, 1) */
 
 		suite.T().Log("About to run line #119: fetch(dtblPluck, 1)")
@@ -510,7 +510,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #137
 		/* partial([{'new_val':partial({'db':'test'})}]) */
-		var expected_ compare.Expected = compare.PartialMatch([]interface{}{map[interface{}]interface{}{"new_val": compare.PartialMatch(map[interface{}]interface{}{"db": "test"})}})
+		var expected_ = compare.PartialMatch([]interface{}{map[interface{}]interface{}{"new_val": compare.PartialMatch(map[interface{}]interface{}{"db": "test"})}})
 		/* fetch(rtblPluck, 1) */
 
 		suite.T().Log("About to run line #137: fetch(rtblPluck, 1)")
@@ -522,7 +522,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #140
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.reconfigure(shards=3, replicas=1) */
 
 		suite.T().Log("About to run line #140: tbl.Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 3, Replicas: 1, })")
@@ -537,7 +537,7 @@ func (suite *ChangefeedsPointSuite) TestCases() {
 	{
 		// changefeeds/point.yaml line #143
 		/* partial([{'old_val':partial({'db':'test'}), 'new_val':partial({'db':'test'})}]) */
-		var expected_ compare.Expected = compare.PartialMatch([]interface{}{map[interface{}]interface{}{"old_val": compare.PartialMatch(map[interface{}]interface{}{"db": "test"}), "new_val": compare.PartialMatch(map[interface{}]interface{}{"db": "test"})}})
+		var expected_ = compare.PartialMatch([]interface{}{map[interface{}]interface{}{"old_val": compare.PartialMatch(map[interface{}]interface{}{"db": "test"}), "new_val": compare.PartialMatch(map[interface{}]interface{}{"db": "test"})}})
 		/* fetch(rtblPluck, 1, 2) */
 
 		suite.T().Log("About to run line #143: fetch(rtblPluck, 1)")

--- a/internal/integration/reql_tests/reql_changefeeds_squash_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_squash_test.go
@@ -70,7 +70,7 @@ func (suite *ChangefeedsSquashSuite) TestCases() {
 	{
 		// changefeeds/squash.yaml line #7
 		/* ("STREAM") */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* tbl.changes(squash=true).type_of() */
 
 		suite.T().Log("About to run line #7: tbl.Changes().OptArgs(r.ChangesOpts{Squash: true, }).TypeOf()")
@@ -113,7 +113,7 @@ func (suite *ChangefeedsSquashSuite) TestCases() {
 	{
 		// changefeeds/squash.yaml line #28
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.insert({'id':100})['inserted'] */
 
 		suite.T().Log("About to run line #28: tbl.Insert(map[interface{}]interface{}{'id': 100, }).AtIndex('inserted')")
@@ -128,7 +128,7 @@ func (suite *ChangefeedsSquashSuite) TestCases() {
 	{
 		// changefeeds/squash.yaml line #32
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get(100).update({'a':1})['replaced'] */
 
 		suite.T().Log("About to run line #32: tbl.Get(100).Update(map[interface{}]interface{}{'a': 1, }).AtIndex('replaced')")
@@ -144,7 +144,7 @@ func (suite *ChangefeedsSquashSuite) TestCases() {
 		// changefeeds/squash.yaml line #36
 		/* ([{'new_val':{'id':100}, 'old_val':null},
 		{'new_val':{'a':1, 'id':100}, 'old_val':{'id':100}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 100}, "old_val": nil}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 100}, "old_val": map[interface{}]interface{}{"id": 100}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 100}, "old_val": nil}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 100}, "old_val": map[interface{}]interface{}{"id": 100}}}
 		/* normal_changes */
 
 		suite.T().Log("About to run line #36: normal_changes")
@@ -160,7 +160,7 @@ func (suite *ChangefeedsSquashSuite) TestCases() {
 		// changefeeds/squash.yaml line #40
 		/* ([{'new_val':{'id':100}, 'old_val':null},
 		{'new_val':{'a':1, 'id':100}, 'old_val':{'id':100}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 100}, "old_val": nil}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 100}, "old_val": map[interface{}]interface{}{"id": 100}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 100}, "old_val": nil}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 100}, "old_val": map[interface{}]interface{}{"id": 100}}}
 		/* false_squash_changes */
 
 		suite.T().Log("About to run line #40: false_squash_changes")
@@ -175,7 +175,7 @@ func (suite *ChangefeedsSquashSuite) TestCases() {
 	{
 		// changefeeds/squash.yaml line #44
 		/* ([{'new_val':{'a':1, 'id':100}, 'old_val':null}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 100}, "old_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"a": 1, "id": 100}, "old_val": nil}}
 		/* long_squash_changes */
 
 		suite.T().Log("About to run line #44: long_squash_changes")
@@ -190,7 +190,7 @@ func (suite *ChangefeedsSquashSuite) TestCases() {
 	{
 		// changefeeds/squash.yaml line #59
 		/* err('ReqlQueryLogicError', 'Expected BOOL or a positive NUMBER but found a negative NUMBER.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected BOOL or a positive NUMBER but found a negative NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected BOOL or a positive NUMBER but found a negative NUMBER.")
 		/* tbl.changes(squash=-10) */
 
 		suite.T().Log("About to run line #59: tbl.Changes().OptArgs(r.ChangesOpts{Squash: -10, })")

--- a/internal/integration/reql_tests/reql_changefeeds_table_test.go
+++ b/internal/integration/reql_tests/reql_changefeeds_table_test.go
@@ -77,7 +77,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #15
 		/* partial({'errors':0, 'inserted':2}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 2})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 2})
 		/* tbl.insert([{'id':1}, {'id':2}]) */
 
 		suite.T().Log("About to run line #15: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 1, }, map[interface{}]interface{}{'id': 2, }})")
@@ -92,7 +92,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #17
 		/* bag([{'old_val':null, 'new_val':{'id':1}}, {'old_val':null, 'new_val':{'id':2}}]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 2}}})
+		var expected_ = compare.UnorderedMatch([]interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 2}}})
 		/* fetch(all, 2) */
 
 		suite.T().Log("About to run line #17: fetch(all, 2)")
@@ -104,7 +104,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #22
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* tbl.get(1).update({'version':1}) */
 
 		suite.T().Log("About to run line #22: tbl.Get(1).Update(map[interface{}]interface{}{'version': 1, })")
@@ -119,7 +119,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #24
 		/* [{'old_val':{'id':1}, 'new_val':{'id':1, 'version':1}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "version": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "version": 1}}}
 		/* fetch(all, 1) */
 
 		suite.T().Log("About to run line #24: fetch(all, 1)")
@@ -131,7 +131,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #29
 		/* partial({'errors':0, 'deleted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
 		/* tbl.get(1).delete() */
 
 		suite.T().Log("About to run line #29: tbl.Get(1).Delete()")
@@ -146,7 +146,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #31
 		/* [{'old_val':{'id':1, 'version':1}, 'new_val':null}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "version": 1}, "new_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "version": 1}, "new_val": nil}}
 		/* fetch(all, 1) */
 
 		suite.T().Log("About to run line #31: fetch(all, 1)")
@@ -165,7 +165,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #37
 		/* partial({'errors':0, 'inserted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
 		/* tbl.insert([{'id':5, 'version':5}]) */
 
 		suite.T().Log("About to run line #37: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 5, 'version': 5, }})")
@@ -180,7 +180,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #39
 		/* [{'new_val':{'version':5}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"version": 5}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"version": 5}}}
 		/* fetch(pluck, 1) */
 
 		suite.T().Log("About to run line #39: fetch(pluck, 1)")
@@ -192,7 +192,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #44
 		/* err('ReqlQueryLogicError', "Cannot call a terminal (`reduce`, `count`, etc.) on an infinite stream (such as a changefeed).") */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot call a terminal (`reduce`, `count`, etc.) on an infinite stream (such as a changefeed).")
+		var expected_ = err("ReqlQueryLogicError", "Cannot call a terminal (`reduce`, `count`, etc.) on an infinite stream (such as a changefeed).")
 		/* tbl.changes().order_by('id') */
 
 		suite.T().Log("About to run line #44: tbl.Changes().OrderBy('id')")
@@ -216,7 +216,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #64
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.insert(r.range(200).map(lambda x: {})) */
 
 		suite.T().Log("About to run line #64: tbl.Insert(r.Range(200).Map(func(x r.Term) interface{} { return map[interface{}]interface{}{}}))")
@@ -231,7 +231,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #66
 		/* partial([{'error': regex('Changefeed cache over array size limit, skipped \d+ elements.')}]) */
-		var expected_ compare.Expected = compare.PartialMatch([]interface{}{map[interface{}]interface{}{"error": compare.MatchesRegexp("Changefeed cache over array size limit, skipped \\d+ elements.")}})
+		var expected_ = compare.PartialMatch([]interface{}{map[interface{}]interface{}{"error": compare.MatchesRegexp("Changefeed cache over array size limit, skipped \\d+ elements.")}})
 		/* fetch(overflow, 90) */
 
 		suite.T().Log("About to run line #66: fetch(overflow, 90)")
@@ -257,7 +257,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #76
 		/* partial({'errors':0, 'inserted':2}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 2})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 2})
 		/* vtbl.insert([{'id':1}, {'id':2}]) */
 
 		suite.T().Log("About to run line #76: vtbl.Insert([]interface{}{map[interface{}]interface{}{'id': 1, }, map[interface{}]interface{}{'id': 2, }})")
@@ -272,7 +272,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #78
 		/* bag([{'old_val':null, 'new_val':{'id':1}}, {'old_val':null, 'new_val':{'id':2}}]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 2}}})
+		var expected_ = compare.UnorderedMatch([]interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 2}}})
 		/* fetch(allVirtual, 2) */
 
 		suite.T().Log("About to run line #78: fetch(allVirtual, 2)")
@@ -284,7 +284,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #83
 		/* partial({'errors':0, 'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "replaced": 1})
 		/* vtbl.get(1).update({'version':1}) */
 
 		suite.T().Log("About to run line #83: vtbl.Get(1).Update(map[interface{}]interface{}{'version': 1, })")
@@ -299,7 +299,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #85
 		/* [{'old_val':{'id':1}, 'new_val':{'id':1, 'version':1}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "version": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "version": 1}}}
 		/* fetch(allVirtual, 1) */
 
 		suite.T().Log("About to run line #85: fetch(allVirtual, 1)")
@@ -311,7 +311,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #90
 		/* partial({'errors':0, 'deleted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "deleted": 1})
 		/* vtbl.get(1).delete() */
 
 		suite.T().Log("About to run line #90: vtbl.Get(1).Delete()")
@@ -326,7 +326,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #92
 		/* [{'old_val':{'id':1, 'version':1}, 'new_val':null}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "version": 1}, "new_val": nil}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1, "version": 1}, "new_val": nil}}
 		/* fetch(allVirtual, 1) */
 
 		suite.T().Log("About to run line #92: fetch(allVirtual, 1)")
@@ -345,7 +345,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #98
 		/* partial({'errors':0, 'inserted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 1})
 		/* vtbl.insert([{'id':5, 'version':5}]) */
 
 		suite.T().Log("About to run line #98: vtbl.Insert([]interface{}{map[interface{}]interface{}{'id': 5, 'version': 5, }})")
@@ -360,7 +360,7 @@ func (suite *ChangefeedsTableSuite) TestCases() {
 	{
 		// changefeeds/table.yaml line #100
 		/* [{'new_val':{'version':5}}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"version": 5}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"version": 5}}}
 		/* fetch(vpluck, 1) */
 
 		suite.T().Log("About to run line #100: fetch(vpluck, 1)")

--- a/internal/integration/reql_tests/reql_control_test.go
+++ b/internal/integration/reql_tests/reql_control_test.go
@@ -78,7 +78,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #7
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(1).do(lambda v: v * 2) */
 
 		suite.T().Log("About to run line #7: r.Expr(1).Do(func(v r.Term) interface{} { return r.Mul(v, 2)})")
@@ -93,7 +93,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #12
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* r.expr([0, 1, 2]).do(lambda v: v.append(3)) */
 
 		suite.T().Log("About to run line #12: r.Expr([]interface{}{0, 1, 2}).Do(func(v r.Term) interface{} { return v.Append(3)})")
@@ -108,7 +108,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #17
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.do(1, 2, lambda x, y: x + y) */
 
 		suite.T().Log("About to run line #17: r.Do(1, 2, func(x r.Term, y r.Term) interface{} { return r.Add(x, y)})")
@@ -123,7 +123,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #22
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.do(lambda: 1) */
 
 		suite.T().Log("About to run line #22: r.Do(func() interface{} { return 1})")
@@ -138,7 +138,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #38
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.do(1) */
 
 		suite.T().Log("About to run line #38: r.Do(1)")
@@ -153,7 +153,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #53
 		/* err("ReqlQueryLogicError", "Expected type ARRAY but found STRING.", [1, 0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type ARRAY but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type ARRAY but found STRING.")
 		/* r.expr('abc').do(lambda v: v.append(3)) */
 
 		suite.T().Log("About to run line #53: r.Expr('abc').Do(func(v r.Term) interface{} { return v.Append(3)})")
@@ -168,7 +168,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #58
 		/* err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.", [1, 1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
 		/* r.expr('abc').do(lambda v: v + 3) */
 
 		suite.T().Log("About to run line #58: r.Expr('abc').Do(func(v r.Term) interface{} { return r.Add(v, 3)})")
@@ -183,7 +183,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #63
 		/* err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.", [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
 		/* r.expr('abc').do(lambda v: v + 'def') + 3 */
 
 		suite.T().Log("About to run line #63: r.Expr('abc').Do(func(v r.Term) interface{} { return r.Add(v, 'def')}).Add(3)")
@@ -198,7 +198,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #78
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* r.expr(5).do(r.row) */
 
 		suite.T().Log("About to run line #78: r.Expr(5).Do(r.Row)")
@@ -213,7 +213,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #84
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch(True, 1, 2) */
 
 		suite.T().Log("About to run line #84: r.Branch(true, 1, 2)")
@@ -228,7 +228,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #86
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.branch(False, 1, 2) */
 
 		suite.T().Log("About to run line #86: r.Branch(false, 1, 2)")
@@ -243,7 +243,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #88
 		/* ("c") */
-		var expected_ string = "c"
+		var expected_ = "c"
 		/* r.branch(1, 'c', False) */
 
 		suite.T().Log("About to run line #88: r.Branch(1, 'c', false)")
@@ -258,7 +258,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #90
 		/* ([]) */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.branch(null, {}, []) */
 
 		suite.T().Log("About to run line #90: r.Branch(nil, map[interface{}]interface{}{}, []interface{}{})")
@@ -273,7 +273,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #93
 		/* err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:")
 		/* r.branch(r.db('test'), 1, 2) */
 
 		suite.T().Log("About to run line #93: r.Branch(r.DB('test'), 1, 2)")
@@ -288,7 +288,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #95
 		/* err("ReqlQueryLogicError", "Expected type DATUM but found TABLE:", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type DATUM but found TABLE:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type DATUM but found TABLE:")
 		/* r.branch(tbl, 1, 2) */
 
 		suite.T().Log("About to run line #95: r.Branch(tbl, 1, 2)")
@@ -303,7 +303,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #97
 		/* err("ReqlUserError", "a", []) */
-		var expected_ Err = err("ReqlUserError", "a")
+		var expected_ = err("ReqlUserError", "a")
 		/* r.branch(r.error("a"), 1, 2) */
 
 		suite.T().Log("About to run line #97: r.Branch(r.Error('a'), 1, 2)")
@@ -318,7 +318,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #100
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch([], 1, 2) */
 
 		suite.T().Log("About to run line #100: r.Branch([]interface{}{}, 1, 2)")
@@ -333,7 +333,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #102
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch({}, 1, 2) */
 
 		suite.T().Log("About to run line #102: r.Branch(map[interface{}]interface{}{}, 1, 2)")
@@ -348,7 +348,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #104
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch("a", 1, 2) */
 
 		suite.T().Log("About to run line #104: r.Branch('a', 1, 2)")
@@ -363,7 +363,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #106
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch(1.2, 1, 2) */
 
 		suite.T().Log("About to run line #106: r.Branch(1.2, 1, 2)")
@@ -378,7 +378,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #109
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch(True, 1, True, 2, 3) */
 
 		suite.T().Log("About to run line #109: r.Branch(true, 1, true, 2, 3)")
@@ -393,7 +393,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #111
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.branch(True, 1, False, 2, 3) */
 
 		suite.T().Log("About to run line #111: r.Branch(true, 1, false, 2, 3)")
@@ -408,7 +408,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #113
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.branch(False, 1, True, 2, 3) */
 
 		suite.T().Log("About to run line #113: r.Branch(false, 1, true, 2, 3)")
@@ -423,7 +423,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #115
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.branch(False, 1, False, 2, 3) */
 
 		suite.T().Log("About to run line #115: r.Branch(false, 1, false, 2, 3)")
@@ -438,7 +438,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #118
 		/* err("ReqlQueryLogicError", "Cannot call `branch` term with an even number of arguments.") */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot call `branch` term with an even number of arguments.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot call `branch` term with an even number of arguments.")
 		/* r.branch(True, 1, True, 2) */
 
 		suite.T().Log("About to run line #118: r.Branch(true, 1, true, 2)")
@@ -453,7 +453,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #122
 		/* err("ReqlUserError", "Hello World", [0]) */
-		var expected_ Err = err("ReqlUserError", "Hello World")
+		var expected_ = err("ReqlUserError", "Hello World")
 		/* r.error('Hello World') */
 
 		suite.T().Log("About to run line #122: r.Error('Hello World')")
@@ -468,7 +468,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #125
 		/* err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
 		/* r.error(5) */
 
 		suite.T().Log("About to run line #125: r.Error(5)")
@@ -483,7 +483,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #140
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.js('1 + 1') */
 
 		suite.T().Log("About to run line #140: r.JS('1 + 1')")
@@ -498,7 +498,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #143
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* r.js('1 + 1; 2 + 2') */
 
 		suite.T().Log("About to run line #143: r.JS('1 + 1; 2 + 2')")
@@ -513,7 +513,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #146
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.do(1, 2, r.js('(function(a, b) { return a + b; })')) */
 
 		suite.T().Log("About to run line #146: r.Do(1, 2, r.JS('(function(a, b) { return a + b; })'))")
@@ -528,7 +528,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #149
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(1).do(r.js('(function(x) { return x + 1; })')) */
 
 		suite.T().Log("About to run line #149: r.Expr(1).Do(r.JS('(function(x) { return x + 1; })'))")
@@ -543,7 +543,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #152
 		/* 'foobar' */
-		var expected_ string = "foobar"
+		var expected_ = "foobar"
 		/* r.expr('foo').do(r.js('(function(x) { return x + "bar"; })')) */
 
 		suite.T().Log("About to run line #152: r.Expr('foo').Do(r.JS('(function(x) { return x + \\'bar\\'; })'))")
@@ -558,7 +558,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #157
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.js('1 + 2', timeout=1.2) */
 
 		suite.T().Log("About to run line #157: r.JS('1 + 2').OptArgs(r.JSOpts{Timeout: 1.2, })")
@@ -573,7 +573,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #161
 		/* err("ReqlQueryLogicError", "Query result must be of type DATUM, GROUPED_DATA, or STREAM (got FUNCTION).", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Query result must be of type DATUM, GROUPED_DATA, or STREAM (got FUNCTION).")
+		var expected_ = err("ReqlQueryLogicError", "Query result must be of type DATUM, GROUPED_DATA, or STREAM (got FUNCTION).")
 		/* r.js('(function() { return 1; })') */
 
 		suite.T().Log("About to run line #161: r.JS('(function() { return 1; })')")
@@ -588,7 +588,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #164
 		/* err("ReqlQueryLogicError", "SyntaxError: Unexpected token (", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "SyntaxError: Unexpected token (")
+		var expected_ = err("ReqlQueryLogicError", "SyntaxError: Unexpected token (")
 		/* r.js('function() { return 1; }') */
 
 		suite.T().Log("About to run line #164: r.JS('function() { return 1; }')")
@@ -603,7 +603,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #168
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.do(1, 2, r.js('(function(a) { return a; })')) */
 
 		suite.T().Log("About to run line #168: r.Do(1, 2, r.JS('(function(a) { return a; })'))")
@@ -618,7 +618,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #171
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.do(1, 2, r.js('(function(a, b, c) { return a; })')) */
 
 		suite.T().Log("About to run line #171: r.Do(1, 2, r.JS('(function(a, b, c) { return a; })'))")
@@ -633,7 +633,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #174
 		/* err("ReqlQueryLogicError", "Cannot convert javascript `undefined` to ql::datum_t.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert javascript `undefined` to ql::datum_t.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert javascript `undefined` to ql::datum_t.")
 		/* r.do(1, 2, r.js('(function(a, b, c) { return c; })')) */
 
 		suite.T().Log("About to run line #174: r.Do(1, 2, r.JS('(function(a, b, c) { return c; })'))")
@@ -648,7 +648,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #177
 		/* ([2, 3]) */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* r.expr([1, 2, 3]).filter(r.js('(function(a) { return a >= 2; })')) */
 
 		suite.T().Log("About to run line #177: r.Expr([]interface{}{1, 2, 3}).Filter(r.JS('(function(a) { return a >= 2; })'))")
@@ -663,7 +663,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #180
 		/* ([2, 3, 4]) */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* r.expr([1, 2, 3]).map(r.js('(function(a) { return a + 1; })')) */
 
 		suite.T().Log("About to run line #180: r.Expr([]interface{}{1, 2, 3}).Map(r.JS('(function(a) { return a + 1; })'))")
@@ -678,7 +678,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #183
 		/* err("ReqlQueryLogicError", "Expected type FUNCTION but found DATUM:", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type FUNCTION but found DATUM:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type FUNCTION but found DATUM:")
 		/* r.expr([1, 2, 3]).map(r.js('1')) */
 
 		suite.T().Log("About to run line #183: r.Expr([]interface{}{1, 2, 3}).Map(r.JS('1'))")
@@ -693,7 +693,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #186
 		/* err("ReqlQueryLogicError", "Cannot convert javascript `undefined` to ql::datum_t.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert javascript `undefined` to ql::datum_t.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert javascript `undefined` to ql::datum_t.")
 		/* r.expr([1, 2, 3]).filter(r.js('(function(a) {})')) */
 
 		suite.T().Log("About to run line #186: r.Expr([]interface{}{1, 2, 3}).Filter(r.JS('(function(a) {})'))")
@@ -708,7 +708,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #190
 		/* err("ReqlQueryLogicError", "Expected type FUNCTION but found DATUM:", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type FUNCTION but found DATUM:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type FUNCTION but found DATUM:")
 		/* r.expr([1, 2, 3]).map(1) */
 
 		suite.T().Log("About to run line #190: r.Expr([]interface{}{1, 2, 3}).Map(1)")
@@ -723,7 +723,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #193
 		/* ([1, 2, 3]) */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.expr([1, 2, 3]).filter('foo') */
 
 		suite.T().Log("About to run line #193: r.Expr([]interface{}{1, 2, 3}).Filter('foo')")
@@ -738,7 +738,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #195
 		/* ([1, 2, 4]) */
-		var expected_ []interface{} = []interface{}{1, 2, 4}
+		var expected_ = []interface{}{1, 2, 4}
 		/* r.expr([1, 2, 4]).filter([]) */
 
 		suite.T().Log("About to run line #195: r.Expr([]interface{}{1, 2, 4}).Filter([]interface{}{})")
@@ -753,7 +753,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #197
 		/* ([]) */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr([1, 2, 3]).filter(null) */
 
 		suite.T().Log("About to run line #197: r.Expr([]interface{}{1, 2, 3}).Filter(nil)")
@@ -768,7 +768,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #200
 		/* ([]) */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr([1, 2, 4]).filter(False) */
 
 		suite.T().Log("About to run line #200: r.Expr([]interface{}{1, 2, 4}).Filter(false)")
@@ -783,7 +783,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #205
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #205: tbl.Count()")
@@ -798,7 +798,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #210
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':3}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 3}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 3}
 		/* r.expr([1, 2, 3]).for_each(lambda row:tbl.insert({ 'id':row })) */
 
 		suite.T().Log("About to run line #210: r.Expr([]interface{}{1, 2, 3}).ForEach(func(row r.Term) interface{} { return tbl.Insert(map[interface{}]interface{}{'id': row, })})")
@@ -813,7 +813,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #214
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #214: tbl.Count()")
@@ -828,7 +828,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #219
 		/* ({'deleted':0.0,'replaced':9,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 9, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 9, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* r.expr([1,2,3]).for_each(lambda row:tbl.update({'foo':row})) */
 
 		suite.T().Log("About to run line #219: r.Expr([]interface{}{1, 2, 3}).ForEach(func(row r.Term) interface{} { return tbl.Update(map[interface{}]interface{}{'foo': row, })})")
@@ -843,7 +843,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #225
 		/* {'first_error':"Duplicate primary key `id`:\n{\n\t\"foo\":\t3,\n\t\"id\":\t1\n}\n{\n\t\"id\":\t1\n}",'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':3,'skipped':0.0,'inserted':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"foo\":\t3,\n\t\"id\":\t1\n}\n{\n\t\"id\":\t1\n}", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 3, "skipped": 0.0, "inserted": 3}
+		var expected_ = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"foo\":\t3,\n\t\"id\":\t1\n}\n{\n\t\"id\":\t1\n}", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 3, "skipped": 0.0, "inserted": 3}
 		/* r.expr([1,2,3]).for_each(lambda row:[tbl.insert({ 'id':row }), tbl.insert({ 'id':row*10 })]) */
 
 		suite.T().Log("About to run line #225: r.Expr([]interface{}{1, 2, 3}).ForEach(func(row r.Term) interface{} { return []interface{}{tbl.Insert(map[interface{}]interface{}{'id': row, }), tbl.Insert(map[interface{}]interface{}{'id': r.Mul(row, 10), })}})")
@@ -860,7 +860,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #229
 		/* 6 */
-		var expected_ int = 6
+		var expected_ = 6
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #229: tbl.Count()")
@@ -882,7 +882,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #233
 		/* ({'deleted':0.0,'replaced':0.0,'generated_keys':arrlen(3,uuid()),'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':3}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "generated_keys": arrlen(3, compare.IsUUID()), "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 3}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "generated_keys": arrlen(3, compare.IsUUID()), "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 3}
 		/* r.expr([1, 2, 3]).for_each( tbl2.insert({}) ) */
 
 		suite.T().Log("About to run line #233: r.Expr([]interface{}{1, 2, 3}).ForEach(tbl2.Insert(map[interface{}]interface{}{}))")
@@ -897,7 +897,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #241
 		/* ({'deleted':0.0,'replaced':36,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 36, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 36, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* r.expr([1,2,3]).for_each(lambda row:[tbl.update({'foo':row}), tbl.update({'bar':row})]) */
 
 		suite.T().Log("About to run line #241: r.Expr([]interface{}{1, 2, 3}).ForEach(func(row r.Term) interface{} { return []interface{}{tbl.Update(map[interface{}]interface{}{'foo': row, }), tbl.Update(map[interface{}]interface{}{'bar': row, })}})")
@@ -914,7 +914,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #246
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':3}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 3}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 3}
 		/* r.expr([1, 2, 3]).for_each( tbl2.insert({ 'id':r.row }) ) */
 
 		suite.T().Log("About to run line #246: r.Expr([]interface{}{1, 2, 3}).ForEach(tbl2.Insert(map[interface{}]interface{}{'id': r.Row, }))")
@@ -929,7 +929,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #250
 		/* err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.")
 		/* r.expr([1, 2, 3]).for_each(1) */
 
 		suite.T().Log("About to run line #250: r.Expr([]interface{}{1, 2, 3}).ForEach(1)")
@@ -944,7 +944,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #253
 		/* err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.", [1, 1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.")
 		/* r.expr([1, 2, 3]).for_each(lambda x:x) */
 
 		suite.T().Log("About to run line #253: r.Expr([]interface{}{1, 2, 3}).ForEach(func(x r.Term) interface{} { return x})")
@@ -959,7 +959,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #258
 		/* err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.", [1, 1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.  Expected type ARRAY but found NUMBER.")
 		/* r.expr([1, 2, 3]).for_each(r.row) */
 
 		suite.T().Log("About to run line #258: r.Expr([]interface{}{1, 2, 3}).ForEach(r.Row)")
@@ -974,7 +974,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #263
 		/* err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.", [1, 1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.")
+		var expected_ = err("ReqlQueryLogicError", "FOR_EACH expects one or more basic write queries.")
 		/* r.expr([1, 2, 3]).for_each(lambda row:tbl) */
 
 		suite.T().Log("About to run line #263: r.Expr([]interface{}{1, 2, 3}).ForEach(func(row r.Term) interface{} { return tbl})")
@@ -989,7 +989,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #272
 		/* ({'deleted':0.0,'replaced':0.0,'generated_keys':arrlen(1,uuid()),'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
 		/* r.expr(1).do(tbl.insert({'foo':r.row})) */
 
 		suite.T().Log("About to run line #272: r.Expr(1).Do(tbl.Insert(map[interface{}]interface{}{'foo': r.Row, }))")
@@ -1004,7 +1004,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #276
 		/* ({'deleted':0.0,'replaced':0.0,'generated_keys':arrlen(1,uuid()),'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
 		/* r.expr([1, 2])[0].do(tbl.insert({'foo':r.row})) */
 
 		suite.T().Log("About to run line #276: r.Expr([]interface{}{1, 2}).AtIndex(0).Do(tbl.Insert(map[interface{}]interface{}{'foo': r.Row, }))")
@@ -1019,7 +1019,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #281
 		/* err('ReqlCompileError', 'Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.', [0]) */
-		var expected_ Err = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
+		var expected_ = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
 		/* r.expr([1, 2]).map(tbl.insert({'foo':r.row})) */
 
 		suite.T().Log("About to run line #281: r.Expr([]interface{}{1, 2}).Map(tbl.Insert(map[interface{}]interface{}{'foo': r.Row, }))")
@@ -1034,7 +1034,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #285
 		/* err('ReqlCompileError', 'Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.', [0]) */
-		var expected_ Err = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
+		var expected_ = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
 		/* r.expr([1, 2]).map(r.db('test').table_create('table_create_failure')) */
 
 		suite.T().Log("About to run line #285: r.Expr([]interface{}{1, 2}).Map(r.DB('test').TableCreate('table_create_failure'))")
@@ -1049,7 +1049,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #288
 		/* err('ReqlCompileError', 'Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.', [0]) */
-		var expected_ Err = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
+		var expected_ = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
 		/* r.expr([1, 2]).map(tbl.insert({'foo':r.row}).get_field('inserted')) */
 
 		suite.T().Log("About to run line #288: r.Expr([]interface{}{1, 2}).Map(tbl.Insert(map[interface{}]interface{}{'foo': r.Row, }).Field('inserted'))")
@@ -1064,7 +1064,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #292
 		/* err('ReqlCompileError', 'Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.', [0]) */
-		var expected_ Err = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
+		var expected_ = err("ReqlCompileError", "Cannot nest writes or meta ops in stream operations.  Use FOR_EACH instead.")
 		/* r.expr([1, 2]).map(tbl.insert({'foo':r.row}).get_field('inserted').add(5)) */
 
 		suite.T().Log("About to run line #292: r.Expr([]interface{}{1, 2}).Map(tbl.Insert(map[interface{}]interface{}{'foo': r.Row, }).Field('inserted').Add(5))")
@@ -1079,7 +1079,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #296
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.expr(1).do(r.db('test').table_create('table_create_success')) */
 
 		suite.T().Log("About to run line #296: r.Expr(1).Do(r.DB('test').TableCreate('table_create_success'))")
@@ -1094,7 +1094,7 @@ func (suite *ControlSuite) TestCases() {
 	{
 		// control.yaml line #300
 		/* [1, 2] */
-		var expected_ []interface{} = []interface{}{1, 2}
+		var expected_ = []interface{}{1, 2}
 		/* r.expr([1, 2]) */
 
 		suite.T().Log("About to run line #300: r.Expr([]interface{}{1, 2})")

--- a/internal/integration/reql_tests/reql_datum_array_test.go
+++ b/internal/integration/reql_tests/reql_datum_array_test.go
@@ -61,7 +61,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #6
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr([]) */
 
 		suite.T().Log("About to run line #6: r.Expr([]interface{}{})")
@@ -76,7 +76,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #9
 		/* [1] */
-		var expected_ []interface{} = []interface{}{1}
+		var expected_ = []interface{}{1}
 		/* r.expr([1]) */
 
 		suite.T().Log("About to run line #9: r.Expr([]interface{}{1})")
@@ -91,7 +91,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #14
 		/* [1,2,3,4,5] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4, 5}
+		var expected_ = []interface{}{1, 2, 3, 4, 5}
 		/* r.expr([1,2,3,4,5]) */
 
 		suite.T().Log("About to run line #14: r.Expr([]interface{}{1, 2, 3, 4, 5})")
@@ -106,7 +106,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #19
 		/* 'ARRAY' */
-		var expected_ string = "ARRAY"
+		var expected_ = "ARRAY"
 		/* r.expr([]).type_of() */
 
 		suite.T().Log("About to run line #19: r.Expr([]interface{}{}).TypeOf()")
@@ -121,7 +121,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #24
 		/* '[1,2]' */
-		var expected_ string = "[1,2]"
+		var expected_ = "[1,2]"
 		/* r.expr([1, 2]).coerce_to('string') */
 
 		suite.T().Log("About to run line #24: r.Expr([]interface{}{1, 2}).CoerceTo('string')")
@@ -136,7 +136,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #25
 		/* '[1,2]' */
-		var expected_ string = "[1,2]"
+		var expected_ = "[1,2]"
 		/* r.expr([1, 2]).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #25: r.Expr([]interface{}{1, 2}).CoerceTo('STRING')")
@@ -151,7 +151,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #28
 		/* [1, 2] */
-		var expected_ []interface{} = []interface{}{1, 2}
+		var expected_ = []interface{}{1, 2}
 		/* r.expr([1, 2]).coerce_to('array') */
 
 		suite.T().Log("About to run line #28: r.Expr([]interface{}{1, 2}).CoerceTo('array')")
@@ -166,7 +166,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #31
 		/* err('ReqlQueryLogicError', 'Cannot coerce ARRAY to NUMBER.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot coerce ARRAY to NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot coerce ARRAY to NUMBER.")
 		/* r.expr([1, 2]).coerce_to('number') */
 
 		suite.T().Log("About to run line #31: r.Expr([]interface{}{1, 2}).CoerceTo('number')")
@@ -181,7 +181,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #34
 		/* {'a':1,'b':2} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2}
 		/* r.expr([['a', 1], ['b', 2]]).coerce_to('object') */
 
 		suite.T().Log("About to run line #34: r.Expr([]interface{}{[]interface{}{'a', 1}, []interface{}{'b', 2}}).CoerceTo('object')")
@@ -196,7 +196,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #37
 		/* err('ReqlQueryLogicError', 'Expected array of size 2, but got size 0.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected array of size 2, but got size 0.")
+		var expected_ = err("ReqlQueryLogicError", "Expected array of size 2, but got size 0.")
 		/* r.expr([[]]).coerce_to('object') */
 
 		suite.T().Log("About to run line #37: r.Expr([]interface{}{[]interface{}{}}).CoerceTo('object')")
@@ -211,7 +211,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #40
 		/* err('ReqlQueryLogicError', 'Expected array of size 2, but got size 3.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected array of size 2, but got size 3.")
+		var expected_ = err("ReqlQueryLogicError", "Expected array of size 2, but got size 3.")
 		/* r.expr([['1',2,3]]).coerce_to('object') */
 
 		suite.T().Log("About to run line #40: r.Expr([]interface{}{[]interface{}{'1', 2, 3}}).CoerceTo('object')")
@@ -226,7 +226,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #44
 		/* [1] */
-		var expected_ []interface{} = []interface{}{1}
+		var expected_ = []interface{}{1}
 		/* r.expr([r.expr(1)]) */
 
 		suite.T().Log("About to run line #44: r.Expr([]interface{}{r.Expr(1)})")
@@ -241,7 +241,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #47
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,3,4]).insert_at(1, 2) */
 
 		suite.T().Log("About to run line #47: r.Expr([]interface{}{1, 3, 4}).InsertAt(1, 2)")
@@ -256,7 +256,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #49
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.expr([2,3]).insert_at(0, 1) */
 
 		suite.T().Log("About to run line #49: r.Expr([]interface{}{2, 3}).InsertAt(0, 1)")
@@ -271,7 +271,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #51
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,2,3]).insert_at(-1, 4) */
 
 		suite.T().Log("About to run line #51: r.Expr([]interface{}{1, 2, 3}).InsertAt(-1, 4)")
@@ -286,7 +286,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #53
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,2,3]).insert_at(3, 4) */
 
 		suite.T().Log("About to run line #53: r.Expr([]interface{}{1, 2, 3}).InsertAt(3, 4)")
@@ -301,7 +301,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #55
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* r.expr(3).do(lambda x: r.expr([1,2,3]).insert_at(x, 4)) */
 
 		suite.T().Log("About to run line #55: r.Expr(3).Do(func(x r.Term) interface{} { return r.Expr([]interface{}{1, 2, 3}).InsertAt(x, 4)})")
@@ -316,7 +316,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #59
 		/* err('ReqlNonExistenceError', 'Index `4` out of bounds for array of size: `3`.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index `4` out of bounds for array of size: `3`.")
+		var expected_ = err("ReqlNonExistenceError", "Index `4` out of bounds for array of size: `3`.")
 		/* r.expr([1,2,3]).insert_at(4, 5) */
 
 		suite.T().Log("About to run line #59: r.Expr([]interface{}{1, 2, 3}).InsertAt(4, 5)")
@@ -331,7 +331,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #61
 		/* err('ReqlNonExistenceError', 'Index out of bounds: -5', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index out of bounds: -5")
+		var expected_ = err("ReqlNonExistenceError", "Index out of bounds: -5")
 		/* r.expr([1,2,3]).insert_at(-5, -1) */
 
 		suite.T().Log("About to run line #61: r.Expr([]interface{}{1, 2, 3}).InsertAt(-5, -1)")
@@ -346,7 +346,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #63
 		/* err('ReqlQueryLogicError', 'Number not an integer: 1.5', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Number not an integer: 1.5")
+		var expected_ = err("ReqlQueryLogicError", "Number not an integer: 1.5")
 		/* r.expr([1,2,3]).insert_at(1.5, 1) */
 
 		suite.T().Log("About to run line #63: r.Expr([]interface{}{1, 2, 3}).InsertAt(1.5, 1)")
@@ -361,7 +361,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #65
 		/* err('ReqlNonExistenceError', 'Expected type NUMBER but found NULL.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* r.expr([1,2,3]).insert_at(null, 1) */
 
 		suite.T().Log("About to run line #65: r.Expr([]interface{}{1, 2, 3}).InsertAt(nil, 1)")
@@ -376,7 +376,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #68
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,4]).splice_at(1, [2,3]) */
 
 		suite.T().Log("About to run line #68: r.Expr([]interface{}{1, 4}).SpliceAt(1, []interface{}{2, 3})")
@@ -391,7 +391,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #70
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([3,4]).splice_at(0, [1,2]) */
 
 		suite.T().Log("About to run line #70: r.Expr([]interface{}{3, 4}).SpliceAt(0, []interface{}{1, 2})")
@@ -406,7 +406,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #72
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,2]).splice_at(2, [3,4]) */
 
 		suite.T().Log("About to run line #72: r.Expr([]interface{}{1, 2}).SpliceAt(2, []interface{}{3, 4})")
@@ -421,7 +421,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #74
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,2]).splice_at(-1, [3,4]) */
 
 		suite.T().Log("About to run line #74: r.Expr([]interface{}{1, 2}).SpliceAt(-1, []interface{}{3, 4})")
@@ -436,7 +436,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #76
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* r.expr(2).do(lambda x: r.expr([1,2]).splice_at(x, [3,4])) */
 
 		suite.T().Log("About to run line #76: r.Expr(2).Do(func(x r.Term) interface{} { return r.Expr([]interface{}{1, 2}).SpliceAt(x, []interface{}{3, 4})})")
@@ -451,7 +451,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #80
 		/* err('ReqlNonExistenceError', 'Index `3` out of bounds for array of size: `2`.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index `3` out of bounds for array of size: `2`.")
+		var expected_ = err("ReqlNonExistenceError", "Index `3` out of bounds for array of size: `2`.")
 		/* r.expr([1,2]).splice_at(3, [3,4]) */
 
 		suite.T().Log("About to run line #80: r.Expr([]interface{}{1, 2}).SpliceAt(3, []interface{}{3, 4})")
@@ -466,7 +466,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #82
 		/* err('ReqlNonExistenceError', 'Index out of bounds: -4', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index out of bounds: -4")
+		var expected_ = err("ReqlNonExistenceError", "Index out of bounds: -4")
 		/* r.expr([1,2]).splice_at(-4, [3,4]) */
 
 		suite.T().Log("About to run line #82: r.Expr([]interface{}{1, 2}).SpliceAt(-4, []interface{}{3, 4})")
@@ -481,7 +481,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #84
 		/* err('ReqlQueryLogicError', 'Number not an integer: 1.5', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Number not an integer: 1.5")
+		var expected_ = err("ReqlQueryLogicError", "Number not an integer: 1.5")
 		/* r.expr([1,2,3]).splice_at(1.5, [1]) */
 
 		suite.T().Log("About to run line #84: r.Expr([]interface{}{1, 2, 3}).SpliceAt(1.5, []interface{}{1})")
@@ -496,7 +496,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #86
 		/* err('ReqlNonExistenceError', 'Expected type NUMBER but found NULL.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* r.expr([1,2,3]).splice_at(null, [1]) */
 
 		suite.T().Log("About to run line #86: r.Expr([]interface{}{1, 2, 3}).SpliceAt(nil, []interface{}{1})")
@@ -511,7 +511,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #88
 		/* err('ReqlQueryLogicError', 'Expected type ARRAY but found NUMBER.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.")
 		/* r.expr([1,4]).splice_at(1, 2) */
 
 		suite.T().Log("About to run line #88: r.Expr([]interface{}{1, 4}).SpliceAt(1, 2)")
@@ -526,7 +526,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #91
 		/* [2,3,4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* r.expr([1,2,3,4]).delete_at(0) */
 
 		suite.T().Log("About to run line #91: r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(0)")
@@ -541,7 +541,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #93
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* r.expr(0).do(lambda x: r.expr([1,2,3,4]).delete_at(x)) */
 
 		suite.T().Log("About to run line #93: r.Expr(0).Do(func(x r.Term) interface{} { return r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(x)})")
@@ -556,7 +556,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #97
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.expr([1,2,3,4]).delete_at(-1) */
 
 		suite.T().Log("About to run line #97: r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(-1)")
@@ -571,7 +571,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #99
 		/* [1,4] */
-		var expected_ []interface{} = []interface{}{1, 4}
+		var expected_ = []interface{}{1, 4}
 		/* r.expr([1,2,3,4]).delete_at(1,3) */
 
 		suite.T().Log("About to run line #99: r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(1, 3)")
@@ -586,7 +586,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #101
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,2,3,4]).delete_at(4,4) */
 
 		suite.T().Log("About to run line #101: r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(4, 4)")
@@ -601,7 +601,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #103
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr([]).delete_at(0,0) */
 
 		suite.T().Log("About to run line #103: r.Expr([]interface{}{}).DeleteAt(0, 0)")
@@ -616,7 +616,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #105
 		/* [1,4] */
-		var expected_ []interface{} = []interface{}{1, 4}
+		var expected_ = []interface{}{1, 4}
 		/* r.expr([1,2,3,4]).delete_at(1,-1) */
 
 		suite.T().Log("About to run line #105: r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(1, -1)")
@@ -631,7 +631,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #107
 		/* err('ReqlNonExistenceError', 'Index `4` out of bounds for array of size: `4`.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index `4` out of bounds for array of size: `4`.")
+		var expected_ = err("ReqlNonExistenceError", "Index `4` out of bounds for array of size: `4`.")
 		/* r.expr([1,2,3,4]).delete_at(4) */
 
 		suite.T().Log("About to run line #107: r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(4)")
@@ -646,7 +646,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #109
 		/* err('ReqlNonExistenceError', 'Index out of bounds: -5', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index out of bounds: -5")
+		var expected_ = err("ReqlNonExistenceError", "Index out of bounds: -5")
 		/* r.expr([1,2,3,4]).delete_at(-5) */
 
 		suite.T().Log("About to run line #109: r.Expr([]interface{}{1, 2, 3, 4}).DeleteAt(-5)")
@@ -661,7 +661,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #111
 		/* err('ReqlQueryLogicError', 'Number not an integer: 1.5', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Number not an integer: 1.5")
+		var expected_ = err("ReqlQueryLogicError", "Number not an integer: 1.5")
 		/* r.expr([1,2,3]).delete_at(1.5) */
 
 		suite.T().Log("About to run line #111: r.Expr([]interface{}{1, 2, 3}).DeleteAt(1.5)")
@@ -676,7 +676,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #113
 		/* err('ReqlNonExistenceError', 'Expected type NUMBER but found NULL.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* r.expr([1,2,3]).delete_at(null) */
 
 		suite.T().Log("About to run line #113: r.Expr([]interface{}{1, 2, 3}).DeleteAt(nil)")
@@ -691,7 +691,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #116
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.expr([0,2,3]).change_at(0, 1) */
 
 		suite.T().Log("About to run line #116: r.Expr([]interface{}{0, 2, 3}).ChangeAt(0, 1)")
@@ -706,7 +706,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #118
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* r.expr(1).do(lambda x: r.expr([0,2,3]).change_at(0,x)) */
 
 		suite.T().Log("About to run line #118: r.Expr(1).Do(func(x r.Term) interface{} { return r.Expr([]interface{}{0, 2, 3}).ChangeAt(0, x)})")
@@ -721,7 +721,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #122
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.expr([1,0,3]).change_at(1, 2) */
 
 		suite.T().Log("About to run line #122: r.Expr([]interface{}{1, 0, 3}).ChangeAt(1, 2)")
@@ -736,7 +736,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #124
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.expr([1,2,0]).change_at(2, 3) */
 
 		suite.T().Log("About to run line #124: r.Expr([]interface{}{1, 2, 0}).ChangeAt(2, 3)")
@@ -751,7 +751,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #126
 		/* err('ReqlNonExistenceError', 'Index `3` out of bounds for array of size: `3`.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index `3` out of bounds for array of size: `3`.")
+		var expected_ = err("ReqlNonExistenceError", "Index `3` out of bounds for array of size: `3`.")
 		/* r.expr([1,2,3]).change_at(3, 4) */
 
 		suite.T().Log("About to run line #126: r.Expr([]interface{}{1, 2, 3}).ChangeAt(3, 4)")
@@ -766,7 +766,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #128
 		/* err('ReqlNonExistenceError', 'Index out of bounds: -5', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Index out of bounds: -5")
+		var expected_ = err("ReqlNonExistenceError", "Index out of bounds: -5")
 		/* r.expr([1,2,3,4]).change_at(-5, 1) */
 
 		suite.T().Log("About to run line #128: r.Expr([]interface{}{1, 2, 3, 4}).ChangeAt(-5, 1)")
@@ -781,7 +781,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #130
 		/* err('ReqlQueryLogicError', 'Number not an integer: 1.5', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Number not an integer: 1.5")
+		var expected_ = err("ReqlQueryLogicError", "Number not an integer: 1.5")
 		/* r.expr([1,2,3]).change_at(1.5, 1) */
 
 		suite.T().Log("About to run line #130: r.Expr([]interface{}{1, 2, 3}).ChangeAt(1.5, 1)")
@@ -796,7 +796,7 @@ func (suite *DatumArraySuite) TestCases() {
 	{
 		// datum/array.yaml line #132
 		/* err('ReqlNonExistenceError', 'Expected type NUMBER but found NULL.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* r.expr([1,2,3]).change_at(null, 1) */
 
 		suite.T().Log("About to run line #132: r.Expr([]interface{}{1, 2, 3}).ChangeAt(nil, 1)")

--- a/internal/integration/reql_tests/reql_datum_binary_test.go
+++ b/internal/integration/reql_tests/reql_datum_binary_test.go
@@ -68,7 +68,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #10
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #10: r.Binary(s)")
@@ -83,7 +83,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #12
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #12: r.Binary(s).Count()")
@@ -104,7 +104,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #19
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #19: r.Binary(s)")
@@ -119,7 +119,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #21
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #21: r.Binary(s).Count()")
@@ -140,7 +140,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #28
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #28: r.Binary(s)")
@@ -155,7 +155,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #30
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #30: r.Binary(s).Count()")
@@ -176,7 +176,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #37
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #37: r.Binary(s)")
@@ -191,7 +191,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #39
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #39: r.Binary(s).Count()")
@@ -212,7 +212,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #46
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #46: r.Binary(s)")
@@ -227,7 +227,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #48
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #48: r.Binary(s).Count()")
@@ -248,7 +248,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #55
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #55: r.Binary(s)")
@@ -263,7 +263,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #57
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #57: r.Binary(s).Count()")
@@ -284,7 +284,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #64
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #64: r.Binary(s)")
@@ -299,7 +299,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #66
 		/* 6 */
-		var expected_ int = 6
+		var expected_ = 6
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #66: r.Binary(s).Count()")
@@ -320,7 +320,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #73
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #73: r.Binary(s)")
@@ -335,7 +335,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #75
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #75: r.Binary(s).Count()")
@@ -356,7 +356,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #82
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #82: r.Binary(s)")
@@ -371,7 +371,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #84
 		/* 8 */
-		var expected_ int = 8
+		var expected_ = 8
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #84: r.Binary(s).Count()")
@@ -392,7 +392,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #91
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #91: r.Binary(s)")
@@ -407,7 +407,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #93
 		/* 9 */
-		var expected_ int = 9
+		var expected_ = 9
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #93: r.Binary(s).Count()")
@@ -428,7 +428,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #100
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #100: r.Binary(s)")
@@ -443,7 +443,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #102
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #102: r.Binary(s).Count()")
@@ -464,7 +464,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #109
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #109: r.Binary(s)")
@@ -479,7 +479,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #111
 		/* 11 */
-		var expected_ int = 11
+		var expected_ = 11
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #111: r.Binary(s).Count()")
@@ -500,7 +500,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #118
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #118: r.Binary(s)")
@@ -515,7 +515,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #120
 		/* 12 */
-		var expected_ int = 12
+		var expected_ = 12
 		/* r.binary(s).count() */
 
 		suite.T().Log("About to run line #120: r.Binary(s).Count()")
@@ -572,7 +572,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #151
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(a).eq(r.binary(a)) */
 
 		suite.T().Log("About to run line #151: r.Binary(a).Eq(r.Binary(a))")
@@ -587,7 +587,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #153
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(a).le(r.binary(a)) */
 
 		suite.T().Log("About to run line #153: r.Binary(a).Le(r.Binary(a))")
@@ -602,7 +602,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #155
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(a).ge(r.binary(a)) */
 
 		suite.T().Log("About to run line #155: r.Binary(a).Ge(r.Binary(a))")
@@ -617,7 +617,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #157
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(a).ne(r.binary(a)) */
 
 		suite.T().Log("About to run line #157: r.Binary(a).Ne(r.Binary(a))")
@@ -632,7 +632,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #159
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(a).lt(r.binary(a)) */
 
 		suite.T().Log("About to run line #159: r.Binary(a).Lt(r.Binary(a))")
@@ -647,7 +647,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #161
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(a).gt(r.binary(a)) */
 
 		suite.T().Log("About to run line #161: r.Binary(a).Gt(r.Binary(a))")
@@ -662,7 +662,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #165
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(a).ne(r.binary(b)) */
 
 		suite.T().Log("About to run line #165: r.Binary(a).Ne(r.Binary(b))")
@@ -677,7 +677,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #167
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(a).lt(r.binary(b)) */
 
 		suite.T().Log("About to run line #167: r.Binary(a).Lt(r.Binary(b))")
@@ -692,7 +692,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #169
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(a).le(r.binary(b)) */
 
 		suite.T().Log("About to run line #169: r.Binary(a).Le(r.Binary(b))")
@@ -707,7 +707,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #171
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(a).ge(r.binary(b)) */
 
 		suite.T().Log("About to run line #171: r.Binary(a).Ge(r.Binary(b))")
@@ -722,7 +722,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #173
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(a).gt(r.binary(b)) */
 
 		suite.T().Log("About to run line #173: r.Binary(a).Gt(r.Binary(b))")
@@ -737,7 +737,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #175
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(a).eq(r.binary(b)) */
 
 		suite.T().Log("About to run line #175: r.Binary(a).Eq(r.Binary(b))")
@@ -752,7 +752,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #179
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(b).ne(r.binary(c)) */
 
 		suite.T().Log("About to run line #179: r.Binary(b).Ne(r.Binary(c))")
@@ -767,7 +767,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #181
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(b).lt(r.binary(c)) */
 
 		suite.T().Log("About to run line #181: r.Binary(b).Lt(r.Binary(c))")
@@ -782,7 +782,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #183
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(b).le(r.binary(c)) */
 
 		suite.T().Log("About to run line #183: r.Binary(b).Le(r.Binary(c))")
@@ -797,7 +797,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #185
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(b).ge(r.binary(c)) */
 
 		suite.T().Log("About to run line #185: r.Binary(b).Ge(r.Binary(c))")
@@ -812,7 +812,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #187
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(b).gt(r.binary(c)) */
 
 		suite.T().Log("About to run line #187: r.Binary(b).Gt(r.Binary(c))")
@@ -827,7 +827,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #189
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(b).eq(r.binary(c)) */
 
 		suite.T().Log("About to run line #189: r.Binary(b).Eq(r.Binary(c))")
@@ -842,7 +842,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #193
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(c).ne(r.binary(d)) */
 
 		suite.T().Log("About to run line #193: r.Binary(c).Ne(r.Binary(d))")
@@ -857,7 +857,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #195
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(c).lt(r.binary(d)) */
 
 		suite.T().Log("About to run line #195: r.Binary(c).Lt(r.Binary(d))")
@@ -872,7 +872,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #197
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(c).le(r.binary(d)) */
 
 		suite.T().Log("About to run line #197: r.Binary(c).Le(r.Binary(d))")
@@ -887,7 +887,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #199
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(c).ge(r.binary(d)) */
 
 		suite.T().Log("About to run line #199: r.Binary(c).Ge(r.Binary(d))")
@@ -902,7 +902,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #201
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(c).gt(r.binary(d)) */
 
 		suite.T().Log("About to run line #201: r.Binary(c).Gt(r.Binary(d))")
@@ -917,7 +917,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #203
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(c).eq(r.binary(d)) */
 
 		suite.T().Log("About to run line #203: r.Binary(c).Eq(r.Binary(d))")
@@ -932,7 +932,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #207
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(d).ne(r.binary(e)) */
 
 		suite.T().Log("About to run line #207: r.Binary(d).Ne(r.Binary(e))")
@@ -947,7 +947,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #209
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(d).lt(r.binary(e)) */
 
 		suite.T().Log("About to run line #209: r.Binary(d).Lt(r.Binary(e))")
@@ -962,7 +962,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #211
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(d).le(r.binary(e)) */
 
 		suite.T().Log("About to run line #211: r.Binary(d).Le(r.Binary(e))")
@@ -977,7 +977,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #213
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(d).ge(r.binary(e)) */
 
 		suite.T().Log("About to run line #213: r.Binary(d).Ge(r.Binary(e))")
@@ -992,7 +992,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #215
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(d).gt(r.binary(e)) */
 
 		suite.T().Log("About to run line #215: r.Binary(d).Gt(r.Binary(e))")
@@ -1007,7 +1007,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #217
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(d).eq(r.binary(e)) */
 
 		suite.T().Log("About to run line #217: r.Binary(d).Eq(r.Binary(e))")
@@ -1022,7 +1022,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #221
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(e).ne(r.binary(f)) */
 
 		suite.T().Log("About to run line #221: r.Binary(e).Ne(r.Binary(f))")
@@ -1037,7 +1037,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #223
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(e).lt(r.binary(f)) */
 
 		suite.T().Log("About to run line #223: r.Binary(e).Lt(r.Binary(f))")
@@ -1052,7 +1052,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #225
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(e).le(r.binary(f)) */
 
 		suite.T().Log("About to run line #225: r.Binary(e).Le(r.Binary(f))")
@@ -1067,7 +1067,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #227
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(e).ge(r.binary(f)) */
 
 		suite.T().Log("About to run line #227: r.Binary(e).Ge(r.Binary(f))")
@@ -1082,7 +1082,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #229
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(e).gt(r.binary(f)) */
 
 		suite.T().Log("About to run line #229: r.Binary(e).Gt(r.Binary(f))")
@@ -1097,7 +1097,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #231
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(e).eq(r.binary(f)) */
 
 		suite.T().Log("About to run line #231: r.Binary(e).Eq(r.Binary(f))")
@@ -1112,7 +1112,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #235
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(f).eq(r.binary(f)) */
 
 		suite.T().Log("About to run line #235: r.Binary(f).Eq(r.Binary(f))")
@@ -1127,7 +1127,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #237
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(f).le(r.binary(f)) */
 
 		suite.T().Log("About to run line #237: r.Binary(f).Le(r.Binary(f))")
@@ -1142,7 +1142,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #239
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(f).ge(r.binary(f)) */
 
 		suite.T().Log("About to run line #239: r.Binary(f).Ge(r.Binary(f))")
@@ -1157,7 +1157,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #241
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(f).ne(r.binary(f)) */
 
 		suite.T().Log("About to run line #241: r.Binary(f).Ne(r.Binary(f))")
@@ -1172,7 +1172,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #243
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(f).lt(r.binary(f)) */
 
 		suite.T().Log("About to run line #243: r.Binary(f).Lt(r.Binary(f))")
@@ -1187,7 +1187,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #245
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(f).gt(r.binary(f)) */
 
 		suite.T().Log("About to run line #245: r.Binary(f).Gt(r.Binary(f))")
@@ -1202,7 +1202,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #269
 		/* 'foo' */
-		var expected_ string = "foo"
+		var expected_ = "foo"
 		/* r.binary(b'foo').coerce_to('string') */
 
 		suite.T().Log("About to run line #269: r.Binary([]byte{102,111,111}).CoerceTo('string')")
@@ -1217,7 +1217,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #284
 		/* b'foo' */
-		var expected_ []byte = []byte{102, 111, 111}
+		var expected_ = []byte{102, 111, 111}
 		/* r.expr('foo').coerce_to('binary') */
 
 		suite.T().Log("About to run line #284: r.Expr('foo').CoerceTo('binary')")
@@ -1232,7 +1232,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #287
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(a).coerce_to('bool') */
 
 		suite.T().Log("About to run line #287: r.Binary(a).CoerceTo('bool')")
@@ -1247,7 +1247,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #290
 		/* b'foo' */
-		var expected_ []byte = []byte{102, 111, 111}
+		var expected_ = []byte{102, 111, 111}
 		/* r.binary(b'foo').coerce_to('binary') */
 
 		suite.T().Log("About to run line #290: r.Binary([]byte{102,111,111}).CoerceTo('binary')")
@@ -1262,7 +1262,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #294
 		/* b'ef' */
-		var expected_ []byte = []byte{101, 102}
+		var expected_ = []byte{101, 102}
 		/* r.binary(b'abcdefg').slice(-3,-1) */
 
 		suite.T().Log("About to run line #294: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(-3, -1)")
@@ -1277,7 +1277,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #296
 		/* b'ab' */
-		var expected_ []byte = []byte{97, 98}
+		var expected_ = []byte{97, 98}
 		/* r.binary(b'abcdefg').slice(0, 2) */
 
 		suite.T().Log("About to run line #296: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(0, 2)")
@@ -1292,7 +1292,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #298
 		/* b'def' */
-		var expected_ []byte = []byte{100, 101, 102}
+		var expected_ = []byte{100, 101, 102}
 		/* r.binary(b'abcdefg').slice(3, -1) */
 
 		suite.T().Log("About to run line #298: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(3, -1)")
@@ -1307,7 +1307,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #300
 		/* b'cde' */
-		var expected_ []byte = []byte{99, 100, 101}
+		var expected_ = []byte{99, 100, 101}
 		/* r.binary(b'abcdefg').slice(-5, 5) */
 
 		suite.T().Log("About to run line #300: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(-5, 5)")
@@ -1322,7 +1322,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #302
 		/* b'ab' */
-		var expected_ []byte = []byte{97, 98}
+		var expected_ = []byte{97, 98}
 		/* r.binary(b'abcdefg').slice(-8, 2) */
 
 		suite.T().Log("About to run line #302: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(-8, 2)")
@@ -1337,7 +1337,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #304
 		/* b'fg' */
-		var expected_ []byte = []byte{102, 103}
+		var expected_ = []byte{102, 103}
 		/* r.binary(b'abcdefg').slice(5, 7) */
 
 		suite.T().Log("About to run line #304: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(5, 7)")
@@ -1352,7 +1352,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #308
 		/* b'ab' */
-		var expected_ []byte = []byte{97, 98}
+		var expected_ = []byte{97, 98}
 		/* r.binary(b'abcdefg').slice(-9, 2) */
 
 		suite.T().Log("About to run line #308: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(-9, 2)")
@@ -1367,7 +1367,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #312
 		/* b'fg' */
-		var expected_ []byte = []byte{102, 103}
+		var expected_ = []byte{102, 103}
 		/* r.binary(b'abcdefg').slice(5, 9) */
 
 		suite.T().Log("About to run line #312: r.Binary([]byte{97,98,99,100,101,102,103}).Slice(5, 9)")
@@ -1382,7 +1382,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #316
 		/* b */
-		var expected_ []byte = b
+		var expected_ = b
 		/* r.binary(b) */
 
 		suite.T().Log("About to run line #316: r.Binary(b)")
@@ -1398,7 +1398,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #320
 		/* {'$reql_type$':'BINARY','data':'AAE='} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "BINARY", "data": "AAE="}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "BINARY", "data": "AAE="}
 		/* r.binary(b) */
 
 		suite.T().Log("About to run line #320: r.Binary(b)")
@@ -1414,7 +1414,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #326
 		/* b"data" */
-		var expected_ []byte = []byte{100, 97, 116, 97}
+		var expected_ = []byte{100, 97, 116, 97}
 		/* r.binary(r.expr("data")) */
 
 		suite.T().Log("About to run line #326: r.Binary(r.Expr('data'))")
@@ -1429,7 +1429,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #332
 		/* err('ReqlQueryLogicError', 'Expected type STRING but found OBJECT.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found OBJECT.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found OBJECT.")
 		/* r.binary(r.expr({})) */
 
 		suite.T().Log("About to run line #332: r.Binary(r.Expr(map[interface{}]interface{}{}))")
@@ -1444,7 +1444,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #335
 		/* err('ReqlQueryLogicError', 'Expected type STRING but found ARRAY.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found ARRAY.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found ARRAY.")
 		/* r.binary(r.expr([])) */
 
 		suite.T().Log("About to run line #335: r.Binary(r.Expr([]interface{}{}))")
@@ -1459,7 +1459,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #341
 		/* err('ReqlQueryLogicError','Invalid binary pseudotype:'+' lacking `data` key.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid binary pseudotype:"+" lacking `data` key.")
+		var expected_ = err("ReqlQueryLogicError", "Invalid binary pseudotype:"+" lacking `data` key.")
 		/* r.expr({'$reql_type$':'BINARY'}) */
 
 		suite.T().Log("About to run line #341: r.Expr(map[interface{}]interface{}{'$reql_type$': 'BINARY', })")
@@ -1474,7 +1474,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #346
 		/* err('ReqlQueryLogicError','Invalid base64 format, data found after padding character \'=\'.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid base64 format, data found after padding character '='.")
+		var expected_ = err("ReqlQueryLogicError", "Invalid base64 format, data found after padding character '='.")
 		/* r.expr({'$reql_type$':'BINARY','data':'ABCDEFGH==AA'}) */
 
 		suite.T().Log("About to run line #346: r.Expr(map[interface{}]interface{}{'$reql_type$': 'BINARY', 'data': 'ABCDEFGH==AA', })")
@@ -1489,7 +1489,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #348
 		/* err('ReqlQueryLogicError','Invalid base64 format, data found after padding character \'=\'.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid base64 format, data found after padding character '='.")
+		var expected_ = err("ReqlQueryLogicError", "Invalid base64 format, data found after padding character '='.")
 		/* r.expr({'$reql_type$':'BINARY','data':'ABCDEF==$'}) */
 
 		suite.T().Log("About to run line #348: r.Expr(map[interface{}]interface{}{'$reql_type$': 'BINARY', 'data': 'ABCDEF==$', })")
@@ -1504,7 +1504,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #350
 		/* err('ReqlQueryLogicError','Invalid base64 character found:'+' \'^\'.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid base64 character found:"+" '^'.")
+		var expected_ = err("ReqlQueryLogicError", "Invalid base64 character found:"+" '^'.")
 		/* r.expr({'$reql_type$':'BINARY','data':'A^CDEFGH'}) */
 
 		suite.T().Log("About to run line #350: r.Expr(map[interface{}]interface{}{'$reql_type$': 'BINARY', 'data': 'A^CDEFGH', })")
@@ -1519,7 +1519,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #352
 		/* err('ReqlQueryLogicError','Invalid base64 length:'+' 1 character remaining, cannot decode a full byte.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid base64 length:"+" 1 character remaining, cannot decode a full byte.")
+		var expected_ = err("ReqlQueryLogicError", "Invalid base64 length:"+" 1 character remaining, cannot decode a full byte.")
 		/* r.expr({'$reql_type$':'BINARY','data':'ABCDE'}) */
 
 		suite.T().Log("About to run line #352: r.Expr(map[interface{}]interface{}{'$reql_type$': 'BINARY', 'data': 'ABCDE', })")
@@ -1534,7 +1534,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #356
 		/* err('ReqlQueryLogicError','Cannot coerce BINARY to ARRAY.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot coerce BINARY to ARRAY.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot coerce BINARY to ARRAY.")
 		/* r.binary(a).coerce_to('array') */
 
 		suite.T().Log("About to run line #356: r.Binary(a).CoerceTo('array')")
@@ -1549,7 +1549,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #358
 		/* err('ReqlQueryLogicError','Cannot coerce BINARY to OBJECT.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot coerce BINARY to OBJECT.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot coerce BINARY to OBJECT.")
 		/* r.binary(a).coerce_to('object') */
 
 		suite.T().Log("About to run line #358: r.Binary(a).CoerceTo('object')")
@@ -1564,7 +1564,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #360
 		/* err('ReqlQueryLogicError','Cannot coerce BINARY to NUMBER.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot coerce BINARY to NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot coerce BINARY to NUMBER.")
 		/* r.binary(a).coerce_to('number') */
 
 		suite.T().Log("About to run line #360: r.Binary(a).CoerceTo('number')")
@@ -1579,7 +1579,7 @@ func (suite *DatumBinarySuite) TestCases() {
 	{
 		// datum/binary.yaml line #362
 		/* err('ReqlQueryLogicError','Cannot coerce BINARY to NULL.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot coerce BINARY to NULL.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot coerce BINARY to NULL.")
 		/* r.binary(a).coerce_to('nu'+'ll') */
 
 		suite.T().Log("About to run line #362: r.Binary(a).CoerceTo(r.Add('nu', 'll'))")

--- a/internal/integration/reql_tests/reql_datum_bool_test.go
+++ b/internal/integration/reql_tests/reql_datum_bool_test.go
@@ -61,7 +61,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #3
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(True) */
 
 		suite.T().Log("About to run line #3: r.Expr(true)")
@@ -76,7 +76,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #10
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(False) */
 
 		suite.T().Log("About to run line #10: r.Expr(false)")
@@ -91,7 +91,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #17
 		/* 'BOOL' */
-		var expected_ string = "BOOL"
+		var expected_ = "BOOL"
 		/* r.expr(False).type_of() */
 
 		suite.T().Log("About to run line #17: r.Expr(false).TypeOf()")
@@ -106,7 +106,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #21
 		/* 'true' */
-		var expected_ string = "true"
+		var expected_ = "true"
 		/* r.expr(True).coerce_to('string') */
 
 		suite.T().Log("About to run line #21: r.Expr(true).CoerceTo('string')")
@@ -121,7 +121,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #24
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(True).coerce_to('bool') */
 
 		suite.T().Log("About to run line #24: r.Expr(true).CoerceTo('bool')")
@@ -136,7 +136,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #27
 		/* False */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(False).coerce_to('bool') */
 
 		suite.T().Log("About to run line #27: r.Expr(false).CoerceTo('bool')")
@@ -151,7 +151,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #30
 		/* False */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(null).coerce_to('bool') */
 
 		suite.T().Log("About to run line #30: r.Expr(nil).CoerceTo('bool')")
@@ -166,7 +166,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #33
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(0).coerce_to('bool') */
 
 		suite.T().Log("About to run line #33: r.Expr(0).CoerceTo('bool')")
@@ -181,7 +181,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #36
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('false').coerce_to('bool') */
 
 		suite.T().Log("About to run line #36: r.Expr('false').CoerceTo('bool')")
@@ -196,7 +196,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #39
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('foo').coerce_to('bool') */
 
 		suite.T().Log("About to run line #39: r.Expr('foo').CoerceTo('bool')")
@@ -211,7 +211,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #42
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([]).coerce_to('bool') */
 
 		suite.T().Log("About to run line #42: r.Expr([]interface{}{}).CoerceTo('bool')")
@@ -226,7 +226,7 @@ func (suite *DatumBoolSuite) TestCases() {
 	{
 		// datum/bool.yaml line #45
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr({}).coerce_to('bool') */
 
 		suite.T().Log("About to run line #45: r.Expr(map[interface{}]interface{}{}).CoerceTo('bool')")

--- a/internal/integration/reql_tests/reql_datum_null_test.go
+++ b/internal/integration/reql_tests/reql_datum_null_test.go
@@ -76,7 +76,7 @@ func (suite *DatumNullSuite) TestCases() {
 	{
 		// datum/null.yaml line #9
 		/* 'NULL' */
-		var expected_ string = "NULL"
+		var expected_ = "NULL"
 		/* r.expr(null).type_of() */
 
 		suite.T().Log("About to run line #9: r.Expr(nil).TypeOf()")
@@ -91,7 +91,7 @@ func (suite *DatumNullSuite) TestCases() {
 	{
 		// datum/null.yaml line #14
 		/* 'null' */
-		var expected_ string = "null"
+		var expected_ = "null"
 		/* r.expr(null).coerce_to('string') */
 
 		suite.T().Log("About to run line #14: r.Expr(nil).CoerceTo('string')")

--- a/internal/integration/reql_tests/reql_datum_number_test.go
+++ b/internal/integration/reql_tests/reql_datum_number_test.go
@@ -61,7 +61,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #6
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1) */
 
 		suite.T().Log("About to run line #6: r.Expr(1)")
@@ -76,7 +76,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #15
 		/* -1 */
-		var expected_ int = -1
+		var expected_ = -1
 		/* r.expr(-1) */
 
 		suite.T().Log("About to run line #15: r.Expr(-1)")
@@ -91,7 +91,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #24
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(0) */
 
 		suite.T().Log("About to run line #24: r.Expr(0)")
@@ -121,7 +121,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #44
 		/* 1.5 */
-		var expected_ float64 = 1.5
+		var expected_ = 1.5
 		/* r.expr(1.5) */
 
 		suite.T().Log("About to run line #44: r.Expr(1.5)")
@@ -166,7 +166,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #73
 		/* 1234567890 */
-		var expected_ int = 1234567890
+		var expected_ = 1234567890
 		/* r.expr(1234567890) */
 
 		suite.T().Log("About to run line #73: r.Expr(1234567890)")
@@ -181,7 +181,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #83
 		/* -73850380122423 */
-		var expected_ int = -73850380122423
+		var expected_ = -73850380122423
 		/* r.expr(-73850380122423) */
 
 		suite.T().Log("About to run line #83: r.Expr(-73850380122423)")
@@ -226,7 +226,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #103
 		/* 'NUMBER' */
-		var expected_ string = "NUMBER"
+		var expected_ = "NUMBER"
 		/* r.expr(1).type_of() */
 
 		suite.T().Log("About to run line #103: r.Expr(1).TypeOf()")
@@ -241,7 +241,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #107
 		/* '1' */
-		var expected_ string = "1"
+		var expected_ = "1"
 		/* r.expr(1).coerce_to('string') */
 
 		suite.T().Log("About to run line #107: r.Expr(1).CoerceTo('string')")
@@ -256,7 +256,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #110
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1).coerce_to('number') */
 
 		suite.T().Log("About to run line #110: r.Expr(1).CoerceTo('number')")
@@ -271,7 +271,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #115
 		/* int_cmp(1) */
-		var expected_ int = int_cmp(1)
+		var expected_ = int_cmp(1)
 		/* r.expr(1.0) */
 
 		suite.T().Log("About to run line #115: r.Expr(1.0)")
@@ -286,7 +286,7 @@ func (suite *DatumNumberSuite) TestCases() {
 	{
 		// datum/number.yaml line #119
 		/* int_cmp(45) */
-		var expected_ int = int_cmp(45)
+		var expected_ = int_cmp(45)
 		/* r.expr(45) */
 
 		suite.T().Log("About to run line #119: r.Expr(45)")

--- a/internal/integration/reql_tests/reql_datum_object_test.go
+++ b/internal/integration/reql_tests/reql_datum_object_test.go
@@ -61,7 +61,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #6
 		/* {} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{}
+		var expected_ = map[interface{}]interface{}{}
 		/* r.expr({}) */
 
 		suite.T().Log("About to run line #6: r.Expr(map[interface{}]interface{}{})")
@@ -76,7 +76,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #11
 		/* {'a':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1}
+		var expected_ = map[interface{}]interface{}{"a": 1}
 		/* r.expr({'a':1}) */
 
 		suite.T().Log("About to run line #11: r.Expr(map[interface{}]interface{}{'a': 1, })")
@@ -91,7 +91,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #16
 		/* {'a':1, 'b':'two', 'c':True} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": "two", "c": true}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": "two", "c": true}
 		/* r.expr({'a':1, 'b':'two', 'c':True}) */
 
 		suite.T().Log("About to run line #16: r.Expr(map[interface{}]interface{}{'a': 1, 'b': 'two', 'c': true, })")
@@ -106,7 +106,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #20
 		/* {'a':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1}
+		var expected_ = map[interface{}]interface{}{"a": 1}
 		/* r.expr({'a':r.expr(1)}) */
 
 		suite.T().Log("About to run line #20: r.Expr(map[interface{}]interface{}{'a': r.Expr(1), })")
@@ -121,7 +121,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #23
 		/* {'a':{'b':[{'c':2}, 'a', 4]}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": []interface{}{map[interface{}]interface{}{"c": 2}, "a", 4}}}
+		var expected_ = map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": []interface{}{map[interface{}]interface{}{"c": 2}, "a", 4}}}
 		/* r.expr({'a':{'b':[{'c':2}, 'a', 4]}}) */
 
 		suite.T().Log("About to run line #23: r.Expr(map[interface{}]interface{}{'a': map[interface{}]interface{}{'b': []interface{}{map[interface{}]interface{}{'c': 2, }, 'a', 4}, }, })")
@@ -136,7 +136,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #26
 		/* 'OBJECT' */
-		var expected_ string = "OBJECT"
+		var expected_ = "OBJECT"
 		/* r.expr({'a':1}).type_of() */
 
 		suite.T().Log("About to run line #26: r.Expr(map[interface{}]interface{}{'a': 1, }).TypeOf()")
@@ -151,7 +151,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #30
 		/* '{"a":1}' */
-		var expected_ string = "{\"a\":1}"
+		var expected_ = "{\"a\":1}"
 		/* r.expr({'a':1}).coerce_to('string') */
 
 		suite.T().Log("About to run line #30: r.Expr(map[interface{}]interface{}{'a': 1, }).CoerceTo('string')")
@@ -166,7 +166,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #34
 		/* {'a':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1}
+		var expected_ = map[interface{}]interface{}{"a": 1}
 		/* r.expr({'a':1}).coerce_to('object') */
 
 		suite.T().Log("About to run line #34: r.Expr(map[interface{}]interface{}{'a': 1, }).CoerceTo('object')")
@@ -181,7 +181,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #37
 		/* [['a',1]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{"a", 1}}
+		var expected_ = []interface{}{[]interface{}{"a", 1}}
 		/* r.expr({'a':1}).coerce_to('array') */
 
 		suite.T().Log("About to run line #37: r.Expr(map[interface{}]interface{}{'a': 1, }).CoerceTo('array')")
@@ -196,7 +196,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #66
 		/* {} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{}
+		var expected_ = map[interface{}]interface{}{}
 		/* r.object() */
 
 		suite.T().Log("About to run line #66: r.Object()")
@@ -211,7 +211,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #69
 		/* {'a':1,'b':2} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2}
 		/* r.object('a', 1, 'b', 2) */
 
 		suite.T().Log("About to run line #69: r.Object('a', 1, 'b', 2)")
@@ -226,7 +226,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #72
 		/* {'cd':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"cd": 3}
+		var expected_ = map[interface{}]interface{}{"cd": 3}
 		/* r.object('c'+'d', 3) */
 
 		suite.T().Log("About to run line #72: r.Object(r.Add('c', 'd'), 3)")
@@ -241,7 +241,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #75
 		/* err("ReqlQueryLogicError", "OBJECT expects an even number of arguments (but found 3).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "OBJECT expects an even number of arguments (but found 3).")
+		var expected_ = err("ReqlQueryLogicError", "OBJECT expects an even number of arguments (but found 3).")
 		/* r.object('o','d','d') */
 
 		suite.T().Log("About to run line #75: r.Object('o', 'd', 'd')")
@@ -256,7 +256,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #78
 		/* err("ReqlQueryLogicError","Expected type STRING but found NUMBER.",[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
 		/* r.object(1, 1) */
 
 		suite.T().Log("About to run line #78: r.Object(1, 1)")
@@ -271,7 +271,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #81
 		/* err("ReqlQueryLogicError","Duplicate key \"e\" in object.  (got 4 and 5 as values)",[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Duplicate key \"e\" in object.  (got 4 and 5 as values)")
+		var expected_ = err("ReqlQueryLogicError", "Duplicate key \"e\" in object.  (got 4 and 5 as values)")
 		/* r.object('e', 4, 'e', 5) */
 
 		suite.T().Log("About to run line #81: r.Object('e', 4, 'e', 5)")
@@ -286,7 +286,7 @@ func (suite *DatumObjectSuite) TestCases() {
 	{
 		// datum/object.yaml line #84
 		/* err("ReqlQueryLogicError","Expected type DATUM but found DATABASE:",[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type DATUM but found DATABASE:")
 		/* r.object('g', r.db('test')) */
 
 		suite.T().Log("About to run line #84: r.Object('g', r.DB('test'))")

--- a/internal/integration/reql_tests/reql_datum_string_test.go
+++ b/internal/integration/reql_tests/reql_datum_string_test.go
@@ -68,7 +68,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #16
 		/* "str" */
-		var expected_ string = "str"
+		var expected_ = "str"
 		/* r.expr('str') */
 
 		suite.T().Log("About to run line #16: r.Expr('str')")
@@ -83,7 +83,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #21
 		/* "str" */
-		var expected_ string = "str"
+		var expected_ = "str"
 		/* r.expr("str") */
 
 		suite.T().Log("About to run line #21: r.Expr('str')")
@@ -98,7 +98,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #28
 		/* 'str' */
-		var expected_ string = "str"
+		var expected_ = "str"
 		/* r.expr(u'str') */
 
 		suite.T().Log("About to run line #28: r.Expr('str')")
@@ -113,7 +113,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #35
 		/* u'こんにちは' */
-		var expected_ string = "こんにちは"
+		var expected_ = "こんにちは"
 		/* r.expr(japanese_hello) */
 
 		suite.T().Log("About to run line #35: r.Expr(japanese_hello)")
@@ -128,7 +128,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #43
 		/* 'STRING' */
-		var expected_ string = "STRING"
+		var expected_ = "STRING"
 		/* r.expr('foo').type_of() */
 
 		suite.T().Log("About to run line #43: r.Expr('foo').TypeOf()")
@@ -143,7 +143,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #47
 		/* 'foo' */
-		var expected_ string = "foo"
+		var expected_ = "foo"
 		/* r.expr('foo').coerce_to('string') */
 
 		suite.T().Log("About to run line #47: r.Expr('foo').CoerceTo('string')")
@@ -173,7 +173,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #51
 		/* err("ReqlQueryLogicError", "Could not coerce `--1.2` to NUMBER.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Could not coerce `--1.2` to NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Could not coerce `--1.2` to NUMBER.")
 		/* r.expr('--1.2').coerce_to('NUMBER') */
 
 		suite.T().Log("About to run line #51: r.Expr('--1.2').CoerceTo('NUMBER')")
@@ -188,7 +188,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #53
 		/* err("ReqlQueryLogicError", "Could not coerce `-1.2-` to NUMBER.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Could not coerce `-1.2-` to NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Could not coerce `-1.2-` to NUMBER.")
 		/* r.expr('-1.2-').coerce_to('NUMBER') */
 
 		suite.T().Log("About to run line #53: r.Expr('-1.2-').CoerceTo('NUMBER')")
@@ -203,7 +203,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #55
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* r.expr('0xa').coerce_to('NUMBER') */
 
 		suite.T().Log("About to run line #55: r.Expr('0xa').CoerceTo('NUMBER')")
@@ -218,7 +218,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #57
 		/* err("ReqlQueryLogicError", "Non-finite number: inf", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Non-finite number: inf")
+		var expected_ = err("ReqlQueryLogicError", "Non-finite number: inf")
 		/* r.expr('inf').coerce_to('NUMBER') */
 
 		suite.T().Log("About to run line #57: r.Expr('inf').CoerceTo('NUMBER')")
@@ -233,7 +233,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #61
 		/* 13 */
-		var expected_ int = 13
+		var expected_ = 13
 		/* r.expr('hello, world!').count() */
 
 		suite.T().Log("About to run line #61: r.Expr('hello, world!').Count()")
@@ -248,7 +248,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #63
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* r.expr(japanese_hello).count() */
 
 		suite.T().Log("About to run line #63: r.Expr(japanese_hello).Count()")
@@ -263,7 +263,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #67
 		/* 'ello' */
-		var expected_ string = "ello"
+		var expected_ = "ello"
 		/* r.expr('hello').slice(1) */
 
 		suite.T().Log("About to run line #67: r.Expr('hello').Slice(1)")
@@ -278,7 +278,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #69
 		/* 'o' */
-		var expected_ string = "o"
+		var expected_ = "o"
 		/* r.expr('hello').slice(-1) */
 
 		suite.T().Log("About to run line #69: r.Expr('hello').Slice(-1)")
@@ -293,7 +293,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #71
 		/* 'el' */
-		var expected_ string = "el"
+		var expected_ = "el"
 		/* r.expr('hello').slice(-4,3) */
 
 		suite.T().Log("About to run line #71: r.Expr('hello').Slice(-4, 3)")
@@ -308,7 +308,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #73
 		/* 'hello' */
-		var expected_ string = "hello"
+		var expected_ = "hello"
 		/* r.expr('hello').slice(-99) */
 
 		suite.T().Log("About to run line #73: r.Expr('hello').Slice(-99)")
@@ -323,7 +323,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #75
 		/* 'hello' */
-		var expected_ string = "hello"
+		var expected_ = "hello"
 		/* r.expr('hello').slice(0) */
 
 		suite.T().Log("About to run line #75: r.Expr('hello').Slice(0)")
@@ -338,7 +338,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #77
 		/* u'んにちは' */
-		var expected_ string = "んにちは"
+		var expected_ = "んにちは"
 		/* r.expr(japanese_hello).slice(1) */
 
 		suite.T().Log("About to run line #77: r.Expr(japanese_hello).Slice(1)")
@@ -353,7 +353,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #84
 		/* u'ん' */
-		var expected_ string = "ん"
+		var expected_ = "ん"
 		/* r.expr(japanese_hello).slice(1,2) */
 
 		suite.T().Log("About to run line #84: r.Expr(japanese_hello).Slice(1, 2)")
@@ -368,7 +368,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #91
 		/* u'にちは' */
-		var expected_ string = "にちは"
+		var expected_ = "にちは"
 		/* r.expr(japanese_hello).slice(-3) */
 
 		suite.T().Log("About to run line #91: r.Expr(japanese_hello).Slice(-3)")
@@ -383,7 +383,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #100
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('').split() */
 
 		suite.T().Log("About to run line #100: r.Expr('').Split()")
@@ -398,7 +398,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #102
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('').split(null) */
 
 		suite.T().Log("About to run line #102: r.Expr('').Split(nil)")
@@ -413,7 +413,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #104
 		/* [''] */
-		var expected_ []interface{} = []interface{}{""}
+		var expected_ = []interface{}{""}
 		/* r.expr('').split(' ') */
 
 		suite.T().Log("About to run line #104: r.Expr('').Split(' ')")
@@ -428,7 +428,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #106
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('').split('') */
 
 		suite.T().Log("About to run line #106: r.Expr('').Split('')")
@@ -443,7 +443,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #108
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('').split(null, 5) */
 
 		suite.T().Log("About to run line #108: r.Expr('').Split(nil, 5)")
@@ -458,7 +458,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #110
 		/* [''] */
-		var expected_ []interface{} = []interface{}{""}
+		var expected_ = []interface{}{""}
 		/* r.expr('').split(' ', 5) */
 
 		suite.T().Log("About to run line #110: r.Expr('').Split(' ', 5)")
@@ -473,7 +473,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #112
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('').split('', 5) */
 
 		suite.T().Log("About to run line #112: r.Expr('').Split('', 5)")
@@ -488,7 +488,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #115
 		/* ['aaaa', 'bbbb', 'cccc'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc"}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc"}
 		/* r.expr('aaaa bbbb  cccc ').split() */
 
 		suite.T().Log("About to run line #115: r.Expr('aaaa bbbb  cccc ').Split()")
@@ -503,7 +503,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #117
 		/* ['aaaa', 'bbbb', 'cccc'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc"}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc"}
 		/* r.expr('aaaa bbbb  cccc ').split(null) */
 
 		suite.T().Log("About to run line #117: r.Expr('aaaa bbbb  cccc ').Split(nil)")
@@ -518,7 +518,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #119
 		/* ['aaaa', 'bbbb', '', 'cccc', ''] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "", "cccc", ""}
+		var expected_ = []interface{}{"aaaa", "bbbb", "", "cccc", ""}
 		/* r.expr('aaaa bbbb  cccc ').split(' ') */
 
 		suite.T().Log("About to run line #119: r.Expr('aaaa bbbb  cccc ').Split(' ')")
@@ -533,7 +533,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #121
 		/* ['a', 'a', 'a', 'a', ' ', 'b', 'b', 'b', 'b', ' ', ' ', 'c', 'c', 'c', 'c', ' '] */
-		var expected_ []interface{} = []interface{}{"a", "a", "a", "a", " ", "b", "b", "b", "b", " ", " ", "c", "c", "c", "c", " "}
+		var expected_ = []interface{}{"a", "a", "a", "a", " ", "b", "b", "b", "b", " ", " ", "c", "c", "c", "c", " "}
 		/* r.expr('aaaa bbbb  cccc ').split('') */
 
 		suite.T().Log("About to run line #121: r.Expr('aaaa bbbb  cccc ').Split('')")
@@ -548,7 +548,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #123
 		/* ['aaaa ', '', '', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "", "", "  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "", "", "  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('b') */
 
 		suite.T().Log("About to run line #123: r.Expr('aaaa bbbb  cccc ').Split('b')")
@@ -563,7 +563,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #125
 		/* ['aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('bb') */
 
 		suite.T().Log("About to run line #125: r.Expr('aaaa bbbb  cccc ').Split('bb')")
@@ -578,7 +578,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #127
 		/* ['aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc "}
+		var expected_ = []interface{}{"aaaa", "cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split(' bbbb  ') */
 
 		suite.T().Log("About to run line #127: r.Expr('aaaa bbbb  cccc ').Split(' bbbb  ')")
@@ -593,7 +593,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #129
 		/* ['aaaa ', '', '  cccc b d ', ' e ', '', ' f'] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc b d ", " e ", "", " f"}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc b d ", " e ", "", " f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split('bb') */
 
 		suite.T().Log("About to run line #129: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split('bb')")
@@ -608,7 +608,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #131
 		/* ['aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ') */
 
 		suite.T().Log("About to run line #131: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ')")
@@ -623,7 +623,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #133
 		/* ['aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e", "f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ') */
 
 		suite.T().Log("About to run line #133: r.Expr('aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ')")
@@ -638,7 +638,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #136
 		/* ['aaaa', 'bbbb', 'cccc'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc"}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc"}
 		/* r.expr('aaaa bbbb  cccc ').split(null, 3) */
 
 		suite.T().Log("About to run line #136: r.Expr('aaaa bbbb  cccc ').Split(nil, 3)")
@@ -653,7 +653,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #138
 		/* ['aaaa', 'bbbb', '', 'cccc', ''] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "", "cccc", ""}
+		var expected_ = []interface{}{"aaaa", "bbbb", "", "cccc", ""}
 		/* r.expr('aaaa bbbb  cccc ').split(' ', 5) */
 
 		suite.T().Log("About to run line #138: r.Expr('aaaa bbbb  cccc ').Split(' ', 5)")
@@ -668,7 +668,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #140
 		/* ['a', 'a', 'a', 'a', ' ', 'bbbb  cccc '] */
-		var expected_ []interface{} = []interface{}{"a", "a", "a", "a", " ", "bbbb  cccc "}
+		var expected_ = []interface{}{"a", "a", "a", "a", " ", "bbbb  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('', 5) */
 
 		suite.T().Log("About to run line #140: r.Expr('aaaa bbbb  cccc ').Split('', 5)")
@@ -683,7 +683,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #142
 		/* ['aaaa ', '', '', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "", "", "  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "", "", "  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('b', 5) */
 
 		suite.T().Log("About to run line #142: r.Expr('aaaa bbbb  cccc ').Split('b', 5)")
@@ -698,7 +698,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #144
 		/* ['aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('bb', 3) */
 
 		suite.T().Log("About to run line #144: r.Expr('aaaa bbbb  cccc ').Split('bb', 3)")
@@ -713,7 +713,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #146
 		/* ['aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc "}
+		var expected_ = []interface{}{"aaaa", "cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #146: r.Expr('aaaa bbbb  cccc ').Split(' bbbb  ', 2)")
@@ -728,7 +728,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #148
 		/* ['aaaa ', '', '  cccc b d ', ' e ', '', ' f'] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc b d ", " e ", "", " f"}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc b d ", " e ", "", " f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split('bb', 6) */
 
 		suite.T().Log("About to run line #148: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split('bb', 6)")
@@ -743,7 +743,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #150
 		/* ['aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #150: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ', 2)")
@@ -758,7 +758,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #152
 		/* ['aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e", "f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ', 3) */
 
 		suite.T().Log("About to run line #152: r.Expr('aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ', 3)")
@@ -773,7 +773,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #155
 		/* ['aaaa', 'bbbb', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc "}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split(null, 2) */
 
 		suite.T().Log("About to run line #155: r.Expr('aaaa bbbb  cccc ').Split(nil, 2)")
@@ -788,7 +788,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #157
 		/* ["a", "b"] */
-		var expected_ []interface{} = []interface{}{"a", "b"}
+		var expected_ = []interface{}{"a", "b"}
 		/* r.expr("a  b  ").split(null, 2) */
 
 		suite.T().Log("About to run line #157: r.Expr('a  b  ').Split(nil, 2)")
@@ -803,7 +803,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #159
 		/* ['aaaa', 'bbbb', '', 'cccc', ''] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "", "cccc", ""}
+		var expected_ = []interface{}{"aaaa", "bbbb", "", "cccc", ""}
 		/* r.expr('aaaa bbbb  cccc ').split(' ', 4) */
 
 		suite.T().Log("About to run line #159: r.Expr('aaaa bbbb  cccc ').Split(' ', 4)")
@@ -818,7 +818,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #161
 		/* ['a', 'a', 'a', 'a', ' bbbb  cccc '] */
-		var expected_ []interface{} = []interface{}{"a", "a", "a", "a", " bbbb  cccc "}
+		var expected_ = []interface{}{"a", "a", "a", "a", " bbbb  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('', 4) */
 
 		suite.T().Log("About to run line #161: r.Expr('aaaa bbbb  cccc ').Split('', 4)")
@@ -833,7 +833,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #163
 		/* ['aaaa ', '', '', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "", "", "  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "", "", "  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('b', 4) */
 
 		suite.T().Log("About to run line #163: r.Expr('aaaa bbbb  cccc ').Split('b', 4)")
@@ -848,7 +848,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #165
 		/* ['aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('bb', 2) */
 
 		suite.T().Log("About to run line #165: r.Expr('aaaa bbbb  cccc ').Split('bb', 2)")
@@ -863,7 +863,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #167
 		/* ['aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc "}
+		var expected_ = []interface{}{"aaaa", "cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split(' bbbb  ', 1) */
 
 		suite.T().Log("About to run line #167: r.Expr('aaaa bbbb  cccc ').Split(' bbbb  ', 1)")
@@ -878,7 +878,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #169
 		/* ['aaaa ', '', '  cccc b d ', ' e ', '', ' f'] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc b d ", " e ", "", " f"}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc b d ", " e ", "", " f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split('bb', 5) */
 
 		suite.T().Log("About to run line #169: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split('bb', 5)")
@@ -893,7 +893,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #171
 		/* ['aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ', 1) */
 
 		suite.T().Log("About to run line #171: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ', 1)")
@@ -908,7 +908,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #173
 		/* ['aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e", "f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #173: r.Expr('aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ', 2)")
@@ -923,7 +923,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #176
 		/* ['aaaa', 'bbbb  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb  cccc "}
+		var expected_ = []interface{}{"aaaa", "bbbb  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split(null, 1) */
 
 		suite.T().Log("About to run line #176: r.Expr('aaaa bbbb  cccc ').Split(nil, 1)")
@@ -938,7 +938,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #178
 		/* ['aaaa', 'bbbb', ' cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", " cccc "}
+		var expected_ = []interface{}{"aaaa", "bbbb", " cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split(' ', 2) */
 
 		suite.T().Log("About to run line #178: r.Expr('aaaa bbbb  cccc ').Split(' ', 2)")
@@ -953,7 +953,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #180
 		/* ['a', 'a', 'aa bbbb  cccc '] */
-		var expected_ []interface{} = []interface{}{"a", "a", "aa bbbb  cccc "}
+		var expected_ = []interface{}{"a", "a", "aa bbbb  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('', 2) */
 
 		suite.T().Log("About to run line #180: r.Expr('aaaa bbbb  cccc ').Split('', 2)")
@@ -968,7 +968,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #182
 		/* ['aaaa ', '', 'bb  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "bb  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "bb  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('b', 2) */
 
 		suite.T().Log("About to run line #182: r.Expr('aaaa bbbb  cccc ').Split('b', 2)")
@@ -983,7 +983,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #184
 		/* ['aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split('bb', 2) */
 
 		suite.T().Log("About to run line #184: r.Expr('aaaa bbbb  cccc ').Split('bb', 2)")
@@ -998,7 +998,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #186
 		/* ['aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc "}
+		var expected_ = []interface{}{"aaaa", "cccc "}
 		/* r.expr('aaaa bbbb  cccc ').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #186: r.Expr('aaaa bbbb  cccc ').Split(' bbbb  ', 2)")
@@ -1013,7 +1013,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #188
 		/* ['aaaa ', '', '  cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"aaaa ", "", "  cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"aaaa ", "", "  cccc b d bb e bbbb f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split('bb', 2) */
 
 		suite.T().Log("About to run line #188: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split('bb', 2)")
@@ -1028,7 +1028,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #190
 		/* ['aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #190: r.Expr('aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ', 2)")
@@ -1043,7 +1043,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #192
 		/* ['aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"aaaa", "cccc b d bb e", "f"}
 		/* r.expr('aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #192: r.Expr('aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ', 2)")
@@ -1058,7 +1058,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #195
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('  ').split() */
 
 		suite.T().Log("About to run line #195: r.Expr('  ').Split()")
@@ -1073,7 +1073,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #197
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('  ').split(null) */
 
 		suite.T().Log("About to run line #197: r.Expr('  ').Split(nil)")
@@ -1088,7 +1088,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #199
 		/* ['', '', ''] */
-		var expected_ []interface{} = []interface{}{"", "", ""}
+		var expected_ = []interface{}{"", "", ""}
 		/* r.expr('  ').split(' ') */
 
 		suite.T().Log("About to run line #199: r.Expr('  ').Split(' ')")
@@ -1103,7 +1103,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #201
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr('  ').split(null, 5) */
 
 		suite.T().Log("About to run line #201: r.Expr('  ').Split(nil, 5)")
@@ -1118,7 +1118,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #203
 		/* ['', '', ''] */
-		var expected_ []interface{} = []interface{}{"", "", ""}
+		var expected_ = []interface{}{"", "", ""}
 		/* r.expr('  ').split(' ', 5) */
 
 		suite.T().Log("About to run line #203: r.Expr('  ').Split(' ', 5)")
@@ -1133,7 +1133,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #206
 		/* ['aaaa', 'bbbb', 'cccc'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc"}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc"}
 		/* r.expr('  aaaa bbbb  cccc ').split() */
 
 		suite.T().Log("About to run line #206: r.Expr('  aaaa bbbb  cccc ').Split()")
@@ -1148,7 +1148,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #208
 		/* ['aaaa', 'bbbb', 'cccc'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc"}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc"}
 		/* r.expr('  aaaa bbbb  cccc ').split(null) */
 
 		suite.T().Log("About to run line #208: r.Expr('  aaaa bbbb  cccc ').Split(nil)")
@@ -1163,7 +1163,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #210
 		/* ['', '', 'aaaa', 'bbbb', '', 'cccc', ''] */
-		var expected_ []interface{} = []interface{}{"", "", "aaaa", "bbbb", "", "cccc", ""}
+		var expected_ = []interface{}{"", "", "aaaa", "bbbb", "", "cccc", ""}
 		/* r.expr('  aaaa bbbb  cccc ').split(' ') */
 
 		suite.T().Log("About to run line #210: r.Expr('  aaaa bbbb  cccc ').Split(' ')")
@@ -1178,7 +1178,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #212
 		/* ['  aaaa ', '', '', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "", "", "  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "", "", "  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('b') */
 
 		suite.T().Log("About to run line #212: r.Expr('  aaaa bbbb  cccc ').Split('b')")
@@ -1193,7 +1193,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #214
 		/* ['  aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('bb') */
 
 		suite.T().Log("About to run line #214: r.Expr('  aaaa bbbb  cccc ').Split('bb')")
@@ -1208,7 +1208,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #216
 		/* ['  aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc "}
+		var expected_ = []interface{}{"  aaaa", "cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(' bbbb  ') */
 
 		suite.T().Log("About to run line #216: r.Expr('  aaaa bbbb  cccc ').Split(' bbbb  ')")
@@ -1223,7 +1223,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #218
 		/* ['  aaaa ', '', '  cccc b d ', ' e ', '', ' f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc b d ", " e ", "", " f"}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc b d ", " e ", "", " f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split('bb') */
 
 		suite.T().Log("About to run line #218: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split('bb')")
@@ -1238,7 +1238,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #220
 		/* ['  aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ') */
 
 		suite.T().Log("About to run line #220: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ')")
@@ -1253,7 +1253,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #222
 		/* ['  aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e", "f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ') */
 
 		suite.T().Log("About to run line #222: r.Expr('  aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ')")
@@ -1268,7 +1268,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #225
 		/* ['aaaa', 'bbbb', 'cccc'] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc"}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc"}
 		/* r.expr('  aaaa bbbb  cccc ').split(null, 3) */
 
 		suite.T().Log("About to run line #225: r.Expr('  aaaa bbbb  cccc ').Split(nil, 3)")
@@ -1283,7 +1283,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #227
 		/* ['', '', 'aaaa', 'bbbb', '', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"", "", "aaaa", "bbbb", "", "cccc "}
+		var expected_ = []interface{}{"", "", "aaaa", "bbbb", "", "cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(' ', 5) */
 
 		suite.T().Log("About to run line #227: r.Expr('  aaaa bbbb  cccc ').Split(' ', 5)")
@@ -1298,7 +1298,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #229
 		/* ['  aaaa ', '', '', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "", "", "  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "", "", "  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('b', 5) */
 
 		suite.T().Log("About to run line #229: r.Expr('  aaaa bbbb  cccc ').Split('b', 5)")
@@ -1313,7 +1313,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #231
 		/* ['  aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('bb', 3) */
 
 		suite.T().Log("About to run line #231: r.Expr('  aaaa bbbb  cccc ').Split('bb', 3)")
@@ -1328,7 +1328,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #233
 		/* ['  aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc "}
+		var expected_ = []interface{}{"  aaaa", "cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #233: r.Expr('  aaaa bbbb  cccc ').Split(' bbbb  ', 2)")
@@ -1343,7 +1343,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #235
 		/* ['  aaaa ', '', '  cccc b d ', ' e ', '', ' f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc b d ", " e ", "", " f"}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc b d ", " e ", "", " f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split('bb', 6) */
 
 		suite.T().Log("About to run line #235: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split('bb', 6)")
@@ -1358,7 +1358,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #237
 		/* ['  aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #237: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ', 2)")
@@ -1373,7 +1373,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #239
 		/* ['  aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e", "f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ', 3) */
 
 		suite.T().Log("About to run line #239: r.Expr('  aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ', 3)")
@@ -1388,7 +1388,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #242
 		/* ['aaaa', 'bbbb', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb", "cccc "}
+		var expected_ = []interface{}{"aaaa", "bbbb", "cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(null, 2) */
 
 		suite.T().Log("About to run line #242: r.Expr('  aaaa bbbb  cccc ').Split(nil, 2)")
@@ -1403,7 +1403,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #244
 		/* ["a", "b"] */
-		var expected_ []interface{} = []interface{}{"a", "b"}
+		var expected_ = []interface{}{"a", "b"}
 		/* r.expr("a  b  ").split(null, 2) */
 
 		suite.T().Log("About to run line #244: r.Expr('a  b  ').Split(nil, 2)")
@@ -1418,7 +1418,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #246
 		/* ['', '', 'aaaa', 'bbbb', ' cccc '] */
-		var expected_ []interface{} = []interface{}{"", "", "aaaa", "bbbb", " cccc "}
+		var expected_ = []interface{}{"", "", "aaaa", "bbbb", " cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(' ', 4) */
 
 		suite.T().Log("About to run line #246: r.Expr('  aaaa bbbb  cccc ').Split(' ', 4)")
@@ -1433,7 +1433,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #248
 		/* ['  aaaa ', '', '', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "", "", "  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "", "", "  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('b', 4) */
 
 		suite.T().Log("About to run line #248: r.Expr('  aaaa bbbb  cccc ').Split('b', 4)")
@@ -1448,7 +1448,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #250
 		/* ['  aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('bb', 2) */
 
 		suite.T().Log("About to run line #250: r.Expr('  aaaa bbbb  cccc ').Split('bb', 2)")
@@ -1463,7 +1463,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #252
 		/* ['  aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc "}
+		var expected_ = []interface{}{"  aaaa", "cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(' bbbb  ', 1) */
 
 		suite.T().Log("About to run line #252: r.Expr('  aaaa bbbb  cccc ').Split(' bbbb  ', 1)")
@@ -1478,7 +1478,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #254
 		/* ['  aaaa ', '', '  cccc b d ', ' e ', '', ' f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc b d ", " e ", "", " f"}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc b d ", " e ", "", " f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split('bb', 5) */
 
 		suite.T().Log("About to run line #254: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split('bb', 5)")
@@ -1493,7 +1493,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #256
 		/* ['  aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ', 1) */
 
 		suite.T().Log("About to run line #256: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ', 1)")
@@ -1508,7 +1508,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #258
 		/* ['  aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e", "f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #258: r.Expr('  aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ', 2)")
@@ -1523,7 +1523,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #261
 		/* ['aaaa', 'bbbb  cccc '] */
-		var expected_ []interface{} = []interface{}{"aaaa", "bbbb  cccc "}
+		var expected_ = []interface{}{"aaaa", "bbbb  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(null, 1) */
 
 		suite.T().Log("About to run line #261: r.Expr('  aaaa bbbb  cccc ').Split(nil, 1)")
@@ -1538,7 +1538,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #263
 		/* ['', '', 'aaaa bbbb  cccc '] */
-		var expected_ []interface{} = []interface{}{"", "", "aaaa bbbb  cccc "}
+		var expected_ = []interface{}{"", "", "aaaa bbbb  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(' ', 2) */
 
 		suite.T().Log("About to run line #263: r.Expr('  aaaa bbbb  cccc ').Split(' ', 2)")
@@ -1553,7 +1553,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #265
 		/* ['  aaaa ', '', 'bb  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "bb  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "bb  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('b', 2) */
 
 		suite.T().Log("About to run line #265: r.Expr('  aaaa bbbb  cccc ').Split('b', 2)")
@@ -1568,7 +1568,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #267
 		/* ['  aaaa ', '', '  cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc "}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split('bb', 2) */
 
 		suite.T().Log("About to run line #267: r.Expr('  aaaa bbbb  cccc ').Split('bb', 2)")
@@ -1583,7 +1583,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #269
 		/* ['  aaaa', 'cccc '] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc "}
+		var expected_ = []interface{}{"  aaaa", "cccc "}
 		/* r.expr('  aaaa bbbb  cccc ').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #269: r.Expr('  aaaa bbbb  cccc ').Split(' bbbb  ', 2)")
@@ -1598,7 +1598,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #271
 		/* ['  aaaa ', '', '  cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa ", "", "  cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"  aaaa ", "", "  cccc b d bb e bbbb f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split('bb', 2) */
 
 		suite.T().Log("About to run line #271: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split('bb', 2)")
@@ -1613,7 +1613,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #273
 		/* ['  aaaa', 'cccc b d bb e bbbb f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e bbbb f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #273: r.Expr('  aaaa bbbb  cccc b d bb e bbbb f').Split(' bbbb  ', 2)")
@@ -1628,7 +1628,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #275
 		/* ['  aaaa', 'cccc b d bb e', 'f'] */
-		var expected_ []interface{} = []interface{}{"  aaaa", "cccc b d bb e", "f"}
+		var expected_ = []interface{}{"  aaaa", "cccc b d bb e", "f"}
 		/* r.expr('  aaaa bbbb  cccc b d bb e bbbb  f').split(' bbbb  ', 2) */
 
 		suite.T().Log("About to run line #275: r.Expr('  aaaa bbbb  cccc b d bb e bbbb  f').Split(' bbbb  ', 2)")
@@ -1643,7 +1643,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #278
 		/* "ABC-DEF-GHJ" */
-		var expected_ string = "ABC-DEF-GHJ"
+		var expected_ = "ABC-DEF-GHJ"
 		/* r.expr("abc-dEf-GHJ").upcase() */
 
 		suite.T().Log("About to run line #278: r.Expr('abc-dEf-GHJ').Upcase()")
@@ -1658,7 +1658,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #280
 		/* "abc-def-ghj" */
-		var expected_ string = "abc-def-ghj"
+		var expected_ = "abc-def-ghj"
 		/* r.expr("abc-dEf-GHJ").downcase() */
 
 		suite.T().Log("About to run line #280: r.Expr('abc-dEf-GHJ').Downcase()")
@@ -1673,7 +1673,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #285
 		/* ["f", "\u00e9", "o", "o"] */
-		var expected_ []interface{} = []interface{}{"f", "é", "o", "o"}
+		var expected_ = []interface{}{"f", "é", "o", "o"}
 		/* r.expr(u"f\u00e9oo").split("") */
 
 		suite.T().Log("About to run line #285: r.Expr('féoo').Split('')")
@@ -1688,7 +1688,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #294
 		/* ["f", "e\u0301", "o", "o"] */
-		var expected_ []interface{} = []interface{}{"f", "é", "o", "o"}
+		var expected_ = []interface{}{"f", "é", "o", "o"}
 		/* r.expr(u"fe\u0301oo").split("") */
 
 		suite.T().Log("About to run line #294: r.Expr('féoo').Split('')")
@@ -1703,7 +1703,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #307
 		/* ["foo", "bar", "baz", "quux", "fred", "barney", "wilma"] */
-		var expected_ []interface{} = []interface{}{"foo", "bar", "baz", "quux", "fred", "barney", "wilma"}
+		var expected_ = []interface{}{"foo", "bar", "baz", "quux", "fred", "barney", "wilma"}
 		/* r.expr(u"foo bar\tbaz\nquux\rfred\u000bbarney\u000cwilma").split() */
 
 		suite.T().Log("About to run line #307: r.Expr('foo bar\\tbaz\\nquux\\rfred\\u000bbarney\\u000cwilma').Split()")
@@ -1718,7 +1718,7 @@ func (suite *DatumStringSuite) TestCases() {
 	{
 		// datum/string.yaml line #323
 		/* ["foo", "bar", "baz\u2060quux", "fred", "barney", "wilma", "betty\u200b"] */
-		var expected_ []interface{} = []interface{}{"foo", "bar", "baz\u2060quux", "fred", "barney", "wilma", "betty\u200b"}
+		var expected_ = []interface{}{"foo", "bar", "baz\u2060quux", "fred", "barney", "wilma", "betty\u200b"}
 		/* r.expr(u"foo\u00a0bar\u2001baz\u2060quux\u2028fred\u2028barney\u2029wilma\u0085betty\u200b").split() */
 
 		suite.T().Log("About to run line #323: r.Expr('foo\\u00a0bar\\u2001baz\\u2060quux\\u2028fred\\u2028barney\\u2029wilma\\u0085betty\\u200b').Split()")

--- a/internal/integration/reql_tests/reql_datum_typeof_test.go
+++ b/internal/integration/reql_tests/reql_datum_typeof_test.go
@@ -61,7 +61,7 @@ func (suite *DatumTypeofSuite) TestCases() {
 	{
 		// datum/typeof.yaml line #5
 		/* 'NULL' */
-		var expected_ string = "NULL"
+		var expected_ = "NULL"
 		/* r.expr(null).type_of() */
 
 		suite.T().Log("About to run line #5: r.Expr(nil).TypeOf()")
@@ -76,7 +76,7 @@ func (suite *DatumTypeofSuite) TestCases() {
 	{
 		// datum/typeof.yaml line #9
 		/* 'NULL' */
-		var expected_ string = "NULL"
+		var expected_ = "NULL"
 		/* r.type_of(null) */
 
 		suite.T().Log("About to run line #9: r.TypeOf(nil)")

--- a/internal/integration/reql_tests/reql_datum_uuid_test.go
+++ b/internal/integration/reql_tests/reql_datum_uuid_test.go
@@ -91,7 +91,7 @@ func (suite *DatumUuidSuite) TestCases() {
 	{
 		// datum/uuid.yaml line #7
 		/* 'STRING' */
-		var expected_ string = "STRING"
+		var expected_ = "STRING"
 		/* r.type_of(r.uuid()) */
 
 		suite.T().Log("About to run line #7: r.TypeOf(r.UUID())")
@@ -106,7 +106,7 @@ func (suite *DatumUuidSuite) TestCases() {
 	{
 		// datum/uuid.yaml line #9
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.uuid().ne(r.uuid()) */
 
 		suite.T().Log("About to run line #9: r.UUID().Ne(r.UUID())")
@@ -121,7 +121,7 @@ func (suite *DatumUuidSuite) TestCases() {
 	{
 		// datum/uuid.yaml line #11
 		/* ('97dd10a5-4fc4-554f-86c5-0d2c2e3d5330') */
-		var expected_ string = "97dd10a5-4fc4-554f-86c5-0d2c2e3d5330"
+		var expected_ = "97dd10a5-4fc4-554f-86c5-0d2c2e3d5330"
 		/* r.uuid('magic') */
 
 		suite.T().Log("About to run line #11: r.UUID('magic')")
@@ -136,7 +136,7 @@ func (suite *DatumUuidSuite) TestCases() {
 	{
 		// datum/uuid.yaml line #13
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.uuid('magic').eq(r.uuid('magic')) */
 
 		suite.T().Log("About to run line #13: r.UUID('magic').Eq(r.UUID('magic'))")
@@ -151,7 +151,7 @@ func (suite *DatumUuidSuite) TestCases() {
 	{
 		// datum/uuid.yaml line #15
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.uuid('magic').ne(r.uuid('beans')) */
 
 		suite.T().Log("About to run line #15: r.UUID('magic').Ne(r.UUID('beans'))")
@@ -166,7 +166,7 @@ func (suite *DatumUuidSuite) TestCases() {
 	{
 		// datum/uuid.yaml line #17
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* r.expr([1,2,3,4,5,6,7,8,9,10]).map(lambda u:r.uuid()).distinct().count() */
 
 		suite.T().Log("About to run line #17: r.Expr([]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}).Map(func(u r.Term) interface{} { return r.UUID()}).Distinct().Count()")

--- a/internal/integration/reql_tests/reql_default_test.go
+++ b/internal/integration/reql_tests/reql_default_test.go
@@ -61,7 +61,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #3
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1).default(2) */
 
 		suite.T().Log("About to run line #3: r.Expr(1).Default(2)")
@@ -76,7 +76,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #5
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(null).default(2) */
 
 		suite.T().Log("About to run line #5: r.Expr(nil).Default(2)")
@@ -91,7 +91,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #7
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr({})['b'].default(2) */
 
 		suite.T().Log("About to run line #7: r.Expr(map[interface{}]interface{}{}).AtIndex('b').Default(2)")
@@ -106,7 +106,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #10
 		/* err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.")
 		/* r.expr(r.expr('a')['b']).default(2) */
 
 		suite.T().Log("About to run line #10: r.Expr(r.Expr('a').AtIndex('b')).Default(2)")
@@ -121,7 +121,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #14
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([]).reduce(lambda a,b:a+b).default(2) */
 
 		suite.T().Log("About to run line #14: r.Expr([]interface{}{}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)}).Default(2)")
@@ -136,7 +136,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #18
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([]).union([]).reduce(lambda a,b:a+b).default(2) */
 
 		suite.T().Log("About to run line #18: r.Expr([]interface{}{}).Union([]interface{}{}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)}).Default(2)")
@@ -151,7 +151,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #22
 		/* err("ReqlQueryLogicError", "Cannot convert STRING to SEQUENCE", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert STRING to SEQUENCE")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert STRING to SEQUENCE")
 		/* r.expr('a').reduce(lambda a,b:a+b).default(2) */
 
 		suite.T().Log("About to run line #22: r.Expr('a').Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)}).Default(2)")
@@ -166,7 +166,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #25
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* (r.expr(null) + 5).default(2) */
 
 		suite.T().Log("About to run line #25: r.Expr(nil).Add(5).Default(2)")
@@ -181,7 +181,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #28
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* (5 + r.expr(null)).default(2) */
 
 		suite.T().Log("About to run line #28: r.Add(5, r.Expr(nil)).Default(2)")
@@ -196,7 +196,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #31
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* (5 - r.expr(null)).default(2) */
 
 		suite.T().Log("About to run line #31: r.Sub(5, r.Expr(nil)).Default(2)")
@@ -211,7 +211,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #34
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* (r.expr(null) - 5).default(2) */
 
 		suite.T().Log("About to run line #34: r.Expr(nil).Sub(5).Default(2)")
@@ -226,7 +226,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #37
 		/* err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
 		/* (r.expr('a') + 5).default(2) */
 
 		suite.T().Log("About to run line #37: r.Expr('a').Add(5).Default(2)")
@@ -241,7 +241,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #40
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* (5 + r.expr('a')).default(2) */
 
 		suite.T().Log("About to run line #40: r.Add(5, r.Expr('a')).Default(2)")
@@ -256,7 +256,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #43
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* (r.expr('a') - 5).default(2) */
 
 		suite.T().Log("About to run line #43: r.Expr('a').Sub(5).Default(2)")
@@ -271,7 +271,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #46
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* (5 - r.expr('a')).default(2) */
 
 		suite.T().Log("About to run line #46: r.Sub(5, r.Expr('a')).Default(2)")
@@ -286,7 +286,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #50
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1).default(r.error()) */
 
 		suite.T().Log("About to run line #50: r.Expr(1).Default(r.Error())")
@@ -316,7 +316,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #54
 		/* err("ReqlNonExistenceError", "No attribute `b` in object:", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `b` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `b` in object:")
 		/* r.expr({})['b'].default(r.error()) */
 
 		suite.T().Log("About to run line #54: r.Expr(map[interface{}]interface{}{}).AtIndex('b').Default(r.Error())")
@@ -331,7 +331,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #58
 		/* err("ReqlNonExistenceError", "Cannot reduce over an empty stream.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Cannot reduce over an empty stream.")
+		var expected_ = err("ReqlNonExistenceError", "Cannot reduce over an empty stream.")
 		/* r.expr([]).reduce(lambda a,b:a+b).default(r.error) */
 
 		suite.T().Log("About to run line #58: r.Expr([]interface{}{}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)}).Default(r.Error())")
@@ -346,7 +346,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #62
 		/* err("ReqlNonExistenceError", "Cannot reduce over an empty stream.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Cannot reduce over an empty stream.")
+		var expected_ = err("ReqlNonExistenceError", "Cannot reduce over an empty stream.")
 		/* r.expr([]).union([]).reduce(lambda a,b:a+b).default(r.error) */
 
 		suite.T().Log("About to run line #62: r.Expr([]interface{}{}).Union([]interface{}{}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)}).Default(r.Error())")
@@ -361,7 +361,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #65
 		/* err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* (r.expr(null) + 5).default(r.error) */
 
 		suite.T().Log("About to run line #65: r.Expr(nil).Add(5).Default(r.Error())")
@@ -376,7 +376,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #68
 		/* err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* (5 + r.expr(null)).default(r.error) */
 
 		suite.T().Log("About to run line #68: r.Add(5, r.Expr(nil)).Default(r.Error())")
@@ -391,7 +391,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #71
 		/* err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* (5 - r.expr(null)).default(r.error) */
 
 		suite.T().Log("About to run line #71: r.Sub(5, r.Expr(nil)).Default(r.Error())")
@@ -406,7 +406,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #74
 		/* err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* (r.expr(null) - 5).default(r.error) */
 
 		suite.T().Log("About to run line #74: r.Expr(nil).Sub(5).Default(r.Error())")
@@ -421,7 +421,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #79
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1).default(lambda e:e) */
 
 		suite.T().Log("About to run line #79: r.Expr(1).Default(func(e r.Term) interface{} { return e})")
@@ -451,7 +451,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #87
 		/* "No attribute `b` in object:\n{}" */
-		var expected_ string = "No attribute `b` in object:\n{}"
+		var expected_ = "No attribute `b` in object:\n{}"
 		/* r.expr({})['b'].default(lambda e:e) */
 
 		suite.T().Log("About to run line #87: r.Expr(map[interface{}]interface{}{}).AtIndex('b').Default(func(e r.Term) interface{} { return e})")
@@ -466,7 +466,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #91
 		/* ("Cannot reduce over an empty stream.") */
-		var expected_ string = "Cannot reduce over an empty stream."
+		var expected_ = "Cannot reduce over an empty stream."
 		/* r.expr([]).reduce(lambda a,b:a+b).default(lambda e:e) */
 
 		suite.T().Log("About to run line #91: r.Expr([]interface{}{}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)}).Default(func(e r.Term) interface{} { return e})")
@@ -481,7 +481,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #95
 		/* ("Cannot reduce over an empty stream.") */
-		var expected_ string = "Cannot reduce over an empty stream."
+		var expected_ = "Cannot reduce over an empty stream."
 		/* r.expr([]).union([]).reduce(lambda a,b:a+b).default(lambda e:e) */
 
 		suite.T().Log("About to run line #95: r.Expr([]interface{}{}).Union([]interface{}{}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)}).Default(func(e r.Term) interface{} { return e})")
@@ -496,7 +496,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #99
 		/* ("Expected type NUMBER but found NULL.") */
-		var expected_ string = "Expected type NUMBER but found NULL."
+		var expected_ = "Expected type NUMBER but found NULL."
 		/* (r.expr(null) + 5).default(lambda e:e) */
 
 		suite.T().Log("About to run line #99: r.Expr(nil).Add(5).Default(func(e r.Term) interface{} { return e})")
@@ -511,7 +511,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #103
 		/* ("Expected type NUMBER but found NULL.") */
-		var expected_ string = "Expected type NUMBER but found NULL."
+		var expected_ = "Expected type NUMBER but found NULL."
 		/* (5 + r.expr(null)).default(lambda e:e) */
 
 		suite.T().Log("About to run line #103: r.Add(5, r.Expr(nil)).Default(func(e r.Term) interface{} { return e})")
@@ -526,7 +526,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #107
 		/* ("Expected type NUMBER but found NULL.") */
-		var expected_ string = "Expected type NUMBER but found NULL."
+		var expected_ = "Expected type NUMBER but found NULL."
 		/* (5 - r.expr(null)).default(lambda e:e) */
 
 		suite.T().Log("About to run line #107: r.Sub(5, r.Expr(nil)).Default(func(e r.Term) interface{} { return e})")
@@ -541,7 +541,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #111
 		/* ("Expected type NUMBER but found NULL.") */
-		var expected_ string = "Expected type NUMBER but found NULL."
+		var expected_ = "Expected type NUMBER but found NULL."
 		/* (r.expr(null) - 5).default(lambda e:e) */
 
 		suite.T().Log("About to run line #111: r.Expr(nil).Sub(5).Default(func(e r.Term) interface{} { return e})")
@@ -563,7 +563,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #118
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].eq(1)) */
 
 		suite.T().Log("About to run line #118: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)})")
@@ -578,7 +578,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #122
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].eq(1), default=False) */
 
 		suite.T().Log("About to run line #122: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: false, })")
@@ -593,7 +593,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #126
 		/* [{}, {'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].eq(1), default=True) */
 
 		suite.T().Log("About to run line #126: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: true, })")
@@ -608,7 +608,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #131
 		/* [{}, {'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].eq(1), default=r.js('true')) */
 
 		suite.T().Log("About to run line #131: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: r.JS('true'), })")
@@ -623,7 +623,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #135
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].eq(1), default=r.js('false')) */
 
 		suite.T().Log("About to run line #135: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: r.JS('false'), })")
@@ -638,7 +638,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #139
 		/* err("ReqlNonExistenceError", "No attribute `a` in object:", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `a` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `a` in object:")
 		/* arr.filter(lambda x:x['a'].eq(1), default=r.error()) */
 
 		suite.T().Log("About to run line #139: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: r.Error(), })")
@@ -653,7 +653,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #144
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* r.expr(False).do(lambda d:arr.filter(lambda x:x['a'].eq(1), default=d)) */
 
 		suite.T().Log("About to run line #144: r.Expr(false).Do(func(d r.Term) interface{} { return arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: d, })})")
@@ -670,7 +670,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #148
 		/* [{}, {'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
 		/* r.expr(True).do(lambda d:arr.filter(lambda x:x['a'].eq(1), default=d)).order_by('a') */
 
 		suite.T().Log("About to run line #148: r.Expr(true).Do(func(d r.Term) interface{} { return arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: d, })}).OrderBy('a')")
@@ -687,7 +687,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #154
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].default(0).eq(1)) */
 
 		suite.T().Log("About to run line #154: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(0).Eq(1)})")
@@ -702,7 +702,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #158
 		/* ([{}, {'a':null}, {'a':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].default(1).eq(1)).order_by('a') */
 
 		suite.T().Log("About to run line #158: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(1).Eq(1)}).OrderBy('a')")
@@ -717,7 +717,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #162
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:x['a'].default(r.error()).eq(1)) */
 
 		suite.T().Log("About to run line #162: arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(r.Error()).Eq(1)})")
@@ -732,7 +732,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #168
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* r.expr(0).do(lambda i:arr.filter(lambda x:x['a'].default(i).eq(1))) */
 
 		suite.T().Log("About to run line #168: r.Expr(0).Do(func(i r.Term) interface{} { return arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(i).Eq(1)})})")
@@ -749,7 +749,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #172
 		/* ([{},{'a':null},{'a':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
 		/* r.expr(1).do(lambda i:arr.filter(lambda x:x['a'].default(i).eq(1))).order_by('a') */
 
 		suite.T().Log("About to run line #172: r.Expr(1).Do(func(i r.Term) interface{} { return arr.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(i).Eq(1)})}).OrderBy('a')")
@@ -766,7 +766,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #177
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2))) */
 
 		suite.T().Log("About to run line #177: arr.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))})")
@@ -781,7 +781,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #181
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2)), default=False) */
 
 		suite.T().Log("About to run line #181: arr.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))}).OptArgs(r.FilterOpts{Default: false, })")
@@ -796,7 +796,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #185
 		/* ([{}, {'a':null}, {'a':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
 		/* arr.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2)), default=True).order_by('a') */
 
 		suite.T().Log("About to run line #185: arr.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))}).OptArgs(r.FilterOpts{Default: true, }).OrderBy('a')")
@@ -811,7 +811,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #189
 		/* err("ReqlNonExistenceError", "No attribute `a` in object:", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `a` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `a` in object:")
 		/* arr.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2)), default=r.error()) */
 
 		suite.T().Log("About to run line #189: arr.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))}).OptArgs(r.FilterOpts{Default: r.Error(), })")
@@ -826,7 +826,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #193
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.table_create('default_test') */
 
 		suite.T().Log("About to run line #193: r.TableCreate('default_test')")
@@ -841,7 +841,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #196
 		/* ({'deleted':0,'replaced':0,'generated_keys':arrlen(3,uuid()),'unchanged':0,'errors':0,'skipped':0,'inserted':3}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(3, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 3}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(3, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 3}
 		/* r.table('default_test').insert(arr) */
 
 		suite.T().Log("About to run line #196: r.Table('default_test').Insert(arr)")
@@ -863,7 +863,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #202
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:x['a'].eq(1)) */
 
 		suite.T().Log("About to run line #202: tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)})")
@@ -878,7 +878,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #206
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:x['a'].eq(1), default=False) */
 
 		suite.T().Log("About to run line #206: tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: false, })")
@@ -893,7 +893,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #210
 		/* [{}, {'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:x['a'].eq(1), default=True) */
 
 		suite.T().Log("About to run line #210: tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: true, })")
@@ -908,7 +908,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #215
 		/* err("ReqlNonExistenceError", "No attribute `a` in object:", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `a` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `a` in object:")
 		/* tbl.filter(lambda x:x['a'].eq(1), default=r.error()) */
 
 		suite.T().Log("About to run line #215: tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: r.Error(), })")
@@ -923,7 +923,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #220
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* r.expr(False).do(lambda d:tbl.filter(lambda x:x['a'].eq(1), default=d)) */
 
 		suite.T().Log("About to run line #220: r.Expr(false).Do(func(d r.Term) interface{} { return tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: d, })})")
@@ -940,7 +940,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #224
 		/* [{}, {'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": 1}}
 		/* r.expr(True).do(lambda d:tbl.filter(lambda x:x['a'].eq(1), default=d)).order_by('a') */
 
 		suite.T().Log("About to run line #224: r.Expr(true).Do(func(d r.Term) interface{} { return tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Eq(1)}).OptArgs(r.FilterOpts{Default: d, })}).OrderBy('a')")
@@ -957,7 +957,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #230
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:x['a'].default(0).eq(1)) */
 
 		suite.T().Log("About to run line #230: tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(0).Eq(1)})")
@@ -972,7 +972,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #234
 		/* ([{}, {'a':null}, {'a':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:x['a'].default(1).eq(1)).order_by('a') */
 
 		suite.T().Log("About to run line #234: tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(1).Eq(1)}).OrderBy('a')")
@@ -987,7 +987,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #238
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:x['a'].default(r.error()).eq(1)) */
 
 		suite.T().Log("About to run line #238: tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(r.Error()).Eq(1)})")
@@ -1002,7 +1002,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #244
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* r.expr(0).do(lambda i:tbl.filter(lambda x:x['a'].default(i).eq(1))) */
 
 		suite.T().Log("About to run line #244: r.Expr(0).Do(func(i r.Term) interface{} { return tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(i).Eq(1)})})")
@@ -1019,7 +1019,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #248
 		/* ([{},{'a':null},{'a':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
 		/* r.expr(1).do(lambda i:tbl.filter(lambda x:x['a'].default(i).eq(1))).order_by('a') */
 
 		suite.T().Log("About to run line #248: r.Expr(1).Do(func(i r.Term) interface{} { return tbl.Filter(func(x r.Term) interface{} { return x.AtIndex('a').Default(i).Eq(1)})}).OrderBy('a')")
@@ -1036,7 +1036,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #253
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2))) */
 
 		suite.T().Log("About to run line #253: tbl.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))})")
@@ -1051,7 +1051,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #257
 		/* [{'a':1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2)), default=False) */
 
 		suite.T().Log("About to run line #257: tbl.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))}).OptArgs(r.FilterOpts{Default: false, })")
@@ -1066,7 +1066,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #261
 		/* ([{}, {'a':null}, {'a':1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{"a": nil}, map[interface{}]interface{}{"a": 1}}
 		/* tbl.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2)), default=True).order_by('a') */
 
 		suite.T().Log("About to run line #261: tbl.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))}).OptArgs(r.FilterOpts{Default: true, }).OrderBy('a')")
@@ -1081,7 +1081,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #265
 		/* err("ReqlNonExistenceError", "No attribute `a` in object:", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `a` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `a` in object:")
 		/* tbl.filter(lambda x:r.or_(x['a'].eq(1), x['a']['b'].eq(2)), default=r.error()) */
 
 		suite.T().Log("About to run line #265: tbl.Filter(func(x r.Term) interface{} { return r.Or(x.AtIndex('a').Eq(1), x.AtIndex('a').AtIndex('b').Eq(2))}).OptArgs(r.FilterOpts{Default: r.Error(), })")
@@ -1096,7 +1096,7 @@ func (suite *DefaultSuite) TestCases() {
 	{
 		// default.yaml line #269
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* r.table_drop('default_test') */
 
 		suite.T().Log("About to run line #269: r.TableDrop('default_test')")

--- a/internal/integration/reql_tests/reql_geo_constructors_test.go
+++ b/internal/integration/reql_tests/reql_geo_constructors_test.go
@@ -61,7 +61,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #4
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[0, 0], 'type':'Point'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point"}
 		/* r.point(0, 0) */
 
 		suite.T().Log("About to run line #4: r.Point(0, 0)")
@@ -76,7 +76,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #6
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[0, -90], 'type':'Point'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, -90}, "type": "Point"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, -90}, "type": "Point"}
 		/* r.point(0, -90) */
 
 		suite.T().Log("About to run line #6: r.Point(0, -90)")
@@ -91,7 +91,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #8
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[0, 90], 'type':'Point'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 90}, "type": "Point"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 90}, "type": "Point"}
 		/* r.point(0, 90) */
 
 		suite.T().Log("About to run line #8: r.Point(0, 90)")
@@ -106,7 +106,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #10
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[-180, 0], 'type':'Point'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{-180, 0}, "type": "Point"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{-180, 0}, "type": "Point"}
 		/* r.point(-180, 0) */
 
 		suite.T().Log("About to run line #10: r.Point(-180, 0)")
@@ -121,7 +121,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #12
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[180, 0], 'type':'Point'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{180, 0}, "type": "Point"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{180, 0}, "type": "Point"}
 		/* r.point(180, 0) */
 
 		suite.T().Log("About to run line #12: r.Point(180, 0)")
@@ -136,7 +136,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #14
 		/* err('ReqlQueryLogicError', 'Latitude must be between -90 and 90.  Got -91.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Latitude must be between -90 and 90.  Got -91.")
+		var expected_ = err("ReqlQueryLogicError", "Latitude must be between -90 and 90.  Got -91.")
 		/* r.point(0, -91) */
 
 		suite.T().Log("About to run line #14: r.Point(0, -91)")
@@ -151,7 +151,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #16
 		/* err('ReqlQueryLogicError', 'Latitude must be between -90 and 90.  Got 91.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Latitude must be between -90 and 90.  Got 91.")
+		var expected_ = err("ReqlQueryLogicError", "Latitude must be between -90 and 90.  Got 91.")
 		/* r.point(0, 91) */
 
 		suite.T().Log("About to run line #16: r.Point(0, 91)")
@@ -166,7 +166,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #18
 		/* err('ReqlQueryLogicError', 'Longitude must be between -180 and 180.  Got -181.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Longitude must be between -180 and 180.  Got -181.")
+		var expected_ = err("ReqlQueryLogicError", "Longitude must be between -180 and 180.  Got -181.")
 		/* r.point(-181, 0) */
 
 		suite.T().Log("About to run line #18: r.Point(-181, 0)")
@@ -181,7 +181,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #20
 		/* err('ReqlQueryLogicError', 'Longitude must be between -180 and 180.  Got 181.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Longitude must be between -180 and 180.  Got 181.")
+		var expected_ = err("ReqlQueryLogicError", "Longitude must be between -180 and 180.  Got 181.")
 		/* r.point(181, 0) */
 
 		suite.T().Log("About to run line #20: r.Point(181, 0)")
@@ -196,7 +196,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #28
 		/* err('ReqlQueryLogicError', 'Invalid LineString.  Are there antipodal or duplicate vertices?', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid LineString.  Are there antipodal or duplicate vertices?")
+		var expected_ = err("ReqlQueryLogicError", "Invalid LineString.  Are there antipodal or duplicate vertices?")
 		/* r.line([0,0], [0,0]) */
 
 		suite.T().Log("About to run line #28: r.Line([]interface{}{0, 0}, []interface{}{0, 0})")
@@ -211,7 +211,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #30
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[0,0], [0,1]], 'type':'LineString'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}}, "type": "LineString"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}}, "type": "LineString"}
 		/* r.line([0,0], [0,1]) */
 
 		suite.T().Log("About to run line #30: r.Line([]interface{}{0, 0}, []interface{}{0, 1})")
@@ -226,7 +226,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #32
 		/* err('ReqlQueryLogicError', 'Expected point coordinate pair.  Got 1 element array instead of a 2 element one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 1 element array instead of a 2 element one.")
+		var expected_ = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 1 element array instead of a 2 element one.")
 		/* r.line([0,0], [1]) */
 
 		suite.T().Log("About to run line #32: r.Line([]interface{}{0, 0}, []interface{}{1})")
@@ -241,7 +241,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #34
 		/* err('ReqlQueryLogicError', 'Expected point coordinate pair.  Got 3 element array instead of a 2 element one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 3 element array instead of a 2 element one.")
+		var expected_ = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 3 element array instead of a 2 element one.")
 		/* r.line([0,0], [1,0,0]) */
 
 		suite.T().Log("About to run line #34: r.Line([]interface{}{0, 0}, []interface{}{1, 0, 0})")
@@ -256,7 +256,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #36
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[0,0], [0,1], [0,0]], 'type':'LineString'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{0, 0}}, "type": "LineString"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{0, 0}}, "type": "LineString"}
 		/* r.line([0,0], [0,1], [0,0]) */
 
 		suite.T().Log("About to run line #36: r.Line([]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{0, 0})")
@@ -271,7 +271,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #38
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[0,0], [0,1], [0,0]], 'type':'LineString'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{0, 0}}, "type": "LineString"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{0, 0}}, "type": "LineString"}
 		/* r.line(r.point(0,0), r.point(0,1), r.point(0,0)) */
 
 		suite.T().Log("About to run line #38: r.Line(r.Point(0, 0), r.Point(0, 1), r.Point(0, 0))")
@@ -286,7 +286,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #40
 		/* err('ReqlQueryLogicError', 'Expected geometry of type `Point` but found `LineString`.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected geometry of type `Point` but found `LineString`.")
+		var expected_ = err("ReqlQueryLogicError", "Expected geometry of type `Point` but found `LineString`.")
 		/* r.line(r.point(0,0), r.point(1,0), r.line([0,0], [1,0])) */
 
 		suite.T().Log("About to run line #40: r.Line(r.Point(0, 0), r.Point(1, 0), r.Line([]interface{}{0, 0}, []interface{}{1, 0}))")
@@ -301,7 +301,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #50
 		/* err('ReqlQueryLogicError', 'Invalid LinearRing.  Are there antipodal or duplicate vertices? Is it self-intersecting?', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid LinearRing.  Are there antipodal or duplicate vertices? Is it self-intersecting?")
+		var expected_ = err("ReqlQueryLogicError", "Invalid LinearRing.  Are there antipodal or duplicate vertices? Is it self-intersecting?")
 		/* r.polygon([0,0], [0,0], [0,0], [0,0]) */
 
 		suite.T().Log("About to run line #50: r.Polygon([]interface{}{0, 0}, []interface{}{0, 0}, []interface{}{0, 0}, []interface{}{0, 0})")
@@ -316,7 +316,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #52
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0,0], [0,1], [1,0], [0,0]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0}}}, "type": "Polygon"}
 		/* r.polygon([0,0], [0,1], [1,0]) */
 
 		suite.T().Log("About to run line #52: r.Polygon([]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0})")
@@ -331,7 +331,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #54
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0,0], [0,1], [1,0], [0,0]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0}}}, "type": "Polygon"}
 		/* r.polygon([0,0], [0,1], [1,0], [0,0]) */
 
 		suite.T().Log("About to run line #54: r.Polygon([]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0})")
@@ -346,7 +346,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #56
 		/* err('ReqlQueryLogicError', 'Invalid LinearRing.  Are there antipodal or duplicate vertices? Is it self-intersecting?', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid LinearRing.  Are there antipodal or duplicate vertices? Is it self-intersecting?")
+		var expected_ = err("ReqlQueryLogicError", "Invalid LinearRing.  Are there antipodal or duplicate vertices? Is it self-intersecting?")
 		/* r.polygon([0,0], [0,1], [1,0], [-1,0.5]) */
 
 		suite.T().Log("About to run line #56: r.Polygon([]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{-1, 0.5})")
@@ -361,7 +361,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #58
 		/* err('ReqlQueryLogicError', 'Expected point coordinate pair.  Got 1 element array instead of a 2 element one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 1 element array instead of a 2 element one.")
+		var expected_ = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 1 element array instead of a 2 element one.")
 		/* r.polygon([0,0], [0,1], [0]) */
 
 		suite.T().Log("About to run line #58: r.Polygon([]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{0})")
@@ -376,7 +376,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #60
 		/* err('ReqlQueryLogicError', 'Expected point coordinate pair.  Got 3 element array instead of a 2 element one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 3 element array instead of a 2 element one.")
+		var expected_ = err("ReqlQueryLogicError", "Expected point coordinate pair.  Got 3 element array instead of a 2 element one.")
 		/* r.polygon([0,0], [0,1], [0,1,0]) */
 
 		suite.T().Log("About to run line #60: r.Polygon([]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{0, 1, 0})")
@@ -391,7 +391,7 @@ func (suite *GeoConstructorsSuite) TestCases() {
 	{
 		// geo/constructors.yaml line #62
 		/* err('ReqlQueryLogicError', 'Expected geometry of type `Point` but found `LineString`.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected geometry of type `Point` but found `LineString`.")
+		var expected_ = err("ReqlQueryLogicError", "Expected geometry of type `Point` but found `LineString`.")
 		/* r.polygon(r.point(0,0), r.point(0,1), r.line([0,0], [0,1])) */
 
 		suite.T().Log("About to run line #62: r.Polygon(r.Point(0, 0), r.Point(0, 1), r.Line([]interface{}{0, 0}, []interface{}{0, 1}))")

--- a/internal/integration/reql_tests/reql_geo_geojson_test.go
+++ b/internal/integration/reql_tests/reql_geo_geojson_test.go
@@ -61,7 +61,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #4
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[0, 0], 'type':'Point'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point"}
 		/* r.geojson({'coordinates':[0, 0], 'type':'Point'}) */
 
 		suite.T().Log("About to run line #4: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{0, 0}, 'type': 'Point', })")
@@ -76,7 +76,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #6
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[0,0], [0,1]], 'type':'LineString'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}}, "type": "LineString"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}}, "type": "LineString"}
 		/* r.geojson({'coordinates':[[0,0], [0,1]], 'type':'LineString'}) */
 
 		suite.T().Log("About to run line #6: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{[]interface{}{0, 0}, []interface{}{0, 1}}, 'type': 'LineString', })")
@@ -91,7 +91,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #8
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0,0], [0,1], [1,0], [0,0]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0}}}, "type": "Polygon"}
 		/* r.geojson({'coordinates':[[[0,0], [0,1], [1,0], [0,0]]], 'type':'Polygon'}) */
 
 		suite.T().Log("About to run line #8: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 0}, []interface{}{0, 0}}}, 'type': 'Polygon', })")
@@ -106,7 +106,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #12
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found ARRAY.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found ARRAY.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found ARRAY.")
 		/* r.geojson({'coordinates':[[], 0], 'type':'Point'}) */
 
 		suite.T().Log("About to run line #12: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{[]interface{}{}, 0}, 'type': 'Point', })")
@@ -121,7 +121,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #14
 		/* err('ReqlQueryLogicError', 'Expected type ARRAY but found BOOL.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type ARRAY but found BOOL.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type ARRAY but found BOOL.")
 		/* r.geojson({'coordinates':true, 'type':'Point'}) */
 
 		suite.T().Log("About to run line #14: r.GeoJSON(map[interface{}]interface{}{'coordinates': true, 'type': 'Point', })")
@@ -136,7 +136,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #16
 		/* err('ReqlNonExistenceError', 'No attribute `coordinates` in object:', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `coordinates` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `coordinates` in object:")
 		/* r.geojson({'type':'Point'}) */
 
 		suite.T().Log("About to run line #16: r.GeoJSON(map[interface{}]interface{}{'type': 'Point', })")
@@ -151,7 +151,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #18
 		/* err('ReqlNonExistenceError', 'No attribute `type` in object:', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "No attribute `type` in object:")
+		var expected_ = err("ReqlNonExistenceError", "No attribute `type` in object:")
 		/* r.geojson({'coordinates':[0, 0]}) */
 
 		suite.T().Log("About to run line #18: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{0, 0}, })")
@@ -166,7 +166,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #20
 		/* err('ReqlQueryLogicError', 'Unrecognized GeoJSON type `foo`.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Unrecognized GeoJSON type `foo`.")
+		var expected_ = err("ReqlQueryLogicError", "Unrecognized GeoJSON type `foo`.")
 		/* r.geojson({'coordinates':[0, 0], 'type':'foo'}) */
 
 		suite.T().Log("About to run line #20: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{0, 0}, 'type': 'foo', })")
@@ -181,7 +181,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #22
 		/* err('ReqlQueryLogicError', 'Unrecognized field `foo` found in geometry object.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Unrecognized field `foo` found in geometry object.")
+		var expected_ = err("ReqlQueryLogicError", "Unrecognized field `foo` found in geometry object.")
 		/* r.geojson({'coordinates':[0, 0], 'type':'Point', 'foo':'wrong'}) */
 
 		suite.T().Log("About to run line #22: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{0, 0}, 'type': 'Point', 'foo': 'wrong', })")
@@ -196,7 +196,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #26
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[0, 0], 'type':'Point', 'crs':null}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point", "crs": nil}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point", "crs": nil}
 		/* r.geojson({'coordinates':[0, 0], 'type':'Point', 'crs':null}) */
 
 		suite.T().Log("About to run line #26: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{0, 0}, 'type': 'Point', 'crs': nil, })")
@@ -211,7 +211,7 @@ func (suite *GeoGeojsonSuite) TestCases() {
 	{
 		// geo/geojson.yaml line #30
 		/* err('ReqlQueryLogicError', 'GeoJSON type `MultiPoint` is not supported.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "GeoJSON type `MultiPoint` is not supported.")
+		var expected_ = err("ReqlQueryLogicError", "GeoJSON type `MultiPoint` is not supported.")
 		/* r.geojson({'coordinates':[0, 0], 'type':'MultiPoint'}) */
 
 		suite.T().Log("About to run line #30: r.GeoJSON(map[interface{}]interface{}{'coordinates': []interface{}{0, 0}, 'type': 'MultiPoint', })")

--- a/internal/integration/reql_tests/reql_geo_indexing_test.go
+++ b/internal/integration/reql_tests/reql_geo_indexing_test.go
@@ -77,7 +77,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #8
 		/* ({'deleted':0,'inserted':3,'skipped':0,'errors':0,'replaced':0,'unchanged':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "inserted": 3, "skipped": 0, "errors": 0, "replaced": 0, "unchanged": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "inserted": 3, "skipped": 0, "errors": 0, "replaced": 0, "unchanged": 0}
 		/* tbl.insert(rows) */
 
 		suite.T().Log("About to run line #8: tbl.Insert(rows)")
@@ -92,7 +92,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #12
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('g', geo=true) */
 
 		suite.T().Log("About to run line #12: tbl.IndexCreate('g').OptArgs(r.IndexCreateOpts{Geo: true, })")
@@ -107,7 +107,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #16
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('m', geo=true, multi=true) */
 
 		suite.T().Log("About to run line #16: tbl.IndexCreate('m').OptArgs(r.IndexCreateOpts{Geo: true, Multi: true, })")
@@ -122,7 +122,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #19
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('other') */
 
 		suite.T().Log("About to run line #19: tbl.IndexCreate('other')")
@@ -137,7 +137,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #23
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('point_det', lambda x: r.point(x, x) ) */
 
 		suite.T().Log("About to run line #23: tbl.IndexCreateFunc('point_det', func(x r.Term) interface{} { return r.Point(x, x)})")
@@ -152,7 +152,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #27
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait() */
 
 		suite.T().Log("About to run line #27: tbl.IndexWait()")
@@ -167,7 +167,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #32
 		/* err('ReqlQueryLogicError', 'Could not prove function deterministic.  Index functions must be deterministic.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Could not prove function deterministic.  Index functions must be deterministic.")
+		var expected_ = err("ReqlQueryLogicError", "Could not prove function deterministic.  Index functions must be deterministic.")
 		/* tbl.index_create('point_det', lambda x: r.line(x, x) ) */
 
 		suite.T().Log("About to run line #32: tbl.IndexCreateFunc('point_det', func(x r.Term) interface{} { return r.Line(x, x)})")
@@ -182,7 +182,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #37
 		/* err('ReqlQueryLogicError', 'Index `other` is not a geospatial index.  get_intersecting can only be used with a geospatial index.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index `other` is not a geospatial index.  get_intersecting can only be used with a geospatial index.")
+		var expected_ = err("ReqlQueryLogicError", "Index `other` is not a geospatial index.  get_intersecting can only be used with a geospatial index.")
 		/* tbl.get_intersecting(r.point(0,0), index='other').count() */
 
 		suite.T().Log("About to run line #37: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'other', }).Count()")
@@ -197,7 +197,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #41
 		/* err_regex('ReqlOpFailedError', 'Index `missing` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]', [0]) */
-		var expected_ Err = err_regex("ReqlOpFailedError", "Index `missing` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
+		var expected_ = err_regex("ReqlOpFailedError", "Index `missing` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
 		/* tbl.get_intersecting(r.point(0,0), index='missing').count() */
 
 		suite.T().Log("About to run line #41: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'missing', }).Count()")
@@ -212,7 +212,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #44
 		/* err('ReqlQueryLogicError', 'get_intersecting requires an index argument.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "get_intersecting requires an index argument.")
+		var expected_ = err("ReqlQueryLogicError", "get_intersecting requires an index argument.")
 		/* tbl.get_intersecting(r.point(0,0)).count() */
 
 		suite.T().Log("About to run line #44: tbl.GetIntersecting(r.Point(0, 0)).Count()")
@@ -227,7 +227,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #47
 		/* err('ReqlQueryLogicError', 'Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.")
+		var expected_ = err("ReqlQueryLogicError", "Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.")
 		/* tbl.get_all(0, index='g').count() */
 
 		suite.T().Log("About to run line #47: tbl.GetAll(0).OptArgs(r.GetAllOpts{Index: 'g', }).Count()")
@@ -242,7 +242,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #51
 		/* err('ReqlQueryLogicError', 'Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.")
+		var expected_ = err("ReqlQueryLogicError", "Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.")
 		/* tbl.between(0, 1, index='g').count() */
 
 		suite.T().Log("About to run line #51: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'g', }).Count()")
@@ -257,7 +257,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #55
 		/* err('ReqlQueryLogicError', 'Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.")
+		var expected_ = err("ReqlQueryLogicError", "Index `g` is a geospatial index.  Only get_nearest and get_intersecting can use a geospatial index.")
 		/* tbl.order_by(index='g').count() */
 
 		suite.T().Log("About to run line #55: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'g', }).Count()")
@@ -272,7 +272,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #77
 		/* err('ReqlQueryLogicError', 'get_intersecting cannot use the primary index.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "get_intersecting cannot use the primary index.")
+		var expected_ = err("ReqlQueryLogicError", "get_intersecting cannot use the primary index.")
 		/* tbl.get_intersecting(r.point(0,0), index='id').count() */
 
 		suite.T().Log("About to run line #77: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'id', }).Count()")
@@ -287,7 +287,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #82
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_intersecting(r.point(0,0), index='g').count() */
 
 		suite.T().Log("About to run line #82: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Count()")
@@ -302,7 +302,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #86
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_intersecting(r.point(10,10), index='g').count() */
 
 		suite.T().Log("About to run line #86: tbl.GetIntersecting(r.Point(10, 10)).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Count()")
@@ -317,7 +317,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #90
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_intersecting(r.point(0.5,0.5), index='g').count() */
 
 		suite.T().Log("About to run line #90: tbl.GetIntersecting(r.Point(0.5, 0.5)).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Count()")
@@ -332,7 +332,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #94
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.get_intersecting(r.point(20,20), index='g').count() */
 
 		suite.T().Log("About to run line #94: tbl.GetIntersecting(r.Point(20, 20)).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Count()")
@@ -347,7 +347,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #98
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl.get_intersecting(r.polygon([0,0], [1,0], [1,1], [0,1]), index='g').count() */
 
 		suite.T().Log("About to run line #98: tbl.GetIntersecting(r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1})).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Count()")
@@ -362,7 +362,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #102
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.get_intersecting(r.line([0,0], [10,10]), index='g').count() */
 
 		suite.T().Log("About to run line #102: tbl.GetIntersecting(r.Line([]interface{}{0, 0}, []interface{}{10, 10})).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Count()")
@@ -377,7 +377,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #106
 		/* ("SELECTION<STREAM>") */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.get_intersecting(r.point(0,0), index='g').type_of() */
 
 		suite.T().Log("About to run line #106: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'g', }).TypeOf()")
@@ -392,7 +392,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #110
 		/* ("SELECTION<STREAM>") */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.get_intersecting(r.point(0,0), index='g').filter(true).type_of() */
 
 		suite.T().Log("About to run line #110: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Filter(true).TypeOf()")
@@ -407,7 +407,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #114
 		/* ("STREAM") */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* tbl.get_intersecting(r.point(0,0), index='g').map(r.row).type_of() */
 
 		suite.T().Log("About to run line #114: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'g', }).Map(r.Row).TypeOf()")
@@ -422,7 +422,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #119
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_intersecting(r.point(0,0), index='m').count() */
 
 		suite.T().Log("About to run line #119: tbl.GetIntersecting(r.Point(0, 0)).OptArgs(r.GetIntersectingOpts{Index: 'm', }).Count()")
@@ -437,7 +437,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #123
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_intersecting(r.point(1,0), index='m').count() */
 
 		suite.T().Log("About to run line #123: tbl.GetIntersecting(r.Point(1, 0)).OptArgs(r.GetIntersectingOpts{Index: 'm', }).Count()")
@@ -452,7 +452,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #127
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_intersecting(r.point(2,0), index='m').count() */
 
 		suite.T().Log("About to run line #127: tbl.GetIntersecting(r.Point(2, 0)).OptArgs(r.GetIntersectingOpts{Index: 'm', }).Count()")
@@ -467,7 +467,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #131
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.get_intersecting(r.point(3,0), index='m').count() */
 
 		suite.T().Log("About to run line #131: tbl.GetIntersecting(r.Point(3, 0)).OptArgs(r.GetIntersectingOpts{Index: 'm', }).Count()")
@@ -482,7 +482,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #136
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl.get_intersecting(r.polygon([0,0], [0,1], [1,1], [1,0]), index='m').count() */
 
 		suite.T().Log("About to run line #136: tbl.GetIntersecting(r.Polygon([]interface{}{0, 0}, []interface{}{0, 1}, []interface{}{1, 1}, []interface{}{1, 0})).OptArgs(r.GetIntersectingOpts{Index: 'm', }).Count()")
@@ -497,7 +497,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #142
 		/* err('ReqlQueryLogicError', 'Index `other` is not a geospatial index.  get_nearest can only be used with a geospatial index.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index `other` is not a geospatial index.  get_nearest can only be used with a geospatial index.")
+		var expected_ = err("ReqlQueryLogicError", "Index `other` is not a geospatial index.  get_nearest can only be used with a geospatial index.")
 		/* tbl.get_nearest(r.point(0,0), index='other') */
 
 		suite.T().Log("About to run line #142: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'other', })")
@@ -512,7 +512,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #146
 		/* err_regex('ReqlOpFailedError', 'Index `missing` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]', [0]) */
-		var expected_ Err = err_regex("ReqlOpFailedError", "Index `missing` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
+		var expected_ = err_regex("ReqlOpFailedError", "Index `missing` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
 		/* tbl.get_nearest(r.point(0,0), index='missing') */
 
 		suite.T().Log("About to run line #146: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'missing', })")
@@ -527,7 +527,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #149
 		/* err('ReqlQueryLogicError', 'get_nearest requires an index argument.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "get_nearest requires an index argument.")
+		var expected_ = err("ReqlQueryLogicError", "get_nearest requires an index argument.")
 		/* tbl.get_nearest(r.point(0,0)) */
 
 		suite.T().Log("About to run line #149: tbl.GetNearest(r.Point(0, 0))")
@@ -542,7 +542,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #170
 		/* err('ReqlQueryLogicError', 'get_nearest cannot use the primary index.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "get_nearest cannot use the primary index.")
+		var expected_ = err("ReqlQueryLogicError", "get_nearest cannot use the primary index.")
 		/* tbl.get_nearest(r.point(0,0), index='id').count() */
 
 		suite.T().Log("About to run line #170: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'id', }).Count()")
@@ -557,7 +557,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #175
 		/* ([{'dist':0,'doc':{'id':1}},{'dist':0.055659745396754216,'doc':{'id':2}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 0.055659745396754216, "doc": map[interface{}]interface{}{"id": 2}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 0.055659745396754216, "doc": map[interface{}]interface{}{"id": 2}}}
 		/* tbl.get_nearest(r.point(0,0), index='g').pluck('dist', {'doc':'id'}) */
 
 		suite.T().Log("About to run line #175: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', }).Pluck('dist', map[interface{}]interface{}{'doc': 'id', })")
@@ -572,7 +572,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #179
 		/* ([{'dist':0,'doc':{'id':2}},{'dist':0.11130264976984369,'doc':{'id':1}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 0.11130264976984369, "doc": map[interface{}]interface{}{"id": 1}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 0.11130264976984369, "doc": map[interface{}]interface{}{"id": 1}}}
 		/* tbl.get_nearest(r.point(-0.000001,1), index='g').pluck('dist', {'doc':'id'}) */
 
 		suite.T().Log("About to run line #179: tbl.GetNearest(r.Point(-1e-06, 1)).OptArgs(r.GetNearestOpts{Index: 'g', }).Pluck('dist', map[interface{}]interface{}{'doc': 'id', })")
@@ -587,7 +587,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #183
 		/* ([{'dist':0,'doc':{'id':1}},{'dist':0.055659745396754216,'doc':{'id':2}},{'dist':1565109.0992178896,'doc':{'id':0}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 0.055659745396754216, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 1565109.0992178896, "doc": map[interface{}]interface{}{"id": 0}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 0.055659745396754216, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 1565109.0992178896, "doc": map[interface{}]interface{}{"id": 0}}}
 		/* tbl.get_nearest(r.point(0,0), index='g', max_dist=1565110).pluck('dist', {'doc':'id'}) */
 
 		suite.T().Log("About to run line #183: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', MaxDist: 1565110, }).Pluck('dist', map[interface{}]interface{}{'doc': 'id', })")
@@ -602,7 +602,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #187
 		/* ([{'dist':0,'doc':{'id':1}},{'dist':0.055659745396754216,'doc':{'id':2}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 0.055659745396754216, "doc": map[interface{}]interface{}{"id": 2}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 0.055659745396754216, "doc": map[interface{}]interface{}{"id": 2}}}
 		/* tbl.get_nearest(r.point(0,0), index='g', max_dist=1565110, max_results=2).pluck('dist', {'doc':'id'}) */
 
 		suite.T().Log("About to run line #187: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', MaxDist: 1565110, MaxResults: 2, }).Pluck('dist', map[interface{}]interface{}{'doc': 'id', })")
@@ -617,7 +617,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #191
 		/* err('ReqlQueryLogicError', 'The distance has become too large for continuing the indexed nearest traversal.  Consider specifying a smaller `max_dist` parameter.  (Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 10968937.995244588703m, but must be smaller than 9985163.1855612862855m.)', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "The distance has become too large for continuing the indexed nearest traversal.  Consider specifying a smaller `max_dist` parameter.  (Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 10968937.995244588703m, but must be smaller than 9985163.1855612862855m.)")
+		var expected_ = err("ReqlQueryLogicError", "The distance has become too large for continuing the indexed nearest traversal.  Consider specifying a smaller `max_dist` parameter.  (Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 10968937.995244588703m, but must be smaller than 9985163.1855612862855m.)")
 		/* tbl.get_nearest(r.point(0,0), index='g', max_dist=10000000).pluck('dist', {'doc':'id'}) */
 
 		suite.T().Log("About to run line #191: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', MaxDist: 10000000, }).Pluck('dist', map[interface{}]interface{}{'doc': 'id', })")
@@ -632,7 +632,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #195
 		/* ([{'dist':0,'doc':{'id':1}},{'dist':0.00005565974539675422,'doc':{'id':2}},{'dist':1565.1090992178897,'doc':{'id':0}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 5.565974539675422e-05, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 1565.1090992178897, "doc": map[interface{}]interface{}{"id": 0}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 5.565974539675422e-05, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 1565.1090992178897, "doc": map[interface{}]interface{}{"id": 0}}}
 		/* tbl.get_nearest(r.point(0,0), index='g', max_dist=1566, unit='km').pluck('dist', {'doc':'id'}) */
 
 		suite.T().Log("About to run line #195: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', MaxDist: 1566, Unit: 'km', }).Pluck('dist', map[interface{}]interface{}{'doc': 'id', })")
@@ -647,7 +647,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #198
 		/* ([{'dist':0, 'doc':{'id':1}}, {'dist':8.726646259990191e-09, 'doc':{'id':2}}, {'dist':0.24619691677893205, 'doc':{'id':0}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 8.726646259990191e-09, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 0.24619691677893205, "doc": map[interface{}]interface{}{"id": 0}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"dist": 0, "doc": map[interface{}]interface{}{"id": 1}}, map[interface{}]interface{}{"dist": 8.726646259990191e-09, "doc": map[interface{}]interface{}{"id": 2}}, map[interface{}]interface{}{"dist": 0.24619691677893205, "doc": map[interface{}]interface{}{"id": 0}}}
 		/* tbl.get_nearest(r.point(0,0), index='g', max_dist=1, geo_system='unit_sphere').pluck('dist', {'doc':'id'}) */
 
 		suite.T().Log("About to run line #198: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', MaxDist: 1, GeoSystem: 'unit_sphere', }).Pluck('dist', map[interface{}]interface{}{'doc': 'id', })")
@@ -662,7 +662,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #202
 		/* ("ARRAY") */
-		var expected_ string = "ARRAY"
+		var expected_ = "ARRAY"
 		/* tbl.get_nearest(r.point(0,0), index='g').type_of() */
 
 		suite.T().Log("About to run line #202: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', }).TypeOf()")
@@ -677,7 +677,7 @@ func (suite *GeoIndexingSuite) TestCases() {
 	{
 		// geo/indexing.yaml line #206
 		/* ("ARRAY") */
-		var expected_ string = "ARRAY"
+		var expected_ = "ARRAY"
 		/* tbl.get_nearest(r.point(0,0), index='g').map(r.row).type_of() */
 
 		suite.T().Log("About to run line #206: tbl.GetNearest(r.Point(0, 0)).OptArgs(r.GetNearestOpts{Index: 'g', }).Map(r.Row).TypeOf()")

--- a/internal/integration/reql_tests/reql_geo_intersection_inclusion_test.go
+++ b/internal/integration/reql_tests/reql_geo_intersection_inclusion_test.go
@@ -61,7 +61,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #4
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.point(1.5,1.5)) */
 
 		suite.T().Log("About to run line #4: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Point(1.5, 1.5))")
@@ -76,7 +76,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #6
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.point(2.5,2.5)) */
 
 		suite.T().Log("About to run line #6: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Point(2.5, 2.5))")
@@ -91,7 +91,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #8
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).intersects(r.point(1.5,1.5)) */
 
 		suite.T().Log("About to run line #8: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Intersects(r.Point(1.5, 1.5))")
@@ -106,7 +106,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #10
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).intersects(r.point(1.05,1.05)) */
 
 		suite.T().Log("About to run line #10: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Intersects(r.Point(1.05, 1.05))")
@@ -121,7 +121,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #13
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.point(2,2)) */
 
 		suite.T().Log("About to run line #13: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Point(2, 2))")
@@ -136,7 +136,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #15
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.point(2,1.5)) */
 
 		suite.T().Log("About to run line #15: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Point(2, 1.5))")
@@ -151,7 +151,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #17
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.line([1.5,1.5], [2,2])) */
 
 		suite.T().Log("About to run line #17: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Line([]interface{}{1.5, 1.5}, []interface{}{2, 2}))")
@@ -166,7 +166,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #19
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.line([1.5,1.5], [2,1.5])) */
 
 		suite.T().Log("About to run line #19: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Line([]interface{}{1.5, 1.5}, []interface{}{2, 1.5}))")
@@ -181,7 +181,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #22
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).intersects(r.point(1.1,1.1)) */
 
 		suite.T().Log("About to run line #22: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Intersects(r.Point(1.1, 1.1))")
@@ -196,7 +196,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #24
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).intersects(r.point(1.5,1.1)) */
 
 		suite.T().Log("About to run line #24: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Intersects(r.Point(1.5, 1.1))")
@@ -211,7 +211,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #27
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.line([2,2], [3,3])) */
 
 		suite.T().Log("About to run line #27: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Line([]interface{}{2, 2}, []interface{}{3, 3}))")
@@ -226,7 +226,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #29
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.line([2,1.5], [3,3])) */
 
 		suite.T().Log("About to run line #29: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Line([]interface{}{2, 1.5}, []interface{}{3, 3}))")
@@ -241,7 +241,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #31
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.line([1.5,1.5], [3,3])) */
 
 		suite.T().Log("About to run line #31: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Line([]interface{}{1.5, 1.5}, []interface{}{3, 3}))")
@@ -256,7 +256,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #33
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.polygon([1.2,1.2], [1.8,1.2], [1.8,1.8], [1.2,1.8])) */
 
 		suite.T().Log("About to run line #33: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Polygon([]interface{}{1.2, 1.2}, []interface{}{1.8, 1.2}, []interface{}{1.8, 1.8}, []interface{}{1.2, 1.8}))")
@@ -271,7 +271,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #35
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.polygon([1.5,1.5], [2.5,1.5], [2.5,2.5], [1.5,2.5])) */
 
 		suite.T().Log("About to run line #35: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Polygon([]interface{}{1.5, 1.5}, []interface{}{2.5, 1.5}, []interface{}{2.5, 2.5}, []interface{}{1.5, 2.5}))")
@@ -286,7 +286,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #37
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).intersects(r.polygon([1.2,1.2], [1.8,1.2], [1.8,1.8], [1.2,1.8])) */
 
 		suite.T().Log("About to run line #37: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Intersects(r.Polygon([]interface{}{1.2, 1.2}, []interface{}{1.8, 1.2}, []interface{}{1.8, 1.8}, []interface{}{1.2, 1.8}))")
@@ -301,7 +301,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #39
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).intersects(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])) */
 
 		suite.T().Log("About to run line #39: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Intersects(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9}))")
@@ -316,7 +316,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #42
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.polygon([2,1.1], [3,1.1], [3,1.9], [2,1.9])) */
 
 		suite.T().Log("About to run line #42: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Polygon([]interface{}{2, 1.1}, []interface{}{3, 1.1}, []interface{}{3, 1.9}, []interface{}{2, 1.9}))")
@@ -331,7 +331,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #44
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).intersects(r.polygon([2,2], [3,2], [3,3], [2,3])) */
 
 		suite.T().Log("About to run line #44: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Intersects(r.Polygon([]interface{}{2, 2}, []interface{}{3, 2}, []interface{}{3, 3}, []interface{}{2, 3}))")
@@ -346,7 +346,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #46
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.point(1,1).intersects(r.point(1.5,1.5)) */
 
 		suite.T().Log("About to run line #46: r.Point(1, 1).Intersects(r.Point(1.5, 1.5))")
@@ -361,7 +361,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #48
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.point(1,1).intersects(r.point(1,1)) */
 
 		suite.T().Log("About to run line #48: r.Point(1, 1).Intersects(r.Point(1, 1))")
@@ -376,7 +376,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #50
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.line([1,1], [2,1]).intersects(r.point(1,1)) */
 
 		suite.T().Log("About to run line #50: r.Line([]interface{}{1, 1}, []interface{}{2, 1}).Intersects(r.Point(1, 1))")
@@ -391,7 +391,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #55
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.line([1,1], [1,2]).intersects(r.point(1,1.8)) */
 
 		suite.T().Log("About to run line #55: r.Line([]interface{}{1, 1}, []interface{}{1, 2}).Intersects(r.Point(1, 1.8))")
@@ -406,7 +406,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #57
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.line([1,0], [2,0]).intersects(r.point(1.8,0)) */
 
 		suite.T().Log("About to run line #57: r.Line([]interface{}{1, 0}, []interface{}{2, 0}).Intersects(r.Point(1.8, 0))")
@@ -421,7 +421,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #59
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.line([1,1], [2,1]).intersects(r.point(1.5,1.5)) */
 
 		suite.T().Log("About to run line #59: r.Line([]interface{}{1, 1}, []interface{}{2, 1}).Intersects(r.Point(1.5, 1.5))")
@@ -436,7 +436,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #61
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.line([1,1], [2,1]).intersects(r.line([2,1], [3,1])) */
 
 		suite.T().Log("About to run line #61: r.Line([]interface{}{1, 1}, []interface{}{2, 1}).Intersects(r.Line([]interface{}{2, 1}, []interface{}{3, 1}))")
@@ -451,7 +451,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #64
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([r.point(1, 0), r.point(3,0), r.point(2, 0)]).intersects(r.line([0,0], [2, 0])).count() */
 
 		suite.T().Log("About to run line #64: r.Expr([]interface{}{r.Point(1, 0), r.Point(3, 0), r.Point(2, 0)}).Intersects(r.Line([]interface{}{0, 0}, []interface{}{2, 0})).Count()")
@@ -466,7 +466,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #68
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.point(1.5,1.5)) */
 
 		suite.T().Log("About to run line #68: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Point(1.5, 1.5))")
@@ -481,7 +481,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #70
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.point(2.5,2.5)) */
 
 		suite.T().Log("About to run line #70: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Point(2.5, 2.5))")
@@ -496,7 +496,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #72
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).includes(r.point(1.5,1.5)) */
 
 		suite.T().Log("About to run line #72: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Includes(r.Point(1.5, 1.5))")
@@ -511,7 +511,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #74
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).includes(r.point(1.05,1.05)) */
 
 		suite.T().Log("About to run line #74: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Includes(r.Point(1.05, 1.05))")
@@ -526,7 +526,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #76
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.point(2,2)) */
 
 		suite.T().Log("About to run line #76: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Point(2, 2))")
@@ -541,7 +541,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #78
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.point(2,1.5)) */
 
 		suite.T().Log("About to run line #78: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Point(2, 1.5))")
@@ -556,7 +556,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #80
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.line([1.5,1.5], [2,2])) */
 
 		suite.T().Log("About to run line #80: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Line([]interface{}{1.5, 1.5}, []interface{}{2, 2}))")
@@ -571,7 +571,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #82
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.line([1.5,1.5], [2,1.5])) */
 
 		suite.T().Log("About to run line #82: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Line([]interface{}{1.5, 1.5}, []interface{}{2, 1.5}))")
@@ -586,7 +586,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #84
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).includes(r.point(1.1,1.1)) */
 
 		suite.T().Log("About to run line #84: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Includes(r.Point(1.1, 1.1))")
@@ -601,7 +601,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #86
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).includes(r.point(1.5,1.1)) */
 
 		suite.T().Log("About to run line #86: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Includes(r.Point(1.5, 1.1))")
@@ -616,7 +616,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #88
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.line([2,2], [3,3])) */
 
 		suite.T().Log("About to run line #88: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Line([]interface{}{2, 2}, []interface{}{3, 3}))")
@@ -631,7 +631,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #90
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.line([2,1.5], [2,2])) */
 
 		suite.T().Log("About to run line #90: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Line([]interface{}{2, 1.5}, []interface{}{2, 2}))")
@@ -646,7 +646,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #92
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.line([2,1], [2,2])) */
 
 		suite.T().Log("About to run line #92: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Line([]interface{}{2, 1}, []interface{}{2, 2}))")
@@ -661,7 +661,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #94
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.line([1.5,1.5], [3,3])) */
 
 		suite.T().Log("About to run line #94: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Line([]interface{}{1.5, 1.5}, []interface{}{3, 3}))")
@@ -676,7 +676,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #96
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.polygon([1,1], [2,1], [2,2], [1,2])) */
 
 		suite.T().Log("About to run line #96: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}))")
@@ -691,7 +691,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #98
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.polygon([1.2,1.2], [1.8,1.2], [1.8,1.8], [1.2,1.8])) */
 
 		suite.T().Log("About to run line #98: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Polygon([]interface{}{1.2, 1.2}, []interface{}{1.8, 1.2}, []interface{}{1.8, 1.8}, []interface{}{1.2, 1.8}))")
@@ -706,7 +706,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #100
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.polygon([1.5,1.5], [2,1.5], [2,2], [1.5,2])) */
 
 		suite.T().Log("About to run line #100: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Polygon([]interface{}{1.5, 1.5}, []interface{}{2, 1.5}, []interface{}{2, 2}, []interface{}{1.5, 2}))")
@@ -721,7 +721,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #102
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.polygon([1.5,1.5], [2.5,1.5], [2.5,2.5], [1.5,2.5])) */
 
 		suite.T().Log("About to run line #102: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Polygon([]interface{}{1.5, 1.5}, []interface{}{2.5, 1.5}, []interface{}{2.5, 2.5}, []interface{}{1.5, 2.5}))")
@@ -736,7 +736,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #104
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).includes(r.polygon([1.2,1.2], [1.8,1.2], [1.8,1.8], [1.2,1.8])) */
 
 		suite.T().Log("About to run line #104: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Includes(r.Polygon([]interface{}{1.2, 1.2}, []interface{}{1.8, 1.2}, []interface{}{1.8, 1.8}, []interface{}{1.2, 1.8}))")
@@ -751,7 +751,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #106
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).polygon_sub(r.polygon([1.1,1.1], [1.9,1.1], [1.9,1.9], [1.1,1.9])).includes(r.polygon([1.1,1.1], [2,1.1], [2,2], [1.1,2])) */
 
 		suite.T().Log("About to run line #106: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).PolygonSub(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{1.9, 1.1}, []interface{}{1.9, 1.9}, []interface{}{1.1, 1.9})).Includes(r.Polygon([]interface{}{1.1, 1.1}, []interface{}{2, 1.1}, []interface{}{2, 2}, []interface{}{1.1, 2}))")
@@ -766,7 +766,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #108
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.polygon([2,1.1], [3,1.1], [3,1.9], [2,1.9])) */
 
 		suite.T().Log("About to run line #108: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Polygon([]interface{}{2, 1.1}, []interface{}{3, 1.1}, []interface{}{3, 1.9}, []interface{}{2, 1.9}))")
@@ -781,7 +781,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #110
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.polygon([1,1], [2,1], [2,2], [1,2]).includes(r.polygon([2,2], [3,2], [3,3], [2,3])) */
 
 		suite.T().Log("About to run line #110: r.Polygon([]interface{}{1, 1}, []interface{}{2, 1}, []interface{}{2, 2}, []interface{}{1, 2}).Includes(r.Polygon([]interface{}{2, 2}, []interface{}{3, 2}, []interface{}{3, 3}, []interface{}{2, 3}))")
@@ -796,7 +796,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #113
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr([r.polygon([0,0], [1,1], [1,0]), r.polygon([0,1], [1,2], [1,1])]).includes(r.point(0,0)).count() */
 
 		suite.T().Log("About to run line #113: r.Expr([]interface{}{r.Polygon([]interface{}{0, 0}, []interface{}{1, 1}, []interface{}{1, 0}), r.Polygon([]interface{}{0, 1}, []interface{}{1, 2}, []interface{}{1, 1})}).Includes(r.Point(0, 0)).Count()")
@@ -811,7 +811,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #116
 		/* err('ReqlQueryLogicError', 'Expected geometry of type `Polygon` but found `Point`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected geometry of type `Polygon` but found `Point`.")
+		var expected_ = err("ReqlQueryLogicError", "Expected geometry of type `Polygon` but found `Point`.")
 		/* r.point(0,0).includes(r.point(0,0)) */
 
 		suite.T().Log("About to run line #116: r.Point(0, 0).Includes(r.Point(0, 0))")
@@ -826,7 +826,7 @@ func (suite *GeoIntersectionInclusionSuite) TestCases() {
 	{
 		// geo/intersection_inclusion.yaml line #118
 		/* err('ReqlQueryLogicError', 'Expected geometry of type `Polygon` but found `LineString`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected geometry of type `Polygon` but found `LineString`.")
+		var expected_ = err("ReqlQueryLogicError", "Expected geometry of type `Polygon` but found `LineString`.")
 		/* r.line([0,0], [0,1]).includes(r.point(0,0)) */
 
 		suite.T().Log("About to run line #118: r.Line([]interface{}{0, 0}, []interface{}{0, 1}).Includes(r.Point(0, 0))")

--- a/internal/integration/reql_tests/reql_geo_operations_test.go
+++ b/internal/integration/reql_tests/reql_geo_operations_test.go
@@ -61,7 +61,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #5
 		/* ("89011.26253835332") */
-		var expected_ string = "89011.26253835332"
+		var expected_ = "89011.26253835332"
 		/* r.distance(r.point(-122, 37), r.point(-123, 37)).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #5: r.Distance(r.Point(-122, 37), r.Point(-123, 37)).CoerceTo('STRING')")
@@ -76,7 +76,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #7
 		/* ("110968.30443995494") */
-		var expected_ string = "110968.30443995494"
+		var expected_ = "110968.30443995494"
 		/* r.distance(r.point(-122, 37), r.point(-122, 36)).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #7: r.Distance(r.Point(-122, 37), r.Point(-122, 36)).CoerceTo('STRING')")
@@ -91,7 +91,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #9
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.distance(r.point(-122, 37), r.point(-122, 36)).eq(r.distance(r.point(-122, 36), r.point(-122, 37))) */
 
 		suite.T().Log("About to run line #9: r.Distance(r.Point(-122, 37), r.Point(-122, 36)).Eq(r.Distance(r.Point(-122, 36), r.Point(-122, 37)))")
@@ -106,7 +106,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #11
 		/* ("89011.26253835332") */
-		var expected_ string = "89011.26253835332"
+		var expected_ = "89011.26253835332"
 		/* r.point(-122, 37).distance(r.point(-123, 37)).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #11: r.Point(-122, 37).Distance(r.Point(-123, 37)).CoerceTo('STRING')")
@@ -128,7 +128,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #15
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* someDist.eq(r.distance(r.point(-122, 37), r.point(-123, 37), unit='m')) */
 
 		suite.T().Log("About to run line #15: someDist.Eq(r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{Unit: 'm', }))")
@@ -143,7 +143,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #19
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* someDist.mul(1.0/1000.0).eq(r.distance(r.point(-122, 37), r.point(-123, 37), unit='km')) */
 
 		suite.T().Log("About to run line #19: someDist.Mul(r.Div(1.0, 1000.0)).Eq(r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{Unit: 'km', }))")
@@ -158,7 +158,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #23
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* someDist.mul(1.0/1609.344).eq(r.distance(r.point(-122, 37), r.point(-123, 37), unit='mi')) */
 
 		suite.T().Log("About to run line #23: someDist.Mul(r.Div(1.0, 1609.344)).Eq(r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{Unit: 'mi', }))")
@@ -173,7 +173,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #27
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* someDist.mul(1.0/0.3048).eq(r.distance(r.point(-122, 37), r.point(-123, 37), unit='ft')) */
 
 		suite.T().Log("About to run line #27: someDist.Mul(r.Div(1.0, 0.3048)).Eq(r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{Unit: 'ft', }))")
@@ -188,7 +188,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #31
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* someDist.mul(1.0/1852.0).eq(r.distance(r.point(-122, 37), r.point(-123, 37), unit='nm')) */
 
 		suite.T().Log("About to run line #31: someDist.Mul(r.Div(1.0, 1852.0)).Eq(r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{Unit: 'nm', }))")
@@ -203,7 +203,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #35
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* someDist.eq(r.distance(r.point(-122, 37), r.point(-123, 37), geo_system='WGS84')) */
 
 		suite.T().Log("About to run line #35: someDist.Eq(r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{GeoSystem: 'WGS84', }))")
@@ -218,7 +218,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #40
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* someDist.div(10).eq(r.distance(r.point(-122, 37), r.point(-123, 37), geo_system={'a':637813.7, 'f':(1.0/298.257223563)})) */
 
 		suite.T().Log("About to run line #40: someDist.Div(10).Eq(r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{GeoSystem: map[interface{}]interface{}{'a': 637813.7, 'f': r.Div(1.0, 298.257223563), }, }))")
@@ -233,7 +233,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #43
 		/* ("0.01393875509649327") */
-		var expected_ string = "0.01393875509649327"
+		var expected_ = "0.01393875509649327"
 		/* r.distance(r.point(-122, 37), r.point(-123, 37), geo_system='unit_sphere').coerce_to('STRING') */
 
 		suite.T().Log("About to run line #43: r.Distance(r.Point(-122, 37), r.Point(-123, 37)).OptArgs(r.DistanceOpts{GeoSystem: 'unit_sphere', }).CoerceTo('STRING')")
@@ -248,7 +248,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #47
 		/* ("0") */
-		var expected_ string = "0"
+		var expected_ = "0"
 		/* r.distance(r.point(0, 0), r.point(0, 0)).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #47: r.Distance(r.Point(0, 0), r.Point(0, 0)).CoerceTo('STRING')")
@@ -263,7 +263,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #50
 		/* ("40007862.917250897") */
-		var expected_ string = "40007862.917250897"
+		var expected_ = "40007862.917250897"
 		/* r.distance(r.point(0, 0), r.point(180, 0)).mul(2).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #50: r.Distance(r.Point(0, 0), r.Point(180, 0)).Mul(2).CoerceTo('STRING')")
@@ -278,7 +278,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #52
 		/* ("40007862.917250897") */
-		var expected_ string = "40007862.917250897"
+		var expected_ = "40007862.917250897"
 		/* r.distance(r.point(0, -90), r.point(0, 90)).mul(2).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #52: r.Distance(r.Point(0, -90), r.Point(0, 90)).Mul(2).CoerceTo('STRING')")
@@ -293,7 +293,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #54
 		/* ("0") */
-		var expected_ string = "0"
+		var expected_ = "0"
 		/* r.distance(r.point(0, 0), r.line([0,0], [0,1])).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #54: r.Distance(r.Point(0, 0), r.Line([]interface{}{0, 0}, []interface{}{0, 1})).CoerceTo('STRING')")
@@ -308,7 +308,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #56
 		/* ("0") */
-		var expected_ string = "0"
+		var expected_ = "0"
 		/* r.distance(r.line([0,0], [0,1]), r.point(0, 0)).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #56: r.Distance(r.Line([]interface{}{0, 0}, []interface{}{0, 1}), r.Point(0, 0)).CoerceTo('STRING')")
@@ -323,7 +323,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #58
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.distance(r.point(0, 0), r.line([0.1,0], [1,0])).eq(r.distance(r.point(0, 0), r.point(0.1, 0))) */
 
 		suite.T().Log("About to run line #58: r.Distance(r.Point(0, 0), r.Line([]interface{}{0.1, 0}, []interface{}{1, 0})).Eq(r.Distance(r.Point(0, 0), r.Point(0.1, 0)))")
@@ -338,7 +338,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #60
 		/* ("492471.4990055255") */
-		var expected_ string = "492471.4990055255"
+		var expected_ = "492471.4990055255"
 		/* r.distance(r.point(0, 0), r.line([5,-1], [4,2])).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #60: r.Distance(r.Point(0, 0), r.Line([]interface{}{5, -1}, []interface{}{4, 2})).CoerceTo('STRING')")
@@ -353,7 +353,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #62
 		/* ("492471.4990055255") */
-		var expected_ string = "492471.4990055255"
+		var expected_ = "492471.4990055255"
 		/* r.distance(r.point(0, 0), r.polygon([5,-1], [4,2], [10,10])).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #62: r.Distance(r.Point(0, 0), r.Polygon([]interface{}{5, -1}, []interface{}{4, 2}, []interface{}{10, 10})).CoerceTo('STRING')")
@@ -368,7 +368,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #64
 		/* ("0") */
-		var expected_ string = "0"
+		var expected_ = "0"
 		/* r.distance(r.point(0, 0), r.polygon([0,-1], [0,1], [10,10])).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #64: r.Distance(r.Point(0, 0), r.Polygon([]interface{}{0, -1}, []interface{}{0, 1}, []interface{}{10, 10})).CoerceTo('STRING')")
@@ -383,7 +383,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #66
 		/* ("0") */
-		var expected_ string = "0"
+		var expected_ = "0"
 		/* r.distance(r.point(0.5, 0.5), r.polygon([0,-1], [0,1], [10,10])).coerce_to('STRING') */
 
 		suite.T().Log("About to run line #66: r.Distance(r.Point(0.5, 0.5), r.Polygon([]interface{}{0, -1}, []interface{}{0, 1}, []interface{}{10, 10})).CoerceTo('STRING')")
@@ -398,7 +398,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #71
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.circle([0,0], 1, fill=false).eq(r.circle([0,0], 1, fill=true)) */
 
 		suite.T().Log("About to run line #71: r.Circle([]interface{}{0, 0}, 1).OptArgs(r.CircleOpts{Fill: false, }).Eq(r.Circle([]interface{}{0, 0}, 1).OptArgs(r.CircleOpts{Fill: true, }))")
@@ -413,7 +413,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #75
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.circle([0,0], 1, fill=false).fill().eq(r.circle([0,0], 1, fill=true)) */
 
 		suite.T().Log("About to run line #75: r.Circle([]interface{}{0, 0}, 1).OptArgs(r.CircleOpts{Fill: false, }).Fill().Eq(r.Circle([]interface{}{0, 0}, 1).OptArgs(r.CircleOpts{Fill: true, }))")
@@ -428,7 +428,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #80
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0,0],[1,0],[1,1],[0,1],[0,0]],[[0.1,0.1],[0.9,0.1],[0.9,0.9],[0.1,0.9],[0.1,0.1]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}, []interface{}{0, 0}}, []interface{}{[]interface{}{0.1, 0.1}, []interface{}{0.9, 0.1}, []interface{}{0.9, 0.9}, []interface{}{0.1, 0.9}, []interface{}{0.1, 0.1}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}, []interface{}{0, 0}}, []interface{}{[]interface{}{0.1, 0.1}, []interface{}{0.9, 0.1}, []interface{}{0.9, 0.9}, []interface{}{0.1, 0.9}, []interface{}{0.1, 0.1}}}, "type": "Polygon"}
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0.1,0.1], [0.9,0.1], [0.9,0.9], [0.1,0.9])) */
 
 		suite.T().Log("About to run line #80: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0.1, 0.1}, []interface{}{0.9, 0.1}, []interface{}{0.9, 0.9}, []interface{}{0.1, 0.9}))")
@@ -443,7 +443,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #82
 		/* err('ReqlQueryLogicError', 'The second argument to `polygon_sub` is not contained in the first one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
+		var expected_ = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0.1,0.9], [0.9,0.0], [0.9,0.9], [0.1,0.9])) */
 
 		suite.T().Log("About to run line #82: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0.1, 0.9}, []interface{}{0.9, 0.0}, []interface{}{0.9, 0.9}, []interface{}{0.1, 0.9}))")
@@ -458,7 +458,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #84
 		/* err('ReqlQueryLogicError', 'The second argument to `polygon_sub` is not contained in the first one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
+		var expected_ = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0,0], [2,0], [2,2], [0,2])) */
 
 		suite.T().Log("About to run line #84: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0, 0}, []interface{}{2, 0}, []interface{}{2, 2}, []interface{}{0, 2}))")
@@ -473,7 +473,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #86
 		/* err('ReqlQueryLogicError', 'The second argument to `polygon_sub` is not contained in the first one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
+		var expected_ = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0,-2], [1,-2], [-1,1], [0,-1])) */
 
 		suite.T().Log("About to run line #86: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0, -2}, []interface{}{1, -2}, []interface{}{-1, 1}, []interface{}{0, -1}))")
@@ -488,7 +488,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #88
 		/* err('ReqlQueryLogicError', 'The second argument to `polygon_sub` is not contained in the first one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
+		var expected_ = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0,-1], [1,-1], [1,0], [0,0])) */
 
 		suite.T().Log("About to run line #88: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0, -1}, []interface{}{1, -1}, []interface{}{1, 0}, []interface{}{0, 0}))")
@@ -503,7 +503,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #90
 		/* err('ReqlQueryLogicError', 'The second argument to `polygon_sub` is not contained in the first one.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
+		var expected_ = err("ReqlQueryLogicError", "The second argument to `polygon_sub` is not contained in the first one.")
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0.1,-1], [0.9,-1], [0.9,0.5], [0.1,0.5])) */
 
 		suite.T().Log("About to run line #90: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0.1, -1}, []interface{}{0.9, -1}, []interface{}{0.9, 0.5}, []interface{}{0.1, 0.5}))")
@@ -518,7 +518,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #92
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0,0],[1,0],[1,1],[0,1],[0,0]],[[0,0],[0.1,0.9],[0.9,0.9],[0.9,0.1],[0,0]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}, []interface{}{0, 0}}, []interface{}{[]interface{}{0, 0}, []interface{}{0.1, 0.9}, []interface{}{0.9, 0.9}, []interface{}{0.9, 0.1}, []interface{}{0, 0}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}, []interface{}{0, 0}}, []interface{}{[]interface{}{0, 0}, []interface{}{0.1, 0.9}, []interface{}{0.9, 0.9}, []interface{}{0.9, 0.1}, []interface{}{0, 0}}}, "type": "Polygon"}
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0,0],[0.1,0.9],[0.9,0.9],[0.9,0.1])) */
 
 		suite.T().Log("About to run line #92: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0, 0}, []interface{}{0.1, 0.9}, []interface{}{0.9, 0.9}, []interface{}{0.9, 0.1}))")
@@ -533,7 +533,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #94
 		/* err('ReqlQueryLogicError', 'Expected a Polygon with only an outer shell.  This one has holes.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected a Polygon with only an outer shell.  This one has holes.")
+		var expected_ = err("ReqlQueryLogicError", "Expected a Polygon with only an outer shell.  This one has holes.")
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.polygon([0,0],[0.1,0.9],[0.9,0.9],[0.9,0.1]).polygon_sub(r.polygon([0.2,0.2],[0.5,0.8],[0.8,0.2]))) */
 
 		suite.T().Log("About to run line #94: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Polygon([]interface{}{0, 0}, []interface{}{0.1, 0.9}, []interface{}{0.9, 0.9}, []interface{}{0.9, 0.1}).PolygonSub(r.Polygon([]interface{}{0.2, 0.2}, []interface{}{0.5, 0.8}, []interface{}{0.8, 0.2})))")
@@ -548,7 +548,7 @@ func (suite *GeoOperationsSuite) TestCases() {
 	{
 		// geo/operations.yaml line #96
 		/* err('ReqlQueryLogicError', 'Expected a Polygon but found a LineString.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected a Polygon but found a LineString.")
+		var expected_ = err("ReqlQueryLogicError", "Expected a Polygon but found a LineString.")
 		/* r.polygon([0,0], [1,0], [1,1], [0,1]).polygon_sub(r.line([0,0],[0.9,0.1],[0.9,0.9],[0.1,0.9])) */
 
 		suite.T().Log("About to run line #96: r.Polygon([]interface{}{0, 0}, []interface{}{1, 0}, []interface{}{1, 1}, []interface{}{0, 1}).PolygonSub(r.Line([]interface{}{0, 0}, []interface{}{0.9, 0.1}, []interface{}{0.9, 0.9}, []interface{}{0.1, 0.9}))")

--- a/internal/integration/reql_tests/reql_geo_primitives_test.go
+++ b/internal/integration/reql_tests/reql_geo_primitives_test.go
@@ -61,7 +61,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #5
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0, -9.04369477050382e-06], [-7.779638566553426e-06, 4.5218473852518965e-06], [7.779638566553426e-06, 4.5218473852518965e-06], [0, -9.04369477050382e-06]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
 		/* r.circle([0,0], 1, num_vertices=3) */
 
 		suite.T().Log("About to run line #5: r.Circle([]interface{}{0, 0}, 1).OptArgs(r.CircleOpts{NumVertices: 3, })")
@@ -76,7 +76,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #10
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0, -9.04369477050382e-06], [-7.779638566553426e-06, 4.5218473852518965e-06], [7.779638566553426e-06, 4.5218473852518965e-06], [0, -9.04369477050382e-06]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
 		/* r.circle(r.point(0,0), 1, num_vertices=3) */
 
 		suite.T().Log("About to run line #10: r.Circle(r.Point(0, 0), 1).OptArgs(r.CircleOpts{NumVertices: 3, })")
@@ -91,7 +91,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #15
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[0, -9.04369477050382e-06], [-7.779638566553426e-06, 4.5218473852518965e-06], [7.779638566553426e-06, 4.5218473852518965e-06], [0, -9.04369477050382e-06]], 'type':'LineString'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}, "type": "LineString"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}, "type": "LineString"}
 		/* r.circle([0,0], 1, num_vertices=3, fill=false) */
 
 		suite.T().Log("About to run line #15: r.Circle([]interface{}{0, 0}, 1).OptArgs(r.CircleOpts{NumVertices: 3, Fill: false, })")
@@ -106,7 +106,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #20
 		/* err('ReqlQueryLogicError', 'Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 14000000m, but must be smaller than 9985163.1855612862855m.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 14000000m, but must be smaller than 9985163.1855612862855m.")
+		var expected_ = err("ReqlQueryLogicError", "Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 14000000m, but must be smaller than 9985163.1855612862855m.")
 		/* r.circle([0,0], 14000000, num_vertices=3) */
 
 		suite.T().Log("About to run line #20: r.Circle([]interface{}{0, 0}, 14000000).OptArgs(r.CircleOpts{NumVertices: 3, })")
@@ -121,7 +121,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #25
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0, -9.04369477050382e-06], [-7.779638566553426e-06, 4.5218473852518965e-06], [7.779638566553426e-06, 4.5218473852518965e-06], [0, -9.04369477050382e-06]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
 		/* r.circle([0,0], 1, num_vertices=3, geo_system='WGS84') */
 
 		suite.T().Log("About to run line #25: r.Circle([]interface{}{0, 0}, 1).OptArgs(r.CircleOpts{NumVertices: 3, GeoSystem: 'WGS84', })")
@@ -136,7 +136,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #30
 		/* err('ReqlQueryLogicError', 'Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 2m, but must be smaller than 1.570796326794896558m.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 2m, but must be smaller than 1.570796326794896558m.")
+		var expected_ = err("ReqlQueryLogicError", "Radius must be smaller than a quarter of the circumference along the minor axis of the reference ellipsoid.  Got 2m, but must be smaller than 1.570796326794896558m.")
 		/* r.circle([0,0], 2, num_vertices=3, geo_system='unit_sphere') */
 
 		suite.T().Log("About to run line #30: r.Circle([]interface{}{0, 0}, 2).OptArgs(r.CircleOpts{NumVertices: 3, GeoSystem: 'unit_sphere', })")
@@ -151,7 +151,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #35
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0, -5.729577951308232], [-4.966092947444857, 2.861205754495701], [4.966092947444857, 2.861205754495701], [0, -5.729577951308232]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -5.729577951308232}, []interface{}{-4.966092947444857, 2.861205754495701}, []interface{}{4.966092947444857, 2.861205754495701}, []interface{}{0, -5.729577951308232}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -5.729577951308232}, []interface{}{-4.966092947444857, 2.861205754495701}, []interface{}{4.966092947444857, 2.861205754495701}, []interface{}{0, -5.729577951308232}}}, "type": "Polygon"}
 		/* r.circle([0,0], 0.1, num_vertices=3, geo_system='unit_sphere') */
 
 		suite.T().Log("About to run line #35: r.Circle([]interface{}{0, 0}, 0.1).OptArgs(r.CircleOpts{NumVertices: 3, GeoSystem: 'unit_sphere', })")
@@ -166,7 +166,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #42
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0, -9.04369477050382e-06], [-7.779638566553426e-06, 4.5218473852518965e-06], [7.779638566553426e-06, 4.5218473852518965e-06], [0, -9.04369477050382e-06]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
 		/* r.circle([0,0], 1.0/1000.0, num_vertices=3, unit='km') */
 
 		suite.T().Log("About to run line #42: r.Circle([]interface{}{0, 0}, r.Div(1.0, 1000.0)).OptArgs(r.CircleOpts{NumVertices: 3, Unit: 'km', })")
@@ -181,7 +181,7 @@ func (suite *GeoPrimitivesSuite) TestCases() {
 	{
 		// geo/primitives.yaml line #47
 		/* ({'$reql_type$':'GEOMETRY', 'coordinates':[[[0, -9.04369477050382e-06], [-7.779638566553426e-06, 4.5218473852518965e-06], [7.779638566553426e-06, 4.5218473852518965e-06], [0, -9.04369477050382e-06]]], 'type':'Polygon'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{[]interface{}{[]interface{}{0, -9.04369477050382e-06}, []interface{}{-7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{7.779638566553426e-06, 4.5218473852518965e-06}, []interface{}{0, -9.04369477050382e-06}}}, "type": "Polygon"}
 		/* r.circle([0,0], 1.0/1609.344, num_vertices=3, unit='mi') */
 
 		suite.T().Log("About to run line #47: r.Circle([]interface{}{0, 0}, r.Div(1.0, 1609.344)).OptArgs(r.CircleOpts{NumVertices: 3, Unit: 'mi', })")

--- a/internal/integration/reql_tests/reql_joins_test.go
+++ b/internal/integration/reql_tests/reql_joins_test.go
@@ -118,7 +118,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #7
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.db('test').table_create('test3', primary_key='foo') */
 
 		suite.T().Log("About to run line #7: r.DB('test').TableCreate('test3').OptArgs(r.TableCreateOpts{PrimaryKey: 'foo', })")
@@ -140,7 +140,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #13
 		/* partial({'errors':0, 'inserted':100}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 100})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 100})
 		/* tbl.insert(r.range(0, 100).map({'id':r.row, 'a':r.row % 4})) */
 
 		suite.T().Log("About to run line #13: tbl.Insert(r.Range(0, 100).Map(map[interface{}]interface{}{'id': r.Row, 'a': r.Row.Mod(4), }))")
@@ -155,7 +155,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #18
 		/* partial({'errors':0, 'inserted':100}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 100})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 100})
 		/* tbl2.insert(r.range(0, 100).map({'id':r.row, 'b':r.row % 4})) */
 
 		suite.T().Log("About to run line #18: tbl2.Insert(r.Range(0, 100).Map(map[interface{}]interface{}{'id': r.Row, 'b': r.Row.Mod(4), }))")
@@ -170,7 +170,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #23
 		/* partial({'errors':0, 'inserted':100}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 100})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 0, "inserted": 100})
 		/* tbl3.insert(r.range(0, 100).map({'foo':r.row, 'b':r.row % 4})) */
 
 		suite.T().Log("About to run line #23: tbl3.Insert(r.Range(0, 100).Map(map[interface{}]interface{}{'foo': r.Row, 'b': r.Row.Mod(4), }))")
@@ -185,7 +185,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #28
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* otbl.insert(r.range(1,100).map({'id': r.row, 'a': r.row})) */
 
 		suite.T().Log("About to run line #28: otbl.Insert(r.Range(1, 100).Map(map[interface{}]interface{}{'id': r.Row, 'a': r.Row, }))")
@@ -200,7 +200,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #29
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* otbl2.insert(r.range(1,100).map({'id': r.row, 'b': 2 * r.row})) */
 
 		suite.T().Log("About to run line #29: otbl2.Insert(r.Range(1, 100).Map(map[interface{}]interface{}{'id': r.Row, 'b': r.Mul(2, r.Row), }))")
@@ -222,7 +222,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #37
 		/* 2500 */
-		var expected_ int = 2500
+		var expected_ = 2500
 		/* ij.count() */
 
 		suite.T().Log("About to run line #37: ij.Count()")
@@ -237,7 +237,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #39
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* ij.filter(lambda row:row['a'] != row['b']).count() */
 
 		suite.T().Log("About to run line #39: ij.Filter(func(row r.Term) interface{} { return row.AtIndex('a').Ne(row.AtIndex('b'))}).Count()")
@@ -259,7 +259,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #49
 		/* 2500 */
-		var expected_ int = 2500
+		var expected_ = 2500
 		/* oj.count() */
 
 		suite.T().Log("About to run line #49: oj.Count()")
@@ -274,7 +274,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #51
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* oj.filter(lambda row:row['a'] != row['b']).count() */
 
 		suite.T().Log("About to run line #51: oj.Filter(func(row r.Term) interface{} { return row.AtIndex('a').Ne(row.AtIndex('b'))}).Count()")
@@ -308,7 +308,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #65
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.eq_join('a', tbl2).zip().count() */
 
 		suite.T().Log("About to run line #65: tbl.EqJoin('a', tbl2).Zip().Count()")
@@ -323,7 +323,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #68
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.eq_join('fake', tbl2).zip().count() */
 
 		suite.T().Log("About to run line #68: tbl.EqJoin('fake', tbl2).Zip().Count()")
@@ -338,7 +338,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #71
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.eq_join(lambda x:x['a'], tbl2).zip().count() */
 
 		suite.T().Log("About to run line #71: tbl.EqJoin(func(x r.Term) interface{} { return x.AtIndex('a')}, tbl2).Zip().Count()")
@@ -353,7 +353,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #76
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.eq_join(lambda x:x['fake'], tbl2).zip().count() */
 
 		suite.T().Log("About to run line #76: tbl.EqJoin(func(x r.Term) interface{} { return x.AtIndex('fake')}, tbl2).Zip().Count()")
@@ -368,7 +368,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #81
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.eq_join(lambda x:null, tbl2).zip().count() */
 
 		suite.T().Log("About to run line #81: tbl.EqJoin(func(x r.Term) interface{} { return nil}, tbl2).Zip().Count()")
@@ -383,7 +383,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #86
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.eq_join(lambda x:x['a'], tbl2).count() */
 
 		suite.T().Log("About to run line #86: tbl.EqJoin(func(x r.Term) interface{} { return x.AtIndex('a')}, tbl2).Count()")
@@ -398,7 +398,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #92
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.eq_join('a', tbl3).zip().count() */
 
 		suite.T().Log("About to run line #92: tbl.EqJoin('a', tbl3).Zip().Count()")
@@ -413,7 +413,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #95
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.eq_join(lambda x:x['a'], tbl3).count() */
 
 		suite.T().Log("About to run line #95: tbl.EqJoin(func(x r.Term) interface{} { return x.AtIndex('a')}, tbl3).Count()")
@@ -428,7 +428,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #101
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.eq_join(r.row['a'], tbl2).count() */
 
 		suite.T().Log("About to run line #101: tbl.EqJoin(r.Row.AtIndex('a'), tbl2).Count()")
@@ -457,7 +457,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #109
 		/* [{'a':2,'b':2},{'a':3,'b':3}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 2, "b": 2}, map[interface{}]interface{}{"a": 3, "b": 3}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 2, "b": 2}, map[interface{}]interface{}{"a": 3, "b": 3}}
 		/* left.inner_join(right, lambda l, r:l['a'] == r['b']).zip() */
 
 		suite.T().Log("About to run line #109: left.InnerJoin(right, func(l r.Term, r r.Term) interface{} { return l.AtIndex('a').Eq(r.AtIndex('b'))}).Zip()")
@@ -472,7 +472,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #115
 		/* [{'a':1},{'a':2,'b':2},{'a':3,'b':3}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2, "b": 2}, map[interface{}]interface{}{"a": 3, "b": 3}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2, "b": 2}, map[interface{}]interface{}{"a": 3, "b": 3}}
 		/* left.outer_join(right, lambda l, r:l['a'] == r['b']).zip() */
 
 		suite.T().Log("About to run line #115: left.OuterJoin(right, func(l r.Term, r r.Term) interface{} { return l.AtIndex('a').Eq(r.AtIndex('b'))}).Zip()")
@@ -487,7 +487,7 @@ func (suite *JoinsSuite) TestCases() {
 	{
 		// joins.yaml line #132
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* r.db('test').table_drop('test3') */
 
 		suite.T().Log("About to run line #132: r.DB('test').TableDrop('test3')")

--- a/internal/integration/reql_tests/reql_json_test.go
+++ b/internal/integration/reql_tests/reql_json_test.go
@@ -61,7 +61,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #4
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.json("[1,2,3]") */
 
 		suite.T().Log("About to run line #4: r.JSON('[1,2,3]')")
@@ -76,7 +76,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #7
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.json("1") */
 
 		suite.T().Log("About to run line #7: r.JSON('1')")
@@ -91,7 +91,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #10
 		/* {} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{}
+		var expected_ = map[interface{}]interface{}{}
 		/* r.json("{}") */
 
 		suite.T().Log("About to run line #10: r.JSON('{}')")
@@ -106,7 +106,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #13
 		/* "foo" */
-		var expected_ string = "foo"
+		var expected_ = "foo"
 		/* r.json('"foo"') */
 
 		suite.T().Log("About to run line #13: r.JSON('\\'foo\\'')")
@@ -121,7 +121,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #16
 		/* err("ReqlQueryLogicError", 'Failed to parse "[1,2" as JSON:' + ' Missing a comma or \']\' after an array element.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Failed to parse \"[1,2\" as JSON:"+" Missing a comma or ']' after an array element.")
+		var expected_ = err("ReqlQueryLogicError", "Failed to parse \"[1,2\" as JSON:"+" Missing a comma or ']' after an array element.")
 		/* r.json("[1,2") */
 
 		suite.T().Log("About to run line #16: r.JSON('[1,2')")
@@ -136,7 +136,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #19
 		/* '[1,2,3]' */
-		var expected_ string = "[1,2,3]"
+		var expected_ = "[1,2,3]"
 		/* r.json("[1,2,3]").to_json_string() */
 
 		suite.T().Log("About to run line #19: r.JSON('[1,2,3]').ToJSON()")
@@ -151,7 +151,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #23
 		/* '[1,2,3]' */
-		var expected_ string = "[1,2,3]"
+		var expected_ = "[1,2,3]"
 		/* r.json("[1,2,3]").to_json() */
 
 		suite.T().Log("About to run line #23: r.JSON('[1,2,3]').ToJSON()")
@@ -166,7 +166,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #26
 		/* '{"foo":4}' */
-		var expected_ string = "{\"foo\":4}"
+		var expected_ = "{\"foo\":4}"
 		/* r.json("{\"foo\":4}").to_json_string() */
 
 		suite.T().Log("About to run line #26: r.JSON('{\\'foo\\':4}').ToJSON()")
@@ -181,7 +181,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #30
 		/* '{"foo":4}' */
-		var expected_ string = "{\"foo\":4}"
+		var expected_ = "{\"foo\":4}"
 		/* r.json("{\"foo\":4}").to_json() */
 
 		suite.T().Log("About to run line #30: r.JSON('{\\'foo\\':4}').ToJSON()")
@@ -210,7 +210,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #37
 		/* sorted */
-		var expected_ string = sorted
+		var expected_ = sorted
 		/* r.json(text).to_json_string() */
 
 		suite.T().Log("About to run line #37: r.JSON(text).ToJSON()")
@@ -225,7 +225,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #40
 		/* err('ReqlQueryLogicError', 'Cannot convert `r.minval` to JSON.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert `r.minval` to JSON.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert `r.minval` to JSON.")
 		/* r.expr(r.minval).to_json_string() */
 
 		suite.T().Log("About to run line #40: r.Expr(r.MinVal).ToJSON()")
@@ -240,7 +240,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #43
 		/* err('ReqlQueryLogicError', 'Cannot convert `r.maxval` to JSON.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert `r.maxval` to JSON.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert `r.maxval` to JSON.")
 		/* r.expr(r.maxval).to_json_string() */
 
 		suite.T().Log("About to run line #43: r.Expr(r.MaxVal).ToJSON()")
@@ -255,7 +255,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #46
 		/* err('ReqlQueryLogicError', 'Cannot convert `r.minval` to JSON.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert `r.minval` to JSON.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert `r.minval` to JSON.")
 		/* r.expr(r.minval).coerce_to('string') */
 
 		suite.T().Log("About to run line #46: r.Expr(r.MinVal).CoerceTo('string')")
@@ -270,7 +270,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #49
 		/* err('ReqlQueryLogicError', 'Cannot convert `r.maxval` to JSON.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert `r.maxval` to JSON.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert `r.maxval` to JSON.")
 		/* r.expr(r.maxval).coerce_to('string') */
 
 		suite.T().Log("About to run line #49: r.Expr(r.MaxVal).CoerceTo('string')")
@@ -285,7 +285,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #52
 		/* {'timezone':'+00:00','$reql_type$':'TIME','epoch_time':1410393600} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"timezone": "+00:00", "$reql_type$": "TIME", "epoch_time": 1410393600}
+		var expected_ = map[interface{}]interface{}{"timezone": "+00:00", "$reql_type$": "TIME", "epoch_time": 1410393600}
 		/* r.time(2014,9,11, 'Z') */
 
 		suite.T().Log("About to run line #52: r.Time(2014, 9, 11, 'Z')")
@@ -301,7 +301,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #57
 		/* '{"$reql_type$":"TIME","epoch_time":1410393600,"timezone":"+00:00"}' */
-		var expected_ string = "{\"$reql_type$\":\"TIME\",\"epoch_time\":1410393600,\"timezone\":\"+00:00\"}"
+		var expected_ = "{\"$reql_type$\":\"TIME\",\"epoch_time\":1410393600,\"timezone\":\"+00:00\"}"
 		/* r.time(2014,9,11, 'Z').to_json_string() */
 
 		suite.T().Log("About to run line #57: r.Time(2014, 9, 11, 'Z').ToJSON()")
@@ -316,7 +316,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #60
 		/* {'$reql_type$':'GEOMETRY','coordinates':[0,0],'type':'Point'} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point"}
+		var expected_ = map[interface{}]interface{}{"$reql_type$": "GEOMETRY", "coordinates": []interface{}{0, 0}, "type": "Point"}
 		/* r.point(0,0) */
 
 		suite.T().Log("About to run line #60: r.Point(0, 0)")
@@ -331,7 +331,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #63
 		/* '{"$reql_type$":"GEOMETRY","coordinates":[0,0],"type":"Point"}' */
-		var expected_ string = "{\"$reql_type$\":\"GEOMETRY\",\"coordinates\":[0,0],\"type\":\"Point\"}"
+		var expected_ = "{\"$reql_type$\":\"GEOMETRY\",\"coordinates\":[0,0],\"type\":\"Point\"}"
 		/* r.point(0,0).to_json_string() */
 
 		suite.T().Log("About to run line #63: r.Point(0, 0).ToJSON()")
@@ -353,7 +353,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #70
 		/* s */
-		var expected_ []byte = s
+		var expected_ = s
 		/* r.binary(s) */
 
 		suite.T().Log("About to run line #70: r.Binary(s)")
@@ -368,7 +368,7 @@ func (suite *JsonSuite) TestCases() {
 	{
 		// json.yaml line #73
 		/* '{"$reql_type$":"BINARY","data":"Zm9v"}' */
-		var expected_ string = "{\"$reql_type$\":\"BINARY\",\"data\":\"Zm9v\"}"
+		var expected_ = "{\"$reql_type$\":\"BINARY\",\"data\":\"Zm9v\"}"
 		/* r.expr("foo").coerce_to("binary").to_json_string() */
 
 		suite.T().Log("About to run line #73: r.Expr('foo').CoerceTo('binary').ToJSON()")

--- a/internal/integration/reql_tests/reql_limits_test.go
+++ b/internal/integration/reql_tests/reql_limits_test.go
@@ -70,7 +70,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #6
 		/* [1,1,1,1,1,1,1,1] */
-		var expected_ []interface{} = []interface{}{1, 1, 1, 1, 1, 1, 1, 1}
+		var expected_ = []interface{}{1, 1, 1, 1, 1, 1, 1, 1}
 		/* r.expr([1,1,1,1]).union([1, 1, 1, 1]) */
 
 		suite.T().Log("About to run line #6: r.Expr([]interface{}{1, 1, 1, 1}).Union([]interface{}{1, 1, 1, 1})")
@@ -86,7 +86,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #10
 		/* err("ReqlResourceLimitError", "Array over size limit `4`.  To raise the number of allowed elements, modify the `array_limit` option to `.run` (not available in the Data Explorer), or use an index.", [0]) */
-		var expected_ Err = err("ReqlResourceLimitError", "Array over size limit `4`.  To raise the number of allowed elements, modify the `array_limit` option to `.run` (not available in the Data Explorer), or use an index.")
+		var expected_ = err("ReqlResourceLimitError", "Array over size limit `4`.  To raise the number of allowed elements, modify the `array_limit` option to `.run` (not available in the Data Explorer), or use an index.")
 		/* r.expr([1,2,3,4]).union([5, 6, 7, 8]) */
 
 		suite.T().Log("About to run line #10: r.Expr([]interface{}{1, 2, 3, 4}).Union([]interface{}{5, 6, 7, 8})")
@@ -102,7 +102,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #16
 		/* err("ReqlResourceLimitError", "Array over size limit `4`.  To raise the number of allowed elements, modify the `array_limit` option to `.run` (not available in the Data Explorer), or use an index.", [0]) */
-		var expected_ Err = err("ReqlResourceLimitError", "Array over size limit `4`.  To raise the number of allowed elements, modify the `array_limit` option to `.run` (not available in the Data Explorer), or use an index.")
+		var expected_ = err("ReqlResourceLimitError", "Array over size limit `4`.  To raise the number of allowed elements, modify the `array_limit` option to `.run` (not available in the Data Explorer), or use an index.")
 		/* r.expr([1,2,3,4,5,6,7,8]) */
 
 		suite.T().Log("About to run line #16: r.Expr([]interface{}{1, 2, 3, 4, 5, 6, 7, 8})")
@@ -118,7 +118,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #22
 		/* err("ReqlQueryLogicError", "Illegal array size limit `-1`.  (Must be >= 1.)", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Illegal array size limit `-1`.  (Must be >= 1.)")
+		var expected_ = err("ReqlQueryLogicError", "Illegal array size limit `-1`.  (Must be >= 1.)")
 		/* r.expr([1,2,3,4,5,6,7,8]) */
 
 		suite.T().Log("About to run line #22: r.Expr([]interface{}{1, 2, 3, 4, 5, 6, 7, 8})")
@@ -134,7 +134,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #27
 		/* err("ReqlQueryLogicError", "Illegal array size limit `0`.  (Must be >= 1.)", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Illegal array size limit `0`.  (Must be >= 1.)")
+		var expected_ = err("ReqlQueryLogicError", "Illegal array size limit `0`.  (Must be >= 1.)")
 		/* r.expr([1,2,3,4,5,6,7,8]) */
 
 		suite.T().Log("About to run line #27: r.Expr([]interface{}{1, 2, 3, 4, 5, 6, 7, 8})")
@@ -173,7 +173,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #58
 		/* ({'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tbl.insert({'id':1, 'array':ten_l}) */
 
 		suite.T().Log("About to run line #58: tbl.Insert(map[interface{}]interface{}{'id': 1, 'array': ten_l, })")
@@ -188,7 +188,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #60
 		/* ({'array':[1,2,3,4,5,6,7,8,9,10],'id':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"array": []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "id": 1}
+		var expected_ = map[interface{}]interface{}{"array": []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "id": 1}
 		/* tbl.get(1) */
 
 		suite.T().Log("About to run line #60: tbl.Get(1)")
@@ -204,7 +204,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #67
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.delete().get_field('deleted') */
 
 		suite.T().Log("About to run line #67: tbl.Delete().Field('deleted')")
@@ -226,7 +226,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #73
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* tbl.insert([{'id':0}, {'id':1}, {'id':2}, {'id':3}, {'id':4}, {'id':5}, {'id':6}]).get_field('inserted') */
 
 		suite.T().Log("About to run line #73: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 0, }, map[interface{}]interface{}{'id': 1, }, map[interface{}]interface{}{'id': 2, }, map[interface{}]interface{}{'id': 3, }, map[interface{}]interface{}{'id': 4, }, map[interface{}]interface{}{'id': 5, }, map[interface{}]interface{}{'id': 6, }}).Field('inserted')")
@@ -241,7 +241,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #85
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* tbl.insert([{'id':7}, {'id':8}, {'id':9}, {'id':10}, {'id':11}, {'id':12}, {'id':13}]).get_field('inserted') */
 
 		suite.T().Log("About to run line #85: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 7, }, map[interface{}]interface{}{'id': 8, }, map[interface{}]interface{}{'id': 9, }, map[interface{}]interface{}{'id': 10, }, map[interface{}]interface{}{'id': 11, }, map[interface{}]interface{}{'id': 12, }, map[interface{}]interface{}{'id': 13, }}).Field('inserted')")
@@ -256,7 +256,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #97
 		/* 14 */
-		var expected_ int = 14
+		var expected_ = 14
 		/* tbl.delete().get_field('deleted') */
 
 		suite.T().Log("About to run line #97: tbl.Delete().Field('deleted')")
@@ -280,7 +280,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #106
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* tbl.insert([{'id':0}, {'id':1}, {'id':2}, {'id':3}, {'id':4}, {'id':5}, {'id':6}]).get_field('inserted') */
 
 		suite.T().Log("About to run line #106: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 0, }, map[interface{}]interface{}{'id': 1, }, map[interface{}]interface{}{'id': 2, }, map[interface{}]interface{}{'id': 3, }, map[interface{}]interface{}{'id': 4, }, map[interface{}]interface{}{'id': 5, }, map[interface{}]interface{}{'id': 6, }}).Field('inserted')")
@@ -295,7 +295,7 @@ func (suite *LimitsSuite) TestCases() {
 	{
 		// limits.yaml line #118
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* tbl.insert([{'id':7}, {'id':8}, {'id':9}, {'id':10}, {'id':11}, {'id':12}, {'id':13}]).get_field('inserted') */
 
 		suite.T().Log("About to run line #118: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 7, }, map[interface{}]interface{}{'id': 8, }, map[interface{}]interface{}{'id': 9, }, map[interface{}]interface{}{'id': 10, }, map[interface{}]interface{}{'id': 11, }, map[interface{}]interface{}{'id': 12, }, map[interface{}]interface{}{'id': 13, }}).Field('inserted')")

--- a/internal/integration/reql_tests/reql_match_test.go
+++ b/internal/integration/reql_tests/reql_match_test.go
@@ -70,7 +70,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #4
 		/* ({'str':'bcde','groups':[null,{'start':2,'str':'cde','end':5}],'start':1,'end':5}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"str": "bcde", "groups": []interface{}{nil, map[interface{}]interface{}{"start": 2, "str": "cde", "end": 5}}, "start": 1, "end": 5}
+		var expected_ = map[interface{}]interface{}{"str": "bcde", "groups": []interface{}{nil, map[interface{}]interface{}{"start": 2, "str": "cde", "end": 5}}, "start": 1, "end": 5}
 		/* r.expr("abcdefg").match("a(b.e)|b(c.e)") */
 
 		suite.T().Log("About to run line #4: r.Expr('abcdefg').Match('a(b.e)|b(c.e)')")
@@ -100,7 +100,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #8
 		/* ({'str':'bcde','groups':[null,{'start':2,'str':'cde','end':5}],'start':1,'end':5}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"str": "bcde", "groups": []interface{}{nil, map[interface{}]interface{}{"start": 2, "str": "cde", "end": 5}}, "start": 1, "end": 5}
+		var expected_ = map[interface{}]interface{}{"str": "bcde", "groups": []interface{}{nil, map[interface{}]interface{}{"start": 2, "str": "cde", "end": 5}}, "start": 1, "end": 5}
 		/* r.expr("abcdefg").match("(?i)a(b.e)|B(c.e)") */
 
 		suite.T().Log("About to run line #8: r.Expr('abcdefg').Match('(?i)a(b.e)|B(c.e)')")
@@ -115,7 +115,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #12
 		/* (["aca", "ada"]) */
-		var expected_ []interface{} = []interface{}{"aca", "ada"}
+		var expected_ = []interface{}{"aca", "ada"}
 		/* r.expr(["aba", "aca", "ada", "aea"]).filter(lambda row:row.match("a(.)a")['groups'][0]['str'].match("[cd]")) */
 
 		suite.T().Log("About to run line #12: r.Expr([]interface{}{'aba', 'aca', 'ada', 'aea'}).Filter(func(row r.Term) interface{} { return row.Match('a(.)a').AtIndex('groups').AtIndex(0).AtIndex('str').Match('[cd]')})")
@@ -132,7 +132,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #16
 		/* ({'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':3}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 3}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 3}
 		/* tbl.insert([{'id':0,'a':'abc'},{'id':1,'a':'ab'},{'id':2,'a':'bc'}]) */
 
 		suite.T().Log("About to run line #16: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 0, 'a': 'abc', }, map[interface{}]interface{}{'id': 1, 'a': 'ab', }, map[interface{}]interface{}{'id': 2, 'a': 'bc', }})")
@@ -147,7 +147,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #20
 		/* ([{'id':0,'a':'abc'},{'id':1,'a':'ab'},{'id':2,'a':'bc'}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 0, "a": "abc"}, map[interface{}]interface{}{"id": 1, "a": "ab"}, map[interface{}]interface{}{"id": 2, "a": "bc"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 0, "a": "abc"}, map[interface{}]interface{}{"id": 1, "a": "ab"}, map[interface{}]interface{}{"id": 2, "a": "bc"}}
 		/* tbl.filter(lambda row:row['a'].match('b')).order_by('id') */
 
 		suite.T().Log("About to run line #20: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('a').Match('b')}).OrderBy('id')")
@@ -162,7 +162,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #24
 		/* ([{'id':0,'a':'abc'},{'id':1,'a':'ab'}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 0, "a": "abc"}, map[interface{}]interface{}{"id": 1, "a": "ab"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 0, "a": "abc"}, map[interface{}]interface{}{"id": 1, "a": "ab"}}
 		/* tbl.filter(lambda row:row['a'].match('ab')).order_by('id') */
 
 		suite.T().Log("About to run line #24: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('a').Match('ab')}).OrderBy('id')")
@@ -177,7 +177,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #28
 		/* ([{'id':1,'a':'ab'}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 1, "a": "ab"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 1, "a": "ab"}}
 		/* tbl.filter(lambda row:row['a'].match('ab$')).order_by('id') */
 
 		suite.T().Log("About to run line #28: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('a').Match('ab$')}).OrderBy('id')")
@@ -192,7 +192,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #32
 		/* ([]) */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.filter(lambda row:row['a'].match('^b$')).order_by('id') */
 
 		suite.T().Log("About to run line #32: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('a').Match('^b$')}).OrderBy('id')")
@@ -207,7 +207,7 @@ func (suite *MatchSuite) TestCases() {
 	{
 		// match.yaml line #36
 		/* err("ReqlQueryLogicError", "Error in regexp `ab\\9` (portion `\\9`): invalid escape sequence: \\9", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Error in regexp `ab\\9` (portion `\\9`): invalid escape sequence: \\9")
+		var expected_ = err("ReqlQueryLogicError", "Error in regexp `ab\\9` (portion `\\9`): invalid escape sequence: \\9")
 		/* r.expr("").match("ab\\9") */
 
 		suite.T().Log("About to run line #36: r.Expr('').Match('ab\\\\9')")

--- a/internal/integration/reql_tests/reql_math_logic_add_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_add_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #3
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.add(1, 1) */
 
 		suite.T().Log("About to run line #3: r.Add(1, 1)")
@@ -76,7 +76,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #8
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(1) + 1 */
 
 		suite.T().Log("About to run line #8: r.Expr(1).Add(1)")
@@ -91,7 +91,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #9
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* 1 + r.expr(1) */
 
 		suite.T().Log("About to run line #9: r.Add(1, r.Expr(1))")
@@ -106,7 +106,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #10
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(1).add(1) */
 
 		suite.T().Log("About to run line #10: r.Expr(1).Add(1)")
@@ -121,7 +121,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #16
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(-1) + 1 */
 
 		suite.T().Log("About to run line #16: r.Expr(-1).Add(1)")
@@ -151,7 +151,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #27
 		/* '' */
-		var expected_ string = ""
+		var expected_ = ""
 		/* r.expr('') + '' */
 
 		suite.T().Log("About to run line #27: r.Expr('').Add('')")
@@ -166,7 +166,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #32
 		/* 'abcdef' */
-		var expected_ string = "abcdef"
+		var expected_ = "abcdef"
 		/* r.expr('abc') + 'def' */
 
 		suite.T().Log("About to run line #32: r.Expr('abc').Add('def')")
@@ -181,7 +181,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #52
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr(1) + 'a' */
 
 		suite.T().Log("About to run line #52: r.Expr(1).Add('a')")
@@ -196,7 +196,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #57
 		/* err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.", [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
 		/* r.expr('a') + 1 */
 
 		suite.T().Log("About to run line #57: r.Expr('a').Add(1)")
@@ -211,7 +211,7 @@ func (suite *MathLogicAddSuite) TestCases() {
 	{
 		// math_logic/add.yaml line #62
 		/* err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.", [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.")
 		/* r.expr([]) + 1 */
 
 		suite.T().Log("About to run line #62: r.Expr([]interface{}{}).Add(1)")

--- a/internal/integration/reql_tests/reql_math_logic_aliases_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_aliases_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #5
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(0).add(1) */
 
 		suite.T().Log("About to run line #5: r.Expr(0).Add(1)")
@@ -76,7 +76,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #6
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.add(0, 1) */
 
 		suite.T().Log("About to run line #6: r.Add(0, 1)")
@@ -91,7 +91,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #7
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(2).sub(1) */
 
 		suite.T().Log("About to run line #7: r.Expr(2).Sub(1)")
@@ -106,7 +106,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #8
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.sub(2, 1) */
 
 		suite.T().Log("About to run line #8: r.Sub(2, 1)")
@@ -121,7 +121,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #9
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(2).div(2) */
 
 		suite.T().Log("About to run line #9: r.Expr(2).Div(2)")
@@ -136,7 +136,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #10
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.div(2, 2) */
 
 		suite.T().Log("About to run line #10: r.Div(2, 2)")
@@ -151,7 +151,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #11
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1).mul(1) */
 
 		suite.T().Log("About to run line #11: r.Expr(1).Mul(1)")
@@ -166,7 +166,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #12
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.mul(1, 1) */
 
 		suite.T().Log("About to run line #12: r.Mul(1, 1)")
@@ -181,7 +181,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #13
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1).mod(2) */
 
 		suite.T().Log("About to run line #13: r.Expr(1).Mod(2)")
@@ -196,7 +196,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #14
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.mod(1, 2) */
 
 		suite.T().Log("About to run line #14: r.Mod(1, 2)")
@@ -211,7 +211,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #25
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(True).and_(True) */
 
 		suite.T().Log("About to run line #25: r.Expr(true).And(true)")
@@ -226,7 +226,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #26
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(True).or_(True) */
 
 		suite.T().Log("About to run line #26: r.Expr(true).Or(true)")
@@ -241,7 +241,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #27
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.and_(True, True) */
 
 		suite.T().Log("About to run line #27: r.And(true, true)")
@@ -256,7 +256,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #28
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.or_(True, True) */
 
 		suite.T().Log("About to run line #28: r.Or(true, true)")
@@ -271,7 +271,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #29
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(False).not_() */
 
 		suite.T().Log("About to run line #29: r.Expr(false).Not()")
@@ -286,7 +286,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #30
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.not_(False) */
 
 		suite.T().Log("About to run line #30: r.Not(false)")
@@ -301,7 +301,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #34
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).eq(1) */
 
 		suite.T().Log("About to run line #34: r.Expr(1).Eq(1)")
@@ -316,7 +316,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #35
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).ne(2) */
 
 		suite.T().Log("About to run line #35: r.Expr(1).Ne(2)")
@@ -331,7 +331,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #36
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).lt(2) */
 
 		suite.T().Log("About to run line #36: r.Expr(1).Lt(2)")
@@ -346,7 +346,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #37
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).gt(0) */
 
 		suite.T().Log("About to run line #37: r.Expr(1).Gt(0)")
@@ -361,7 +361,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #38
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).le(1) */
 
 		suite.T().Log("About to run line #38: r.Expr(1).Le(1)")
@@ -376,7 +376,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #39
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).ge(1) */
 
 		suite.T().Log("About to run line #39: r.Expr(1).Ge(1)")
@@ -391,7 +391,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #40
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.eq(1, 1) */
 
 		suite.T().Log("About to run line #40: r.Eq(1, 1)")
@@ -406,7 +406,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #41
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.ne(1, 2) */
 
 		suite.T().Log("About to run line #41: r.Ne(1, 2)")
@@ -421,7 +421,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #42
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.lt(1, 2) */
 
 		suite.T().Log("About to run line #42: r.Lt(1, 2)")
@@ -436,7 +436,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #43
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.gt(1, 0) */
 
 		suite.T().Log("About to run line #43: r.Gt(1, 0)")
@@ -451,7 +451,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #44
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.le(1, 1) */
 
 		suite.T().Log("About to run line #44: r.Le(1, 1)")
@@ -466,7 +466,7 @@ func (suite *MathLogicAliasesSuite) TestCases() {
 	{
 		// math_logic/aliases.yaml line #45
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.ge(1, 1) */
 
 		suite.T().Log("About to run line #45: r.Ge(1, 1)")

--- a/internal/integration/reql_tests/reql_math_logic_bit_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_bit_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #4
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(3).bit_and(2) */
 
 		suite.T().Log("About to run line #4: r.Expr(3).BitAnd(2)")
@@ -76,7 +76,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #7
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(-2).bit_and(3) */
 
 		suite.T().Log("About to run line #7: r.Expr(-2).BitAnd(3)")
@@ -91,7 +91,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #10
 		/* err('ReqlQueryLogicError', 'Integer too large: 9007199254740992') */
-		var expected_ Err = err("ReqlQueryLogicError", "Integer too large: 9007199254740992")
+		var expected_ = err("ReqlQueryLogicError", "Integer too large: 9007199254740992")
 		/* r.expr(9007199254740992).bit_and(0) */
 
 		suite.T().Log("About to run line #10: r.Expr(9007199254740992).BitAnd(0)")
@@ -106,7 +106,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #13
 		/* err('ReqlQueryLogicError', 'Number not an integer (>2^53): 9007199254740994') */
-		var expected_ Err = err("ReqlQueryLogicError", "Number not an integer (>2^53): 9007199254740994")
+		var expected_ = err("ReqlQueryLogicError", "Number not an integer (>2^53): 9007199254740994")
 		/* r.expr(9007199254740994).bit_and(0) */
 
 		suite.T().Log("About to run line #13: r.Expr(9007199254740994).BitAnd(0)")
@@ -121,7 +121,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #16
 		/* 23 */
-		var expected_ int = 23
+		var expected_ = 23
 		/* r.expr(9007199254740991).bit_and(23) */
 
 		suite.T().Log("About to run line #16: r.Expr(9007199254740991).BitAnd(23)")
@@ -136,7 +136,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #19
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(-9007199254740992).bit_and(12345) */
 
 		suite.T().Log("About to run line #19: r.Expr(-9007199254740992).BitAnd(12345)")
@@ -151,7 +151,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #22
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.expr(1).bit_or(2) */
 
 		suite.T().Log("About to run line #22: r.Expr(1).BitOr(2)")
@@ -166,7 +166,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #25
 		/* err('ReqlQueryLogicError', 'Integer too large: 9007199254740992') */
-		var expected_ Err = err("ReqlQueryLogicError", "Integer too large: 9007199254740992")
+		var expected_ = err("ReqlQueryLogicError", "Integer too large: 9007199254740992")
 		/* r.expr(9007199254740992).bit_or(0) */
 
 		suite.T().Log("About to run line #25: r.Expr(9007199254740992).BitOr(0)")
@@ -181,7 +181,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #28
 		/* 9007199254740991 */
-		var expected_ int = 9007199254740991
+		var expected_ = 9007199254740991
 		/* r.expr(9007199254740991).bit_or(0) */
 
 		suite.T().Log("About to run line #28: r.Expr(9007199254740991).BitOr(0)")
@@ -196,7 +196,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #31
 		/* -1 */
-		var expected_ int = -1
+		var expected_ = -1
 		/* r.expr(9007199254740991).bit_or(-1) */
 
 		suite.T().Log("About to run line #31: r.Expr(9007199254740991).BitOr(-1)")
@@ -211,7 +211,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #34
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* r.expr(3).bit_xor(6) */
 
 		suite.T().Log("About to run line #34: r.Expr(3).BitXor(6)")
@@ -226,7 +226,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #37
 		/* -3 */
-		var expected_ int = -3
+		var expected_ = -3
 		/* r.expr(2).bit_not() */
 
 		suite.T().Log("About to run line #37: r.Expr(2).BitNot()")
@@ -241,7 +241,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #40
 		/* -9007199254740992 */
-		var expected_ int = -9007199254740992
+		var expected_ = -9007199254740992
 		/* r.expr(9007199254740991).bit_not() */
 
 		suite.T().Log("About to run line #40: r.Expr(9007199254740991).BitNot()")
@@ -256,7 +256,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #43
 		/* 9007199254740991 */
-		var expected_ int = 9007199254740991
+		var expected_ = 9007199254740991
 		/* r.expr(9007199254740991).bit_not().bit_not() */
 
 		suite.T().Log("About to run line #43: r.Expr(9007199254740991).BitNot().BitNot()")
@@ -271,7 +271,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #47
 		/* err('ReqlQueryLogicError', 'Integer too large: 9007199254740992') */
-		var expected_ Err = err("ReqlQueryLogicError", "Integer too large: 9007199254740992")
+		var expected_ = err("ReqlQueryLogicError", "Integer too large: 9007199254740992")
 		/* r.expr(9007199254740992).bit_sar(0) */
 
 		suite.T().Log("About to run line #47: r.Expr(9007199254740992).BitSar(0)")
@@ -286,7 +286,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #50
 		/* -9007199254740992 */
-		var expected_ int = -9007199254740992
+		var expected_ = -9007199254740992
 		/* r.expr(-9007199254740992).bit_sar(0) */
 
 		suite.T().Log("About to run line #50: r.Expr(-9007199254740992).BitSar(0)")
@@ -301,7 +301,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #53
 		/* -4503599627370496 */
-		var expected_ int = -4503599627370496
+		var expected_ = -4503599627370496
 		/* r.expr(-9007199254740992).bit_sar(1) */
 
 		suite.T().Log("About to run line #53: r.Expr(-9007199254740992).BitSar(1)")
@@ -316,7 +316,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #56
 		/* -2 */
-		var expected_ int = -2
+		var expected_ = -2
 		/* r.expr(-9007199254740992).bit_sar(52) */
 
 		suite.T().Log("About to run line #56: r.Expr(-9007199254740992).BitSar(52)")
@@ -331,7 +331,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #59
 		/* -1 */
-		var expected_ int = -1
+		var expected_ = -1
 		/* r.expr(-9007199254740992).bit_sar(53) */
 
 		suite.T().Log("About to run line #59: r.Expr(-9007199254740992).BitSar(53)")
@@ -346,7 +346,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #62
 		/* -1 */
-		var expected_ int = -1
+		var expected_ = -1
 		/* r.expr(-9007199254740992).bit_sar(54) */
 
 		suite.T().Log("About to run line #62: r.Expr(-9007199254740992).BitSar(54)")
@@ -361,7 +361,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #65
 		/* 9007199254740991 */
-		var expected_ int = 9007199254740991
+		var expected_ = 9007199254740991
 		/* r.expr(9007199254740991).bit_sar(0) */
 
 		suite.T().Log("About to run line #65: r.Expr(9007199254740991).BitSar(0)")
@@ -376,7 +376,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #68
 		/* 4503599627370495 */
-		var expected_ int = 4503599627370495
+		var expected_ = 4503599627370495
 		/* r.expr(9007199254740991).bit_sar(1) */
 
 		suite.T().Log("About to run line #68: r.Expr(9007199254740991).BitSar(1)")
@@ -391,7 +391,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #71
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(9007199254740991).bit_sar(52) */
 
 		suite.T().Log("About to run line #71: r.Expr(9007199254740991).BitSar(52)")
@@ -406,7 +406,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #74
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(9007199254740991).bit_sar(53) */
 
 		suite.T().Log("About to run line #74: r.Expr(9007199254740991).BitSar(53)")
@@ -421,7 +421,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #78
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(0).bit_sal(999999) */
 
 		suite.T().Log("About to run line #78: r.Expr(0).BitSal(999999)")
@@ -436,7 +436,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #81
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(0).bit_sal(3000) */
 
 		suite.T().Log("About to run line #81: r.Expr(0).BitSal(3000)")
@@ -451,7 +451,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #84
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(0).bit_sal(500) */
 
 		suite.T().Log("About to run line #84: r.Expr(0).BitSal(500)")
@@ -466,7 +466,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #87
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(0).bit_sal(0) */
 
 		suite.T().Log("About to run line #87: r.Expr(0).BitSal(0)")
@@ -481,7 +481,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #90
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(1).bit_sal(0) */
 
 		suite.T().Log("About to run line #90: r.Expr(1).BitSal(0)")
@@ -496,7 +496,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #93
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(1).bit_sal(1) */
 
 		suite.T().Log("About to run line #93: r.Expr(1).BitSal(1)")
@@ -511,7 +511,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #96
 		/* 8 */
-		var expected_ int = 8
+		var expected_ = 8
 		/* r.expr(1).bit_sal(3) */
 
 		suite.T().Log("About to run line #96: r.Expr(1).BitSal(3)")
@@ -526,7 +526,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #99
 		/* -8 */
-		var expected_ int = -8
+		var expected_ = -8
 		/* r.expr(-1).bit_sal(3) */
 
 		suite.T().Log("About to run line #99: r.Expr(-1).BitSal(3)")
@@ -541,7 +541,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #102
 		/* -18014398509481984 */
-		var expected_ int = -18014398509481984
+		var expected_ = -18014398509481984
 		/* r.expr(-1).bit_sal(54) */
 
 		suite.T().Log("About to run line #102: r.Expr(-1).BitSal(54)")
@@ -556,7 +556,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #105
 		/* 18014398509481984 */
-		var expected_ int = 18014398509481984
+		var expected_ = 18014398509481984
 		/* r.expr(1).bit_sal(54) */
 
 		suite.T().Log("About to run line #105: r.Expr(1).BitSal(54)")
@@ -571,7 +571,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #108
 		/* -18014398509481984 */
-		var expected_ int = -18014398509481984
+		var expected_ = -18014398509481984
 		/* r.expr(-2).bit_sal(53) */
 
 		suite.T().Log("About to run line #108: r.Expr(-2).BitSal(53)")
@@ -586,7 +586,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #111
 		/* 18014398509481984 */
-		var expected_ int = 18014398509481984
+		var expected_ = 18014398509481984
 		/* r.expr(2).bit_sal(53) */
 
 		suite.T().Log("About to run line #111: r.Expr(2).BitSal(53)")
@@ -601,7 +601,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #114
 		/* err('ReqlQueryLogicError', 'Cannot bit-shift by a negative value') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot bit-shift by a negative value")
+		var expected_ = err("ReqlQueryLogicError", "Cannot bit-shift by a negative value")
 		/* r.expr(5).bit_sal(-1) */
 
 		suite.T().Log("About to run line #114: r.Expr(5).BitSal(-1)")
@@ -616,7 +616,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #117
 		/* err('ReqlQueryLogicError', 'Cannot bit-shift by a negative value') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot bit-shift by a negative value")
+		var expected_ = err("ReqlQueryLogicError", "Cannot bit-shift by a negative value")
 		/* r.expr(5).bit_sar(-1) */
 
 		suite.T().Log("About to run line #117: r.Expr(5).BitSar(-1)")
@@ -631,7 +631,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #121
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('a').bit_and(12) */
 
 		suite.T().Log("About to run line #121: r.Expr('a').BitAnd(12)")
@@ -646,7 +646,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #124
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr(12).bit_and('a') */
 
 		suite.T().Log("About to run line #124: r.Expr(12).BitAnd('a')")
@@ -661,7 +661,7 @@ func (suite *MathLogicBitSuite) TestCases() {
 	{
 		// math_logic/bit.yaml line #127
 		/* err('ReqlQueryLogicError', 'Number not an integer: 1.5') */
-		var expected_ Err = err("ReqlQueryLogicError", "Number not an integer: 1.5")
+		var expected_ = err("ReqlQueryLogicError", "Number not an integer: 1.5")
 		/* r.expr(1.5).bit_and(3) */
 
 		suite.T().Log("About to run line #127: r.Expr(1.5).BitAnd(3)")

--- a/internal/integration/reql_tests/reql_math_logic_comparison_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_comparison_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #10
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1) < 2 */
 
 		suite.T().Log("About to run line #10: r.Expr(1).Lt(2)")
@@ -76,7 +76,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #11
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* 1 < r.expr(2) */
 
 		suite.T().Log("About to run line #11: r.Lt(1, r.Expr(2))")
@@ -91,7 +91,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #12
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).lt(2) */
 
 		suite.T().Log("About to run line #12: r.Expr(1).Lt(2)")
@@ -106,7 +106,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #19
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(3) < 2 */
 
 		suite.T().Log("About to run line #19: r.Expr(3).Lt(2)")
@@ -121,7 +121,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #22
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(2) < 2 */
 
 		suite.T().Log("About to run line #22: r.Expr(2).Lt(2)")
@@ -136,7 +136,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #38
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(1) > 2 */
 
 		suite.T().Log("About to run line #38: r.Expr(1).Gt(2)")
@@ -151,7 +151,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #39
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* 1 > r.expr(2) */
 
 		suite.T().Log("About to run line #39: r.Gt(1, r.Expr(2))")
@@ -166,7 +166,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #40
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(1).gt(2) */
 
 		suite.T().Log("About to run line #40: r.Expr(1).Gt(2)")
@@ -181,7 +181,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #45
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(3) > 2 */
 
 		suite.T().Log("About to run line #45: r.Expr(3).Gt(2)")
@@ -196,7 +196,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #49
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(2) > 2 */
 
 		suite.T().Log("About to run line #49: r.Expr(2).Gt(2)")
@@ -211,7 +211,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #63
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(1) == 2 */
 
 		suite.T().Log("About to run line #63: r.Expr(1).Eq(2)")
@@ -226,7 +226,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #64
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* 1 == r.expr(2) */
 
 		suite.T().Log("About to run line #64: r.Eq(1, r.Expr(2))")
@@ -241,7 +241,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #65
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(1).eq(2) */
 
 		suite.T().Log("About to run line #65: r.Expr(1).Eq(2)")
@@ -256,7 +256,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #68
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(3) == 2 */
 
 		suite.T().Log("About to run line #68: r.Expr(3).Eq(2)")
@@ -271,7 +271,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #72
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(2) == 2 */
 
 		suite.T().Log("About to run line #72: r.Expr(2).Eq(2)")
@@ -286,7 +286,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #86
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1) != 2 */
 
 		suite.T().Log("About to run line #86: r.Expr(1).Ne(2)")
@@ -301,7 +301,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #87
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* 1 != r.expr(2) */
 
 		suite.T().Log("About to run line #87: r.Ne(1, r.Expr(2))")
@@ -316,7 +316,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #88
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).ne(2) */
 
 		suite.T().Log("About to run line #88: r.Expr(1).Ne(2)")
@@ -331,7 +331,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #91
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(3) != 2 */
 
 		suite.T().Log("About to run line #91: r.Expr(3).Ne(2)")
@@ -346,7 +346,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #95
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(2) != 2 */
 
 		suite.T().Log("About to run line #95: r.Expr(2).Ne(2)")
@@ -361,7 +361,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #109
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1) <= 2 */
 
 		suite.T().Log("About to run line #109: r.Expr(1).Le(2)")
@@ -376,7 +376,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #110
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* 1 <= r.expr(2) */
 
 		suite.T().Log("About to run line #110: r.Le(1, r.Expr(2))")
@@ -391,7 +391,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #111
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1).le(2) */
 
 		suite.T().Log("About to run line #111: r.Expr(1).Le(2)")
@@ -406,7 +406,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #116
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(3) <= 2 */
 
 		suite.T().Log("About to run line #116: r.Expr(3).Le(2)")
@@ -421,7 +421,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #120
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(2) <= 2 */
 
 		suite.T().Log("About to run line #120: r.Expr(2).Le(2)")
@@ -436,7 +436,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #134
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(1) >= 2 */
 
 		suite.T().Log("About to run line #134: r.Expr(1).Ge(2)")
@@ -451,7 +451,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #135
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* 1 >= r.expr(2) */
 
 		suite.T().Log("About to run line #135: r.Ge(1, r.Expr(2))")
@@ -466,7 +466,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #136
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(1).ge(2) */
 
 		suite.T().Log("About to run line #136: r.Expr(1).Ge(2)")
@@ -481,7 +481,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #141
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(3) >= 2 */
 
 		suite.T().Log("About to run line #141: r.Expr(3).Ge(2)")
@@ -496,7 +496,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #145
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(2) >= 2 */
 
 		suite.T().Log("About to run line #145: r.Expr(2).Ge(2)")
@@ -511,7 +511,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #158
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(null) == null */
 
 		suite.T().Log("About to run line #158: r.Expr(nil).Eq(nil)")
@@ -526,7 +526,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #159
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* null == r.expr(null) */
 
 		suite.T().Log("About to run line #159: r.Eq(nil, r.Expr(nil))")
@@ -541,7 +541,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #164
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(null) < null */
 
 		suite.T().Log("About to run line #164: r.Expr(nil).Lt(nil)")
@@ -556,7 +556,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #165
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* null < r.expr(null) */
 
 		suite.T().Log("About to run line #165: r.Lt(nil, r.Expr(nil))")
@@ -571,7 +571,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #166
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(null).lt(null) */
 
 		suite.T().Log("About to run line #166: r.Expr(nil).Lt(nil)")
@@ -586,7 +586,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #172
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(null) > null */
 
 		suite.T().Log("About to run line #172: r.Expr(nil).Gt(nil)")
@@ -601,7 +601,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #173
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* null > r.expr(null) */
 
 		suite.T().Log("About to run line #173: r.Gt(nil, r.Expr(nil))")
@@ -616,7 +616,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #174
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(null).gt(null) */
 
 		suite.T().Log("About to run line #174: r.Expr(nil).Gt(nil)")
@@ -631,7 +631,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #180
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('a') == 'a' */
 
 		suite.T().Log("About to run line #180: r.Expr('a').Eq('a')")
@@ -646,7 +646,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #184
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr('a') == 'aa' */
 
 		suite.T().Log("About to run line #184: r.Expr('a').Eq('aa')")
@@ -661,7 +661,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #188
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('a') < 'aa' */
 
 		suite.T().Log("About to run line #188: r.Expr('a').Lt('aa')")
@@ -676,7 +676,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #192
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('a') < 'bb' */
 
 		suite.T().Log("About to run line #192: r.Expr('a').Lt('bb')")
@@ -691,7 +691,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #196
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('bb') > 'a' */
 
 		suite.T().Log("About to run line #196: r.Expr('bb').Gt('a')")
@@ -706,7 +706,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #200
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('abcdef') < 'abcdeg' */
 
 		suite.T().Log("About to run line #200: r.Expr('abcdef').Lt('abcdeg')")
@@ -721,7 +721,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #204
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr('abcdefg') > 'abcdeg' */
 
 		suite.T().Log("About to run line #204: r.Expr('abcdefg').Gt('abcdeg')")
@@ -736,7 +736,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #208
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('A quick brown fox') > 'A quick brawn fox' */
 
 		suite.T().Log("About to run line #208: r.Expr('A quick brown fox').Gt('A quick brawn fox')")
@@ -751,7 +751,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #216
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([1]) < [2] */
 
 		suite.T().Log("About to run line #216: r.Expr([]interface{}{1}).Lt([]interface{}{2})")
@@ -766,7 +766,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #221
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr([1]) > [2] */
 
 		suite.T().Log("About to run line #221: r.Expr([]interface{}{1}).Gt([]interface{}{2})")
@@ -781,7 +781,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #226
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([1, 0]) < [2] */
 
 		suite.T().Log("About to run line #226: r.Expr([]interface{}{1, 0}).Lt([]interface{}{2})")
@@ -796,7 +796,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #231
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr([1, 0]) < [1] */
 
 		suite.T().Log("About to run line #231: r.Expr([]interface{}{1, 0}).Lt([]interface{}{1})")
@@ -811,7 +811,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #236
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([1, 0]) > [0] */
 
 		suite.T().Log("About to run line #236: r.Expr([]interface{}{1, 0}).Gt([]interface{}{0})")
@@ -826,7 +826,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #241
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([1, 'a']) < [1, 'b'] */
 
 		suite.T().Log("About to run line #241: r.Expr([]interface{}{1, 'a'}).Lt([]interface{}{1, 'b'})")
@@ -841,7 +841,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #246
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([0, 'z']) < [1, 'b'] */
 
 		suite.T().Log("About to run line #246: r.Expr([]interface{}{0, 'z'}).Lt([]interface{}{1, 'b'})")
@@ -856,7 +856,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #251
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr([1, 1, 1]) < [1, 0, 2] */
 
 		suite.T().Log("About to run line #251: r.Expr([]interface{}{1, 1, 1}).Lt([]interface{}{1, 0, 2})")
@@ -871,7 +871,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #256
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([1, 0, 2]) < [1, 1, 1] */
 
 		suite.T().Log("About to run line #256: r.Expr([]interface{}{1, 0, 2}).Lt([]interface{}{1, 1, 1})")
@@ -886,7 +886,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #263
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr({'a':0}) == {'a':0} */
 
 		suite.T().Log("About to run line #263: r.Expr(map[interface{}]interface{}{'a': 0, }).Eq(map[interface{}]interface{}{'a': 0, })")
@@ -901,7 +901,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #267
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr({'a':0, 'b':1}) == {'b':1, 'a':0} */
 
 		suite.T().Log("About to run line #267: r.Expr(map[interface{}]interface{}{'a': 0, 'b': 1, }).Eq(map[interface{}]interface{}{'b': 1, 'a': 0, })")
@@ -916,7 +916,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #271
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'a':0, 'b':1, 'c':2}) == {'b':1, 'a':0} */
 
 		suite.T().Log("About to run line #271: r.Expr(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, }).Eq(map[interface{}]interface{}{'b': 1, 'a': 0, })")
@@ -931,7 +931,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #275
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'a':0, 'b':1}) == {'b':1, 'a':0, 'c':2} */
 
 		suite.T().Log("About to run line #275: r.Expr(map[interface{}]interface{}{'a': 0, 'b': 1, }).Eq(map[interface{}]interface{}{'b': 1, 'a': 0, 'c': 2, })")
@@ -946,7 +946,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #279
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'a':0, 'b':1, 'd':2}) == {'b':1, 'a':0, 'c':2} */
 
 		suite.T().Log("About to run line #279: r.Expr(map[interface{}]interface{}{'a': 0, 'b': 1, 'd': 2, }).Eq(map[interface{}]interface{}{'b': 1, 'a': 0, 'c': 2, })")
@@ -961,7 +961,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #283
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr({'a':0}) < {'b':0} */
 
 		suite.T().Log("About to run line #283: r.Expr(map[interface{}]interface{}{'a': 0, }).Lt(map[interface{}]interface{}{'b': 0, })")
@@ -976,7 +976,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #287
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr({'a':1}) < {'b':0} */
 
 		suite.T().Log("About to run line #287: r.Expr(map[interface{}]interface{}{'a': 1, }).Lt(map[interface{}]interface{}{'b': 0, })")
@@ -991,7 +991,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #291
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'b':1}) < {'b':0} */
 
 		suite.T().Log("About to run line #291: r.Expr(map[interface{}]interface{}{'b': 1, }).Lt(map[interface{}]interface{}{'b': 0, })")
@@ -1006,7 +1006,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #295
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'b':1}) < {'a':0} */
 
 		suite.T().Log("About to run line #295: r.Expr(map[interface{}]interface{}{'b': 1, }).Lt(map[interface{}]interface{}{'a': 0, })")
@@ -1021,7 +1021,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #299
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'a':0, 'b':1, 'c':2}) < {'a':0, 'b':1, 'c':2} */
 
 		suite.T().Log("About to run line #299: r.Expr(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, }).Lt(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, })")
@@ -1036,7 +1036,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #303
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'a':0, 'b':1, 'c':2, 'd':3}) < {'a':0, 'b':1, 'c':2} */
 
 		suite.T().Log("About to run line #303: r.Expr(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, 'd': 3, }).Lt(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, })")
@@ -1051,7 +1051,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #307
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr({'a':0, 'b':1, 'c':2}) < {'a':0, 'b':1, 'c':2, 'd':3} */
 
 		suite.T().Log("About to run line #307: r.Expr(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, }).Lt(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, 'd': 3, })")
@@ -1066,7 +1066,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #311
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr({'a':0, 'c':2}) < {'a':0, 'b':1, 'c':2} */
 
 		suite.T().Log("About to run line #311: r.Expr(map[interface{}]interface{}{'a': 0, 'c': 2, }).Lt(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, })")
@@ -1081,7 +1081,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #315
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr({'a':0, 'c':2}) > {'a':0, 'b':1, 'c':2} */
 
 		suite.T().Log("About to run line #315: r.Expr(map[interface{}]interface{}{'a': 0, 'c': 2, }).Gt(map[interface{}]interface{}{'a': 0, 'b': 1, 'c': 2, })")
@@ -1103,7 +1103,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #336
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.and_(r.args(everything.map(r.lt(r.minval, r.row)))) */
 
 		suite.T().Log("About to run line #336: r.And(r.Args(everything.Map(r.Lt(r.MinVal, r.Row))))")
@@ -1118,7 +1118,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #341
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.or_(r.args(everything.map(r.gt(r.minval, r.row)))) */
 
 		suite.T().Log("About to run line #341: r.Or(r.Args(everything.Map(r.Gt(r.MinVal, r.Row))))")
@@ -1133,7 +1133,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #345
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.eq(r.minval, r.minval) */
 
 		suite.T().Log("About to run line #345: r.Eq(r.MinVal, r.MinVal)")
@@ -1148,7 +1148,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #348
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([]) < True */
 
 		suite.T().Log("About to run line #348: r.Expr([]interface{}{}).Lt(true)")
@@ -1163,7 +1163,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #353
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([1,2]) < False */
 
 		suite.T().Log("About to run line #353: r.Expr([]interface{}{1, 2}).Lt(false)")
@@ -1178,7 +1178,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #358
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(False) < [] */
 
 		suite.T().Log("About to run line #358: r.Expr(false).Lt([]interface{}{})")
@@ -1193,7 +1193,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #363
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([]) < r.binary(b"\xAE") */
 
 		suite.T().Log("About to run line #363: r.Expr([]interface{}{}).Lt(r.Binary([]byte{174}))")
@@ -1208,7 +1208,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #368
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([1,2]) < r.binary(b"\xAE") */
 
 		suite.T().Log("About to run line #368: r.Expr([]interface{}{1, 2}).Lt(r.Binary([]byte{174}))")
@@ -1223,7 +1223,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #373
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* True < r.expr(null) */
 
 		suite.T().Log("About to run line #373: r.Lt(true, r.Expr(nil))")
@@ -1238,7 +1238,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #378
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(null) > [] */
 
 		suite.T().Log("About to run line #378: r.Expr(nil).Gt([]interface{}{})")
@@ -1253,7 +1253,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #383
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(null) < 12 */
 
 		suite.T().Log("About to run line #383: r.Expr(nil).Lt(12)")
@@ -1268,7 +1268,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #388
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(null) < -2 */
 
 		suite.T().Log("About to run line #388: r.Expr(nil).Lt(-2)")
@@ -1283,7 +1283,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #393
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(-12) < {} */
 
 		suite.T().Log("About to run line #393: r.Expr(-12).Lt(map[interface{}]interface{}{})")
@@ -1298,7 +1298,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #398
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(100) < {'a':-12} */
 
 		suite.T().Log("About to run line #398: r.Expr(100).Lt(map[interface{}]interface{}{'a': -12, })")
@@ -1313,7 +1313,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #403
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(r.binary(b"\xAE")) < 12 */
 
 		suite.T().Log("About to run line #403: r.Expr(r.Binary([]byte{174})).Lt(12)")
@@ -1328,7 +1328,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #408
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.binary(b"0xAE") < 'abc' */
 
 		suite.T().Log("About to run line #408: r.Binary([]byte{48,120,65,69}).Lt('abc')")
@@ -1343,7 +1343,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #413
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.binary(b"0xAE") > r.now() */
 
 		suite.T().Log("About to run line #413: r.Binary([]byte{48,120,65,69}).Gt(r.Now())")
@@ -1358,7 +1358,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #418
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.now() > 12 */
 
 		suite.T().Log("About to run line #418: r.Now().Gt(12)")
@@ -1373,7 +1373,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #422
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.now() > 'abc' */
 
 		suite.T().Log("About to run line #422: r.Now().Gt('abc')")
@@ -1388,7 +1388,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #426
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr("abc") > {'a':-12} */
 
 		suite.T().Log("About to run line #426: r.Expr('abc').Gt(map[interface{}]interface{}{'a': -12, })")
@@ -1403,7 +1403,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #431
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr("abc") > {'abc':'abc'} */
 
 		suite.T().Log("About to run line #431: r.Expr('abc').Gt(map[interface{}]interface{}{'abc': 'abc', })")
@@ -1418,7 +1418,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #436
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('zzz') > 128 */
 
 		suite.T().Log("About to run line #436: r.Expr('zzz').Gt(128)")
@@ -1433,7 +1433,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #441
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr('zzz') > {} */
 
 		suite.T().Log("About to run line #441: r.Expr('zzz').Gt(map[interface{}]interface{}{})")
@@ -1448,7 +1448,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #446
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* 'zzz' > r.expr(-152) */
 
 		suite.T().Log("About to run line #446: r.Gt('zzz', r.Expr(-152))")
@@ -1463,7 +1463,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #451
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* 'zzz' > r.expr(null) */
 
 		suite.T().Log("About to run line #451: r.Gt('zzz', r.Expr(nil))")
@@ -1478,7 +1478,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #456
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* 'zzz' > r.expr([]) */
 
 		suite.T().Log("About to run line #456: r.Gt('zzz', r.Expr([]interface{}{}))")
@@ -1500,7 +1500,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #467
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.and_(r.args(everything2.map(r.gt(r.maxval, r.row)))) */
 
 		suite.T().Log("About to run line #467: r.And(r.Args(everything2.Map(r.Gt(r.MaxVal, r.Row))))")
@@ -1515,7 +1515,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #472
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.or_(r.args(everything2.map(r.lt(r.maxval, r.row)))) */
 
 		suite.T().Log("About to run line #472: r.Or(r.Args(everything2.Map(r.Lt(r.MaxVal, r.Row))))")
@@ -1530,7 +1530,7 @@ func (suite *MathLogicComparisonSuite) TestCases() {
 	{
 		// math_logic/comparison.yaml line #476
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.eq(r.maxval, r.maxval) */
 
 		suite.T().Log("About to run line #476: r.Eq(r.MaxVal, r.MaxVal)")

--- a/internal/integration/reql_tests/reql_math_logic_div_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_div_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #6
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(4) / 2 */
 
 		suite.T().Log("About to run line #6: r.Expr(4).Div(2)")
@@ -76,7 +76,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #7
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* 4 / r.expr(2) */
 
 		suite.T().Log("About to run line #7: r.Div(4, r.Expr(2))")
@@ -91,7 +91,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #8
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(4).div(2) */
 
 		suite.T().Log("About to run line #8: r.Expr(4).Div(2)")
@@ -151,7 +151,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #37
 		/* err('ReqlQueryLogicError', 'Cannot divide by zero.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot divide by zero.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot divide by zero.")
 		/* r.expr(1) / 0 */
 
 		suite.T().Log("About to run line #37: r.Expr(1).Div(0)")
@@ -166,7 +166,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #38
 		/* err('ReqlQueryLogicError', 'Cannot divide by zero.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot divide by zero.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot divide by zero.")
 		/* r.expr(2.0) / 0 */
 
 		suite.T().Log("About to run line #38: r.Expr(2.0).Div(0)")
@@ -181,7 +181,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #39
 		/* err('ReqlQueryLogicError', 'Cannot divide by zero.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot divide by zero.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot divide by zero.")
 		/* r.expr(3) / 0.0 */
 
 		suite.T().Log("About to run line #39: r.Expr(3).Div(0.0)")
@@ -196,7 +196,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #40
 		/* err('ReqlQueryLogicError', 'Cannot divide by zero.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot divide by zero.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot divide by zero.")
 		/* r.expr(4.0) / 0.0 */
 
 		suite.T().Log("About to run line #40: r.Expr(4.0).Div(0.0)")
@@ -211,7 +211,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #41
 		/* err('ReqlQueryLogicError', 'Cannot divide by zero.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot divide by zero.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot divide by zero.")
 		/* r.expr(0) / 0 */
 
 		suite.T().Log("About to run line #41: r.Expr(0).Div(0)")
@@ -226,7 +226,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #42
 		/* err('ReqlQueryLogicError', 'Cannot divide by zero.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot divide by zero.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot divide by zero.")
 		/* r.expr(0.0) / 0.0 */
 
 		suite.T().Log("About to run line #42: r.Expr(0.0).Div(0.0)")
@@ -241,7 +241,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #46
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('a') / 0.8 */
 
 		suite.T().Log("About to run line #46: r.Expr('a').Div(0.8)")
@@ -256,7 +256,7 @@ func (suite *MathLogicDivSuite) TestCases() {
 	{
 		// math_logic/div.yaml line #50
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr(1) / 'a' */
 
 		suite.T().Log("About to run line #50: r.Expr(1).Div('a')")

--- a/internal/integration/reql_tests/reql_math_logic_floor_ceil_round_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_floor_ceil_round_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicFloorCeilRoundSuite) TestCases() {
 	{
 		// math_logic/floor_ceil_round.yaml line #3
 		/* "NUMBER" */
-		var expected_ string = "NUMBER"
+		var expected_ = "NUMBER"
 		/* r.floor(1.0).type_of() */
 
 		suite.T().Log("About to run line #3: r.Floor(1.0).TypeOf()")
@@ -196,7 +196,7 @@ func (suite *MathLogicFloorCeilRoundSuite) TestCases() {
 	{
 		// math_logic/floor_ceil_round.yaml line #23
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('X').floor() */
 
 		suite.T().Log("About to run line #23: r.Expr('X').Floor()")
@@ -211,7 +211,7 @@ func (suite *MathLogicFloorCeilRoundSuite) TestCases() {
 	{
 		// math_logic/floor_ceil_round.yaml line #27
 		/* "NUMBER" */
-		var expected_ string = "NUMBER"
+		var expected_ = "NUMBER"
 		/* r.ceil(1.0).type_of() */
 
 		suite.T().Log("About to run line #27: r.Ceil(1.0).TypeOf()")
@@ -346,7 +346,7 @@ func (suite *MathLogicFloorCeilRoundSuite) TestCases() {
 	{
 		// math_logic/floor_ceil_round.yaml line #47
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('X').ceil() */
 
 		suite.T().Log("About to run line #47: r.Expr('X').Ceil()")
@@ -361,7 +361,7 @@ func (suite *MathLogicFloorCeilRoundSuite) TestCases() {
 	{
 		// math_logic/floor_ceil_round.yaml line #51
 		/* "NUMBER" */
-		var expected_ string = "NUMBER"
+		var expected_ = "NUMBER"
 		/* r.round(1.0).type_of() */
 
 		suite.T().Log("About to run line #51: r.Round(1.0).TypeOf()")
@@ -766,7 +766,7 @@ func (suite *MathLogicFloorCeilRoundSuite) TestCases() {
 	{
 		// math_logic/floor_ceil_round.yaml line #113
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('X').round() */
 
 		suite.T().Log("About to run line #113: r.Expr('X').Round()")

--- a/internal/integration/reql_tests/reql_math_logic_logic_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_logic_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #8
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(true) & true */
 
 		suite.T().Log("About to run line #8: r.Expr(true).And(true)")
@@ -76,7 +76,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #9
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* true & r.expr(true) */
 
 		suite.T().Log("About to run line #9: r.And(true, r.Expr(true))")
@@ -91,7 +91,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #10
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.and_(true,true) */
 
 		suite.T().Log("About to run line #10: r.And(true, true)")
@@ -106,7 +106,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #11
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(true).and_(true) */
 
 		suite.T().Log("About to run line #11: r.Expr(true).And(true)")
@@ -121,7 +121,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #22
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(true) & false */
 
 		suite.T().Log("About to run line #22: r.Expr(true).And(false)")
@@ -136,7 +136,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #23
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(false) & false */
 
 		suite.T().Log("About to run line #23: r.Expr(false).And(false)")
@@ -151,7 +151,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #24
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* true & r.expr(false) */
 
 		suite.T().Log("About to run line #24: r.And(true, r.Expr(false))")
@@ -166,7 +166,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #25
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* false & r.expr(false) */
 
 		suite.T().Log("About to run line #25: r.And(false, r.Expr(false))")
@@ -181,7 +181,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #26
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.and_(true,false) */
 
 		suite.T().Log("About to run line #26: r.And(true, false)")
@@ -196,7 +196,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #27
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.and_(false,false) */
 
 		suite.T().Log("About to run line #27: r.And(false, false)")
@@ -211,7 +211,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #28
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(true).and_(false) */
 
 		suite.T().Log("About to run line #28: r.Expr(true).And(false)")
@@ -226,7 +226,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #29
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(false).and_(false) */
 
 		suite.T().Log("About to run line #29: r.Expr(false).And(false)")
@@ -241,7 +241,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #48
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(true) | true */
 
 		suite.T().Log("About to run line #48: r.Expr(true).Or(true)")
@@ -256,7 +256,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #49
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(true) | false */
 
 		suite.T().Log("About to run line #49: r.Expr(true).Or(false)")
@@ -271,7 +271,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #50
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* true | r.expr(true) */
 
 		suite.T().Log("About to run line #50: r.Or(true, r.Expr(true))")
@@ -286,7 +286,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #51
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* true | r.expr(false) */
 
 		suite.T().Log("About to run line #51: r.Or(true, r.Expr(false))")
@@ -301,7 +301,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #52
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.or_(true,true) */
 
 		suite.T().Log("About to run line #52: r.Or(true, true)")
@@ -316,7 +316,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #53
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.or_(true,false) */
 
 		suite.T().Log("About to run line #53: r.Or(true, false)")
@@ -331,7 +331,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #54
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(true).or_(true) */
 
 		suite.T().Log("About to run line #54: r.Expr(true).Or(true)")
@@ -346,7 +346,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #55
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(true).or_(false) */
 
 		suite.T().Log("About to run line #55: r.Expr(true).Or(false)")
@@ -361,7 +361,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #72
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(false) | false */
 
 		suite.T().Log("About to run line #72: r.Expr(false).Or(false)")
@@ -376,7 +376,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #73
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* false | r.expr(false) */
 
 		suite.T().Log("About to run line #73: r.Or(false, r.Expr(false))")
@@ -391,7 +391,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #74
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.and_(false,false) */
 
 		suite.T().Log("About to run line #74: r.And(false, false)")
@@ -406,7 +406,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #75
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(false).and_(false) */
 
 		suite.T().Log("About to run line #75: r.Expr(false).And(false)")
@@ -421,7 +421,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #88
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* ~r.expr(True) */
 
 		suite.T().Log("About to run line #88: r.Expr(true).Not()")
@@ -436,7 +436,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #89
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.not_(True) */
 
 		suite.T().Log("About to run line #89: r.Not(true)")
@@ -451,7 +451,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #93
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ~r.expr(False) */
 
 		suite.T().Log("About to run line #93: r.Expr(false).Not()")
@@ -466,7 +466,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #94
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.not_(False) */
 
 		suite.T().Log("About to run line #94: r.Not(false)")
@@ -481,7 +481,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #97
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(True).not_() */
 
 		suite.T().Log("About to run line #97: r.Expr(true).Not()")
@@ -496,7 +496,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #100
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(False).not_() */
 
 		suite.T().Log("About to run line #100: r.Expr(false).Not()")
@@ -511,7 +511,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #107
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ~r.and_(True, True) == r.or_(~r.expr(True), ~r.expr(True)) */
 
 		suite.T().Log("About to run line #107: r.And(true, true).Not().Eq(r.Or(r.Expr(true).Not(), r.Expr(true).Not()))")
@@ -526,7 +526,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #108
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ~r.and_(True, False) == r.or_(~r.expr(True), ~r.expr(False)) */
 
 		suite.T().Log("About to run line #108: r.And(true, false).Not().Eq(r.Or(r.Expr(true).Not(), r.Expr(false).Not()))")
@@ -541,7 +541,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #109
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ~r.and_(False, False) == r.or_(~r.expr(False), ~r.expr(False)) */
 
 		suite.T().Log("About to run line #109: r.And(false, false).Not().Eq(r.Or(r.Expr(false).Not(), r.Expr(false).Not()))")
@@ -556,7 +556,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #110
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ~r.and_(False, True) == r.or_(~r.expr(False), ~r.expr(True)) */
 
 		suite.T().Log("About to run line #110: r.And(false, true).Not().Eq(r.Or(r.Expr(false).Not(), r.Expr(true).Not()))")
@@ -571,7 +571,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #120
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.and_(True, True, True, True, True) */
 
 		suite.T().Log("About to run line #120: r.And(true, true, true, true, true)")
@@ -586,7 +586,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #123
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.and_(True, True, True, False, True) */
 
 		suite.T().Log("About to run line #123: r.And(true, true, true, false, true)")
@@ -601,7 +601,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #126
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.and_(True, False, True, False, True) */
 
 		suite.T().Log("About to run line #126: r.And(true, false, true, false, true)")
@@ -616,7 +616,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #129
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.or_(False, False, False, False, False) */
 
 		suite.T().Log("About to run line #129: r.Or(false, false, false, false, false)")
@@ -631,7 +631,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #132
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.or_(False, False, False, True, False) */
 
 		suite.T().Log("About to run line #132: r.Or(false, false, false, true, false)")
@@ -646,7 +646,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #135
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.or_(False, True, False, True, False) */
 
 		suite.T().Log("About to run line #135: r.Or(false, true, false, true, false)")
@@ -661,7 +661,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #140
 		/* err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.")
 		/* r.expr(r.expr('a')['b']).default(2) */
 
 		suite.T().Log("About to run line #140: r.Expr(r.Expr('a').AtIndex('b')).Default(2)")
@@ -676,7 +676,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #145
 		/* False */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(r.and_(True, False) == r.or_(False, True)) */
 
 		suite.T().Log("About to run line #145: r.Expr(r.And(true, false).Eq(r.Or(false, true)))")
@@ -691,7 +691,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #151
 		/* False */
-		var expected_ bool = false
+		var expected_ = false
 		/* r.expr(r.and_(True, False) >= r.or_(False, True)) */
 
 		suite.T().Log("About to run line #151: r.Expr(r.And(true, false).Ge(r.Or(false, true)))")
@@ -706,7 +706,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #156
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr(1) & True */
 
 		suite.T().Log("About to run line #156: r.Expr(1).And(true)")
@@ -721,7 +721,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #160
 		/* ("str") */
-		var expected_ string = "str"
+		var expected_ = "str"
 		/* r.expr(False) | 'str' */
 
 		suite.T().Log("About to run line #160: r.Expr(false).Or('str')")
@@ -736,7 +736,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #164
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* ~r.expr(1) */
 
 		suite.T().Log("About to run line #164: r.Expr(1).Not()")
@@ -751,7 +751,7 @@ func (suite *MathLogicLogicSuite) TestCases() {
 	{
 		// math_logic/logic.yaml line #168
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ~r.expr(null) */
 
 		suite.T().Log("About to run line #168: r.Expr(nil).Not()")

--- a/internal/integration/reql_tests/reql_math_logic_math_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_math_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicMathSuite) TestCases() {
 	{
 		// math_logic/math.yaml line #4
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* (((4 + 2 * (r.expr(26) % 18)) / 5) - 3) */
 
 		suite.T().Log("About to run line #4: r.Add(4, r.Mul(2, r.Expr(26).Mod(18))).Div(5).Sub(3)")

--- a/internal/integration/reql_tests/reql_math_logic_mod_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_mod_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicModSuite) TestCases() {
 	{
 		// math_logic/mod.yaml line #6
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(10) % 3 */
 
 		suite.T().Log("About to run line #6: r.Expr(10).Mod(3)")
@@ -76,7 +76,7 @@ func (suite *MathLogicModSuite) TestCases() {
 	{
 		// math_logic/mod.yaml line #7
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* 10 % r.expr(3) */
 
 		suite.T().Log("About to run line #7: r.Mod(10, r.Expr(3))")
@@ -91,7 +91,7 @@ func (suite *MathLogicModSuite) TestCases() {
 	{
 		// math_logic/mod.yaml line #8
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(10).mod(3) */
 
 		suite.T().Log("About to run line #8: r.Expr(10).Mod(3)")
@@ -106,7 +106,7 @@ func (suite *MathLogicModSuite) TestCases() {
 	{
 		// math_logic/mod.yaml line #16
 		/* -1 */
-		var expected_ int = -1
+		var expected_ = -1
 		/* r.expr(-10) % -3 */
 
 		suite.T().Log("About to run line #16: r.Expr(-10).Mod(-3)")
@@ -121,7 +121,7 @@ func (suite *MathLogicModSuite) TestCases() {
 	{
 		// math_logic/mod.yaml line #22
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr(4) % 'a' */
 
 		suite.T().Log("About to run line #22: r.Expr(4).Mod('a')")
@@ -136,7 +136,7 @@ func (suite *MathLogicModSuite) TestCases() {
 	{
 		// math_logic/mod.yaml line #27
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('a') % 1 */
 
 		suite.T().Log("About to run line #27: r.Expr('a').Mod(1)")
@@ -151,7 +151,7 @@ func (suite *MathLogicModSuite) TestCases() {
 	{
 		// math_logic/mod.yaml line #32
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('a') % 'b' */
 
 		suite.T().Log("About to run line #32: r.Expr('a').Mod('b')")

--- a/internal/integration/reql_tests/reql_math_logic_mul_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_mul_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #6
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(1) * 2 */
 
 		suite.T().Log("About to run line #6: r.Expr(1).Mul(2)")
@@ -76,7 +76,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #7
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* 1 * r.expr(2) */
 
 		suite.T().Log("About to run line #7: r.Mul(1, r.Expr(2))")
@@ -91,7 +91,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #8
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr(1).mul(2) */
 
 		suite.T().Log("About to run line #8: r.Expr(1).Mul(2)")
@@ -106,7 +106,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #15
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr(-1) * -1 */
 
 		suite.T().Log("About to run line #15: r.Expr(-1).Mul(-1)")
@@ -136,7 +136,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #25
 		/* [1,2,3,1,2,3,1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 1, 2, 3, 1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3, 1, 2, 3, 1, 2, 3}
 		/* r.expr([1,2,3]) * 3 */
 
 		suite.T().Log("About to run line #25: r.Expr([]interface{}{1, 2, 3}).Mul(3)")
@@ -151,7 +151,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #30
 		/* 120 */
-		var expected_ int = 120
+		var expected_ = 120
 		/* r.expr(1).mul(2,3,4,5) */
 
 		suite.T().Log("About to run line #30: r.Expr(1).Mul(2, 3, 4, 5)")
@@ -166,7 +166,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #46
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('a') * 0.8 */
 
 		suite.T().Log("About to run line #46: r.Expr('a').Mul(0.8)")
@@ -181,7 +181,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #50
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr(1) * 'a' */
 
 		suite.T().Log("About to run line #50: r.Expr(1).Mul('a')")
@@ -196,7 +196,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #54
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('b') * 'a' */
 
 		suite.T().Log("About to run line #54: r.Expr('b').Mul('a')")
@@ -211,7 +211,7 @@ func (suite *MathLogicMulSuite) TestCases() {
 	{
 		// math_logic/mul.yaml line #58
 		/* err('ReqlQueryLogicError', 'Number not an integer: 1.5', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Number not an integer: 1.5")
+		var expected_ = err("ReqlQueryLogicError", "Number not an integer: 1.5")
 		/* r.expr([]) * 1.5 */
 
 		suite.T().Log("About to run line #58: r.Expr([]interface{}{}).Mul(1.5)")

--- a/internal/integration/reql_tests/reql_math_logic_sub_test.go
+++ b/internal/integration/reql_tests/reql_math_logic_sub_test.go
@@ -61,7 +61,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #6
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(1) - 1 */
 
 		suite.T().Log("About to run line #6: r.Expr(1).Sub(1)")
@@ -76,7 +76,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #7
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* 1 - r.expr(1) */
 
 		suite.T().Log("About to run line #7: r.Sub(1, r.Expr(1))")
@@ -91,7 +91,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #8
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.expr(1).sub(1) */
 
 		suite.T().Log("About to run line #8: r.Expr(1).Sub(1)")
@@ -106,7 +106,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #17
 		/* -2 */
-		var expected_ int = -2
+		var expected_ = -2
 		/* r.expr(-1) - 1 */
 
 		suite.T().Log("About to run line #17: r.Expr(-1).Sub(1)")
@@ -136,7 +136,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #26
 		/* -13 */
-		var expected_ int = -13
+		var expected_ = -13
 		/* r.expr(1).sub(2,3,4,5) */
 
 		suite.T().Log("About to run line #26: r.Expr(1).Sub(2, 3, 4, 5)")
@@ -151,7 +151,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #30
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('a').sub(0.8) */
 
 		suite.T().Log("About to run line #30: r.Expr('a').Sub(0.8)")
@@ -166,7 +166,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #33
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [1]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr(1).sub('a') */
 
 		suite.T().Log("About to run line #33: r.Expr(1).Sub('a')")
@@ -181,7 +181,7 @@ func (suite *MathLogicSubSuite) TestCases() {
 	{
 		// math_logic/sub.yaml line #36
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.expr('b').sub('a') */
 
 		suite.T().Log("About to run line #36: r.Expr('b').Sub('a')")

--- a/internal/integration/reql_tests/reql_meta_dbs_test.go
+++ b/internal/integration/reql_tests/reql_meta_dbs_test.go
@@ -61,7 +61,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #11
 		/* partial({'dbs_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
 		/* r.db_create('a') */
 
 		suite.T().Log("About to run line #11: r.DBCreate('a')")
@@ -76,7 +76,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #13
 		/* partial({'dbs_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
 		/* r.db_create('b') */
 
 		suite.T().Log("About to run line #13: r.DBCreate('b')")
@@ -91,7 +91,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #23
 		/* {'name':'a','id':uuid()} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"name": "a", "id": compare.IsUUID()}
+		var expected_ = map[interface{}]interface{}{"name": "a", "id": compare.IsUUID()}
 		/* r.db('a').config() */
 
 		suite.T().Log("About to run line #23: r.DB('a').Config()")
@@ -106,7 +106,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #28
 		/* partial({'dbs_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1})
 		/* r.db_drop('b') */
 
 		suite.T().Log("About to run line #28: r.DBDrop('b')")
@@ -121,7 +121,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #34
 		/* partial({'dbs_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1})
 		/* r.db_drop('a') */
 
 		suite.T().Log("About to run line #34: r.DBDrop('a')")
@@ -136,7 +136,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #41
 		/* partial({'dbs_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
 		/* r.db_create('bar') */
 
 		suite.T().Log("About to run line #41: r.DBCreate('bar')")
@@ -151,7 +151,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #44
 		/* err('ReqlOpFailedError', 'Database `bar` already exists.', [0]) */
-		var expected_ Err = err("ReqlOpFailedError", "Database `bar` already exists.")
+		var expected_ = err("ReqlOpFailedError", "Database `bar` already exists.")
 		/* r.db_create('bar') */
 
 		suite.T().Log("About to run line #44: r.DBCreate('bar')")
@@ -166,7 +166,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #47
 		/* partial({'dbs_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1})
 		/* r.db_drop('bar') */
 
 		suite.T().Log("About to run line #47: r.DBDrop('bar')")
@@ -181,7 +181,7 @@ func (suite *MetaDbsSuite) TestCases() {
 	{
 		// meta/dbs.yaml line #50
 		/* err('ReqlOpFailedError', 'Database `bar` does not exist.', [0]) */
-		var expected_ Err = err("ReqlOpFailedError", "Database `bar` does not exist.")
+		var expected_ = err("ReqlOpFailedError", "Database `bar` does not exist.")
 		/* r.db_drop('bar') */
 
 		suite.T().Log("About to run line #50: r.DBDrop('bar')")

--- a/internal/integration/reql_tests/reql_meta_table_test.go
+++ b/internal/integration/reql_tests/reql_meta_table_test.go
@@ -68,7 +68,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #6
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* db.table_list() */
 
 		suite.T().Log("About to run line #6: db.TableList()")
@@ -83,7 +83,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #9
 		/* ({'type':'DB','name':'rethinkdb','id':uuid()}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"type": "DB", "name": "rethinkdb", "id": compare.IsUUID()}
+		var expected_ = map[interface{}]interface{}{"type": "DB", "name": "rethinkdb", "id": compare.IsUUID()}
 		/* r.db('rethinkdb').info() */
 
 		suite.T().Log("About to run line #9: r.DB('rethinkdb').Info()")
@@ -100,7 +100,7 @@ func (suite *MetaTableSuite) TestCases() {
 		/* partial({'db':{'type':'DB','name':'rethinkdb','id':uuid()},
 		'type':'TABLE','id':uuid(),'name':'stats',
 		'indexes':[],'primary_key':'id'}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"db": map[interface{}]interface{}{"type": "DB", "name": "rethinkdb", "id": compare.IsUUID()}, "type": "TABLE", "id": compare.IsUUID(), "name": "stats", "indexes": []interface{}{}, "primary_key": "id"})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"db": map[interface{}]interface{}{"type": "DB", "name": "rethinkdb", "id": compare.IsUUID()}, "type": "TABLE", "id": compare.IsUUID(), "name": "stats", "indexes": []interface{}{}, "primary_key": "id"})
 		/* r.db('rethinkdb').table('stats').info() */
 
 		suite.T().Log("About to run line #12: r.DB('rethinkdb').Table('stats').Info()")
@@ -115,7 +115,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #18
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('a') */
 
 		suite.T().Log("About to run line #18: db.TableCreate('a')")
@@ -130,7 +130,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #21
 		/* ['a'] */
-		var expected_ []interface{} = []interface{}{"a"}
+		var expected_ = []interface{}{"a"}
 		/* db.table_list() */
 
 		suite.T().Log("About to run line #21: db.TableList()")
@@ -145,7 +145,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #24
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('b') */
 
 		suite.T().Log("About to run line #24: db.TableCreate('b')")
@@ -160,7 +160,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #27
 		/* bag(['a', 'b']) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{"a", "b"})
+		var expected_ = compare.UnorderedMatch([]interface{}{"a", "b"})
 		/* db.table_list() */
 
 		suite.T().Log("About to run line #27: db.TableList()")
@@ -175,7 +175,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #31
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('a') */
 
 		suite.T().Log("About to run line #31: db.TableDrop('a')")
@@ -190,7 +190,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #34
 		/* ['b'] */
-		var expected_ []interface{} = []interface{}{"b"}
+		var expected_ = []interface{}{"b"}
 		/* db.table_list() */
 
 		suite.T().Log("About to run line #34: db.TableList()")
@@ -205,7 +205,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #37
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('b') */
 
 		suite.T().Log("About to run line #37: db.TableDrop('b')")
@@ -220,7 +220,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #40
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* db.table_list() */
 
 		suite.T().Log("About to run line #40: db.TableList()")
@@ -235,7 +235,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #44
 		/* partial({'tables_created':1,'config_changes':[partial({'new_val':partial({'durability':'soft'})})]}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1, "config_changes": []interface{}{compare.PartialMatch(map[interface{}]interface{}{"new_val": compare.PartialMatch(map[interface{}]interface{}{"durability": "soft"})})}})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1, "config_changes": []interface{}{compare.PartialMatch(map[interface{}]interface{}{"new_val": compare.PartialMatch(map[interface{}]interface{}{"durability": "soft"})})}})
 		/* db.table_create('ab', durability='soft') */
 
 		suite.T().Log("About to run line #44: db.TableCreate('ab').OptArgs(r.TableCreateOpts{Durability: 'soft', })")
@@ -250,7 +250,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #49
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('ab') */
 
 		suite.T().Log("About to run line #49: db.TableDrop('ab')")
@@ -265,7 +265,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #52
 		/* partial({'tables_created':1,'config_changes':[partial({'new_val':partial({'durability':'hard'})})]}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1, "config_changes": []interface{}{compare.PartialMatch(map[interface{}]interface{}{"new_val": compare.PartialMatch(map[interface{}]interface{}{"durability": "hard"})})}})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1, "config_changes": []interface{}{compare.PartialMatch(map[interface{}]interface{}{"new_val": compare.PartialMatch(map[interface{}]interface{}{"durability": "hard"})})}})
 		/* db.table_create('ab', durability='hard') */
 
 		suite.T().Log("About to run line #52: db.TableCreate('ab').OptArgs(r.TableCreateOpts{Durability: 'hard', })")
@@ -280,7 +280,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #57
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('ab') */
 
 		suite.T().Log("About to run line #57: db.TableDrop('ab')")
@@ -295,7 +295,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #60
 		/* err('ReqlQueryLogicError', 'Durability option `fake` unrecognized (options are "hard" and "soft").') */
-		var expected_ Err = err("ReqlQueryLogicError", "Durability option `fake` unrecognized (options are \"hard\" and \"soft\").")
+		var expected_ = err("ReqlQueryLogicError", "Durability option `fake` unrecognized (options are \"hard\" and \"soft\").")
 		/* db.table_create('ab', durability='fake') */
 
 		suite.T().Log("About to run line #60: db.TableCreate('ab').OptArgs(r.TableCreateOpts{Durability: 'fake', })")
@@ -310,7 +310,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #65
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('ab', primary_key='bar', shards=2, replicas=1) */
 
 		suite.T().Log("About to run line #65: db.TableCreate('ab').OptArgs(r.TableCreateOpts{PrimaryKey: 'bar', Shards: 2, Replicas: 1, })")
@@ -325,7 +325,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #70
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('ab') */
 
 		suite.T().Log("About to run line #70: db.TableDrop('ab')")
@@ -340,7 +340,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #73
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('ab', primary_key='bar', primary_replica_tag='default') */
 
 		suite.T().Log("About to run line #73: db.TableCreate('ab').OptArgs(r.TableCreateOpts{PrimaryKey: 'bar', PrimaryReplicaTag: 'default', })")
@@ -355,7 +355,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #78
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('ab') */
 
 		suite.T().Log("About to run line #78: db.TableDrop('ab')")
@@ -370,7 +370,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #81
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('ab', nonvoting_replica_tags=['default']) */
 
 		suite.T().Log("About to run line #81: db.TableCreate('ab').OptArgs(r.TableCreateOpts{NonVotingReplicaTags: []interface{}{'default'}, })")
@@ -385,7 +385,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #86
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('ab') */
 
 		suite.T().Log("About to run line #86: db.TableDrop('ab')")
@@ -400,7 +400,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #90
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('a') */
 
 		suite.T().Log("About to run line #90: db.TableCreate('a')")
@@ -415,7 +415,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #93
 		/* partial({'reconfigured':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
 		/* db.table('a').reconfigure(shards=1, replicas=1) */
 
 		suite.T().Log("About to run line #93: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: 1, })")
@@ -430,7 +430,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #98
 		/* partial({'reconfigured':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
 		/* db.table('a').reconfigure(shards=1, replicas={"default":1}, nonvoting_replica_tags=['default'], primary_replica_tag='default') */
 
 		suite.T().Log("About to run line #98: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'default': 1, }, NonVotingReplicaTags: []interface{}{'default'}, PrimaryReplicaTag: 'default', })")
@@ -445,7 +445,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #103
 		/* partial({'reconfigured':0}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 0})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 0})
 		/* db.table('a').reconfigure(shards=1, replicas=1, dry_run=True) */
 
 		suite.T().Log("About to run line #103: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: 1, DryRun: true, })")
@@ -460,7 +460,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #108
 		/* err('ReqlOpFailedError', 'This table doesn\'t need to be repaired.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "This table doesn't need to be repaired.")
+		var expected_ = err("ReqlOpFailedError", "This table doesn't need to be repaired.")
 		/* db.table('a').reconfigure(emergency_repair="unsafe_rollback") */
 
 		suite.T().Log("About to run line #108: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{EmergencyRepair: 'unsafe_rollback', })")
@@ -475,7 +475,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #113
 		/* err('ReqlOpFailedError', 'This table doesn\'t need to be repaired.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "This table doesn't need to be repaired.")
+		var expected_ = err("ReqlOpFailedError", "This table doesn't need to be repaired.")
 		/* db.table('a').reconfigure(emergency_repair="unsafe_rollback", dry_run=True) */
 
 		suite.T().Log("About to run line #113: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{EmergencyRepair: 'unsafe_rollback', DryRun: true, })")
@@ -490,7 +490,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #118
 		/* err('ReqlOpFailedError', 'This table doesn\'t need to be repaired.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "This table doesn't need to be repaired.")
+		var expected_ = err("ReqlOpFailedError", "This table doesn't need to be repaired.")
 		/* db.table('a').reconfigure(emergency_repair="unsafe_rollback_or_erase") */
 
 		suite.T().Log("About to run line #118: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{EmergencyRepair: 'unsafe_rollback_or_erase', })")
@@ -505,7 +505,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #123
 		/* partial({'reconfigured':0}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 0})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 0})
 		/* db.table('a').reconfigure(emergency_repair=None, shards=1, replicas=1, dry_run=True) */
 
 		suite.T().Log("About to run line #123: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{EmergencyRepair: nil, Shards: 1, Replicas: 1, DryRun: true, })")
@@ -520,7 +520,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #128
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('a') */
 
 		suite.T().Log("About to run line #128: db.TableDrop('a')")
@@ -535,7 +535,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #132
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('foo') */
 
 		suite.T().Log("About to run line #132: db.TableCreate('foo')")
@@ -550,7 +550,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #135
 		/* err('ReqlOpFailedError', 'Table `test.foo` already exists.', [0]) */
-		var expected_ Err = err("ReqlOpFailedError", "Table `test.foo` already exists.")
+		var expected_ = err("ReqlOpFailedError", "Table `test.foo` already exists.")
 		/* db.table_create('foo') */
 
 		suite.T().Log("About to run line #135: db.TableCreate('foo')")
@@ -565,7 +565,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #138
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('foo') */
 
 		suite.T().Log("About to run line #138: db.TableDrop('foo')")
@@ -580,7 +580,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #141
 		/* err('ReqlOpFailedError', 'Table `test.foo` does not exist.', [0]) */
-		var expected_ Err = err("ReqlOpFailedError", "Table `test.foo` does not exist.")
+		var expected_ = err("ReqlOpFailedError", "Table `test.foo` does not exist.")
 		/* db.table_drop('foo') */
 
 		suite.T().Log("About to run line #141: db.TableDrop('foo')")
@@ -595,7 +595,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #158
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create('a') */
 
 		suite.T().Log("About to run line #158: db.TableCreate('a')")
@@ -610,7 +610,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #161
 		/* err('ReqlQueryLogicError', 'Every table must have at least one shard.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Every table must have at least one shard.")
+		var expected_ = err("ReqlQueryLogicError", "Every table must have at least one shard.")
 		/* db.table('a').reconfigure(shards=0, replicas=1) */
 
 		suite.T().Log("About to run line #161: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 0, Replicas: 1, })")
@@ -625,7 +625,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #166
 		/* err('ReqlOpFailedError', 'Can\'t use server tag `foo` for primary replicas because you specified no replicas in server tag `foo`.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "Can't use server tag `foo` for primary replicas because you specified no replicas in server tag `foo`.")
+		var expected_ = err("ReqlOpFailedError", "Can't use server tag `foo` for primary replicas because you specified no replicas in server tag `foo`.")
 		/* db.table('a').reconfigure(shards=1, replicas={"default":1}, primary_replica_tag="foo") */
 
 		suite.T().Log("About to run line #166: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'default': 1, }, PrimaryReplicaTag: 'foo', })")
@@ -640,7 +640,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #171
 		/* err('ReqlOpFailedError', 'You specified that the replicas in server tag `foo` should be non-voting, but you didn\'t specify a number of replicas in server tag `foo`.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "You specified that the replicas in server tag `foo` should be non-voting, but you didn't specify a number of replicas in server tag `foo`.")
+		var expected_ = err("ReqlOpFailedError", "You specified that the replicas in server tag `foo` should be non-voting, but you didn't specify a number of replicas in server tag `foo`.")
 		/* db.table('a').reconfigure(shards=1, replicas={"default":1}, primary_replica_tag="default", nonvoting_replica_tags=["foo"]) */
 
 		suite.T().Log("About to run line #171: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'default': 1, }, PrimaryReplicaTag: 'default', NonVotingReplicaTags: []interface{}{'foo'}, })")
@@ -655,7 +655,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #176
 		/* err('ReqlOpFailedError', 'You must set `replicas` to at least one. `replicas` includes the primary replica; if there are zero replicas, there is nowhere to put the data.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "You must set `replicas` to at least one. `replicas` includes the primary replica; if there are zero replicas, there is nowhere to put the data.")
+		var expected_ = err("ReqlOpFailedError", "You must set `replicas` to at least one. `replicas` includes the primary replica; if there are zero replicas, there is nowhere to put the data.")
 		/* db.table('a').reconfigure(shards=1, replicas={"foo":0}, primary_replica_tag="foo") */
 
 		suite.T().Log("About to run line #176: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'foo': 0, }, PrimaryReplicaTag: 'foo', })")
@@ -670,7 +670,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #181
 		/* err('ReqlQueryLogicError', '`primary_replica_tag` must be specified when `replicas` is an OBJECT.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "`primary_replica_tag` must be specified when `replicas` is an OBJECT.")
+		var expected_ = err("ReqlQueryLogicError", "`primary_replica_tag` must be specified when `replicas` is an OBJECT.")
 		/* db.table('a').reconfigure(shards=1, replicas={"default":0}) */
 
 		suite.T().Log("About to run line #181: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'default': 0, }, })")
@@ -685,7 +685,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #186
 		/* err('ReqlQueryLogicError', 'Can\'t have a negative number of replicas', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Can't have a negative number of replicas")
+		var expected_ = err("ReqlQueryLogicError", "Can't have a negative number of replicas")
 		/* db.table('a').reconfigure(shards=1, replicas={"default":-3}, primary_replica_tag='default') */
 
 		suite.T().Log("About to run line #186: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'default': -3, }, PrimaryReplicaTag: 'default', })")
@@ -700,7 +700,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #191
 		/* err('ReqlQueryLogicError', '`replicas` must be an OBJECT if `primary_replica_tag` is specified.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "`replicas` must be an OBJECT if `primary_replica_tag` is specified.")
+		var expected_ = err("ReqlQueryLogicError", "`replicas` must be an OBJECT if `primary_replica_tag` is specified.")
 		/* db.table('a').reconfigure(shards=1, replicas=3, primary_replica_tag='foo') */
 
 		suite.T().Log("About to run line #191: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: 3, PrimaryReplicaTag: 'foo', })")
@@ -715,7 +715,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #196
 		/* err('ReqlQueryLogicError', '`replicas` must be an OBJECT if `nonvoting_replica_tags` is specified.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "`replicas` must be an OBJECT if `nonvoting_replica_tags` is specified.")
+		var expected_ = err("ReqlQueryLogicError", "`replicas` must be an OBJECT if `nonvoting_replica_tags` is specified.")
 		/* db.table('a').reconfigure(shards=1, replicas=3, nonvoting_replica_tags=['foo']) */
 
 		suite.T().Log("About to run line #196: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: 3, NonVotingReplicaTags: []interface{}{'foo'}, })")
@@ -730,7 +730,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #201
 		/* err('ReqlQueryLogicError', 'Can\'t emergency repair an entire database at once; instead you should run `reconfigure()` on each table individually.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Can't emergency repair an entire database at once; instead you should run `reconfigure()` on each table individually.")
+		var expected_ = err("ReqlQueryLogicError", "Can't emergency repair an entire database at once; instead you should run `reconfigure()` on each table individually.")
 		/* db.reconfigure(emergency_repair="unsafe_rollback") */
 
 		suite.T().Log("About to run line #201: db.Reconfigure().OptArgs(r.ReconfigureOpts{EmergencyRepair: 'unsafe_rollback', })")
@@ -745,7 +745,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #206
 		/* err('ReqlQueryLogicError', '`emergency_repair` should be "unsafe_rollback" or "unsafe_rollback_or_erase"', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "`emergency_repair` should be \"unsafe_rollback\" or \"unsafe_rollback_or_erase\"")
+		var expected_ = err("ReqlQueryLogicError", "`emergency_repair` should be \"unsafe_rollback\" or \"unsafe_rollback_or_erase\"")
 		/* db.table('a').reconfigure(emergency_repair="foo") */
 
 		suite.T().Log("About to run line #206: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{EmergencyRepair: 'foo', })")
@@ -760,7 +760,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #211
 		/* err('ReqlQueryLogicError', 'In emergency repair mode, you can\'t specify shards, replicas, etc.') */
-		var expected_ Err = err("ReqlQueryLogicError", "In emergency repair mode, you can't specify shards, replicas, etc.")
+		var expected_ = err("ReqlQueryLogicError", "In emergency repair mode, you can't specify shards, replicas, etc.")
 		/* db.table('a').reconfigure(emergency_repair="unsafe_rollback", shards=1, replicas=1) */
 
 		suite.T().Log("About to run line #211: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{EmergencyRepair: 'unsafe_rollback', Shards: 1, Replicas: 1, })")
@@ -775,7 +775,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #217
 		/* partial({'reconfigured':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
 		/* db.table('a').reconfigure(shards=2, replicas=1) */
 
 		suite.T().Log("About to run line #217: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 2, Replicas: 1, })")
@@ -790,7 +790,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #222
 		/* {"ready":1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"ready": 1}
+		var expected_ = map[interface{}]interface{}{"ready": 1}
 		/* db.table('a').wait(wait_for="all_replicas_ready") */
 
 		suite.T().Log("About to run line #222: db.Table('a').Wait().OptArgs(r.WaitOpts{WaitFor: 'all_replicas_ready', })")
@@ -805,7 +805,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #228
 		/* partial({"inserted":4}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"inserted": 4})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"inserted": 4})
 		/* db.table('a').insert([{"id":1}, {"id":2}, {"id":3}, {"id":4}]) */
 
 		suite.T().Log("About to run line #228: db.Table('a').Insert([]interface{}{map[interface{}]interface{}{'id': 1, }, map[interface{}]interface{}{'id': 2, }, map[interface{}]interface{}{'id': 3, }, map[interface{}]interface{}{'id': 4, }})")
@@ -820,7 +820,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #233
 		/* partial({'reconfigured':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 1})
 		/* db.table('a').reconfigure(shards=2, replicas=1) */
 
 		suite.T().Log("About to run line #233: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 2, Replicas: 1, })")
@@ -835,7 +835,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #238
 		/* err('ReqlOpFailedError', 'Can\'t put 2 replicas on servers with the tag `default` because there are only 1 servers with the tag `default`. It\'s impossible to have more replicas of the data than there are servers.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "Can't put 2 replicas on servers with the tag `default` because there are only 1 servers with the tag `default`. It's impossible to have more replicas of the data than there are servers.")
+		var expected_ = err("ReqlOpFailedError", "Can't put 2 replicas on servers with the tag `default` because there are only 1 servers with the tag `default`. It's impossible to have more replicas of the data than there are servers.")
 		/* db.table('a').reconfigure(shards=1, replicas=2) */
 
 		suite.T().Log("About to run line #238: db.Table('a').Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: 2, })")
@@ -850,7 +850,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #244
 		/* {"ready":1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"ready": 1}
+		var expected_ = map[interface{}]interface{}{"ready": 1}
 		/* db.table('a').wait(wait_for="all_replicas_ready") */
 
 		suite.T().Log("About to run line #244: db.Table('a').Wait().OptArgs(r.WaitOpts{WaitFor: 'all_replicas_ready', })")
@@ -865,7 +865,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #248
 		/* partial({'rebalanced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"rebalanced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"rebalanced": 1})
 		/* db.table('a').rebalance() */
 
 		suite.T().Log("About to run line #248: db.Table('a').Rebalance()")
@@ -880,7 +880,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #251
 		/* {"ready":1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"ready": 1}
+		var expected_ = map[interface{}]interface{}{"ready": 1}
 		/* db.wait(wait_for="all_replicas_ready") */
 
 		suite.T().Log("About to run line #251: db.Wait().OptArgs(r.WaitOpts{WaitFor: 'all_replicas_ready', })")
@@ -895,7 +895,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #255
 		/* partial({'rebalanced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"rebalanced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"rebalanced": 1})
 		/* db.rebalance() */
 
 		suite.T().Log("About to run line #255: db.Rebalance()")
@@ -910,7 +910,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #271
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('a') */
 
 		suite.T().Log("About to run line #271: db.TableDrop('a')")
@@ -925,7 +925,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #275
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* db.table_create('a') */
 
 		suite.T().Log("About to run line #275: db.TableCreate('a')")
@@ -940,7 +940,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #276
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* db.table_create('b') */
 
 		suite.T().Log("About to run line #276: db.TableCreate('b')")
@@ -955,7 +955,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #277
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* db.table_create('c') */
 
 		suite.T().Log("About to run line #277: db.TableCreate('c')")
@@ -970,7 +970,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #279
 		/* err('ReqlQueryLogicError', 'Every table must have at least one shard.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Every table must have at least one shard.")
+		var expected_ = err("ReqlQueryLogicError", "Every table must have at least one shard.")
 		/* db.reconfigure(shards=0, replicas=1) */
 
 		suite.T().Log("About to run line #279: db.Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 0, Replicas: 1, })")
@@ -985,7 +985,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #284
 		/* err('ReqlQueryLogicError', '`primary_replica_tag` must be specified when `replicas` is an OBJECT.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "`primary_replica_tag` must be specified when `replicas` is an OBJECT.")
+		var expected_ = err("ReqlQueryLogicError", "`primary_replica_tag` must be specified when `replicas` is an OBJECT.")
 		/* db.reconfigure(shards=1, replicas={"default":0}) */
 
 		suite.T().Log("About to run line #284: db.Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'default': 0, }, })")
@@ -1000,7 +1000,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #289
 		/* err('ReqlQueryLogicError', 'Can\'t have a negative number of replicas', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Can't have a negative number of replicas")
+		var expected_ = err("ReqlQueryLogicError", "Can't have a negative number of replicas")
 		/* db.reconfigure(shards=1, replicas={"default":-3}, primary_replica_tag='default') */
 
 		suite.T().Log("About to run line #289: db.Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: map[interface{}]interface{}{'default': -3, }, PrimaryReplicaTag: 'default', })")
@@ -1015,7 +1015,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #294
 		/* err('ReqlQueryLogicError', '`replicas` must be an OBJECT if `primary_replica_tag` is specified.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "`replicas` must be an OBJECT if `primary_replica_tag` is specified.")
+		var expected_ = err("ReqlQueryLogicError", "`replicas` must be an OBJECT if `primary_replica_tag` is specified.")
 		/* db.reconfigure(shards=1, replicas=3, primary_replica_tag='foo') */
 
 		suite.T().Log("About to run line #294: db.Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 1, Replicas: 3, PrimaryReplicaTag: 'foo', })")
@@ -1030,7 +1030,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #299
 		/* partial({'reconfigured':3}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 3})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"reconfigured": 3})
 		/* db.reconfigure(shards=2, replicas=1) */
 
 		suite.T().Log("About to run line #299: db.Reconfigure().OptArgs(r.ReconfigureOpts{Shards: 2, Replicas: 1, })")
@@ -1045,7 +1045,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #304
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('a') */
 
 		suite.T().Log("About to run line #304: db.TableDrop('a')")
@@ -1060,7 +1060,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #306
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('b') */
 
 		suite.T().Log("About to run line #306: db.TableDrop('b')")
@@ -1075,7 +1075,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #308
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('c') */
 
 		suite.T().Log("About to run line #308: db.TableDrop('c')")
@@ -1090,7 +1090,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #312
 		/* partial({'dbs_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_created": 1})
 		/* r.db_create("test2") */
 
 		suite.T().Log("About to run line #312: r.DBCreate('test2')")
@@ -1112,7 +1112,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #317
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create("testA") */
 
 		suite.T().Log("About to run line #317: db.TableCreate('testA')")
@@ -1127,7 +1127,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #319
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db.table_create("testB") */
 
 		suite.T().Log("About to run line #319: db.TableCreate('testB')")
@@ -1142,7 +1142,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #321
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* db2.table_create("test2B") */
 
 		suite.T().Log("About to run line #321: db2.TableCreate('test2B')")
@@ -1157,7 +1157,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #324
 		/* {'db':'test','name':'testA'} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"db": "test", "name": "testA"}
+		var expected_ = map[interface{}]interface{}{"db": "test", "name": "testA"}
 		/* r.table('testA').config().pluck('db','name') */
 
 		suite.T().Log("About to run line #324: r.Table('testA').Config().Pluck('db', 'name')")
@@ -1172,7 +1172,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #327
 		/* err('ReqlOpFailedError', 'Table `test.doesntexist` does not exist.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "Table `test.doesntexist` does not exist.")
+		var expected_ = err("ReqlOpFailedError", "Table `test.doesntexist` does not exist.")
 		/* r.table('doesntexist').config() */
 
 		suite.T().Log("About to run line #327: r.Table('doesntexist').Config()")
@@ -1187,7 +1187,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #330
 		/* err('ReqlOpFailedError', 'Table `test.test2B` does not exist.', []) */
-		var expected_ Err = err("ReqlOpFailedError", "Table `test.test2B` does not exist.")
+		var expected_ = err("ReqlOpFailedError", "Table `test.test2B` does not exist.")
 		/* r.table('test2B').config() */
 
 		suite.T().Log("About to run line #330: r.Table('test2B').Config()")
@@ -1202,7 +1202,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #333
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.db('rethinkdb').table('table_config').filter({'name':'testA'}).nth(0).eq(r.table('testA').config()) */
 
 		suite.T().Log("About to run line #333: r.DB('rethinkdb').Table('table_config').Filter(map[interface{}]interface{}{'name': 'testA', }).Nth(0).Eq(r.Table('testA').Config())")
@@ -1217,7 +1217,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #336
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.db('rethinkdb').table('table_status').filter({'name':'testA'}).nth(0).eq(r.table('testA').status()) */
 
 		suite.T().Log("About to run line #336: r.DB('rethinkdb').Table('table_status').Filter(map[interface{}]interface{}{'name': 'testA', }).Nth(0).Eq(r.Table('testA').Status())")
@@ -1247,7 +1247,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #344
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* r.table('testA', identifier_format='uuid').count() */
 
 		suite.T().Log("About to run line #344: r.Table('testA').OptArgs(r.TableOpts{IdentifierFormat: 'uuid', }).Count()")
@@ -1262,7 +1262,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #358
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('testA') */
 
 		suite.T().Log("About to run line #358: db.TableDrop('testA')")
@@ -1277,7 +1277,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #361
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* db.table_drop('testB') */
 
 		suite.T().Log("About to run line #361: db.TableDrop('testB')")
@@ -1292,7 +1292,7 @@ func (suite *MetaTableSuite) TestCases() {
 	{
 		// meta/table.yaml line #364
 		/* partial({'dbs_dropped':1,'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1, "tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"dbs_dropped": 1, "tables_dropped": 1})
 		/* r.db_drop('test2') */
 
 		suite.T().Log("About to run line #364: r.DBDrop('test2')")

--- a/internal/integration/reql_tests/reql_mutation_atomic_get_set_test.go
+++ b/internal/integration/reql_tests/reql_mutation_atomic_get_set_test.go
@@ -70,7 +70,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #12
 		/* ({'changes':[{'old_val':null,'new_val':{'id':0}}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 0}}}}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": map[interface{}]interface{}{"id": 0}}}}
 		/* tbl.insert({'id':0}, return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #12: tbl.Insert(map[interface{}]interface{}{'id': 0, }).OptArgs(r.InsertOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -85,7 +85,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #16
 		/* ({'changes':[], 'first_error':"Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}
 		/* tbl.insert({'id':0}, return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #16: tbl.Insert(map[interface{}]interface{}{'id': 0, }).OptArgs(r.InsertOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -100,7 +100,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #20
 		/* ({'first_error':"Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}",'changes':[{'old_val':{'id':0},'new_val':{'id':0},'error':"Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}", "changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0}, "new_val": map[interface{}]interface{}{"id": 0}, "error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}}}
+		var expected_ = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}", "changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0}, "new_val": map[interface{}]interface{}{"id": 0}, "error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}}}
 		/* tbl.insert({'id':0}, return_changes='always').pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #20: tbl.Insert(map[interface{}]interface{}{'id': 0, }).OptArgs(r.InsertOpts{ReturnChanges: 'always', }).Pluck('changes', 'first_error')")
@@ -115,7 +115,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #24
 		/* ({'changes':[{'new_val':{'id':1},'old_val':null}], 'errors':0, 'deleted':0, 'unchanged':0, 'skipped':0, 'replaced':0, 'inserted':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}, "old_val": nil}}, "errors": 0, "deleted": 0, "unchanged": 0, "skipped": 0, "replaced": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}, "old_val": nil}}, "errors": 0, "deleted": 0, "unchanged": 0, "skipped": 0, "replaced": 0, "inserted": 1}
 		/* tbl.insert([{'id':1}], return_changes=True) */
 
 		suite.T().Log("About to run line #24: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 1, }}).OptArgs(r.InsertOpts{ReturnChanges: true, })")
@@ -130,7 +130,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #28
 		/* ({'changes':[],'first_error':"Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t0\n}\n{\n\t\"id\":\t0\n}"}
 		/* tbl.insert([{'id':0}], return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #28: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 0, }}).OptArgs(r.InsertOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -145,7 +145,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #33
 		/* ({'changes':[{'old_val':{'id':0},'new_val':{'id':0,'x':1}}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0}, "new_val": map[interface{}]interface{}{"id": 0, "x": 1}}}}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0}, "new_val": map[interface{}]interface{}{"id": 0, "x": 1}}}}
 		/* tbl.get(0).update({'x':1}, return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #33: tbl.Get(0).Update(map[interface{}]interface{}{'x': 1, }).OptArgs(r.UpdateOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -160,7 +160,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #37
 		/* ({'changes':[],'first_error':'a'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "a"}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "a"}
 		/* tbl.get(0).update({'x':r.error("a")}, return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #37: tbl.Get(0).Update(map[interface{}]interface{}{'x': r.Error('a'), }).OptArgs(r.UpdateOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -175,7 +175,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #41
 		/* ({'changes':[{'old_val':{'id':0, 'x':1},'new_val':{'id':0, 'x':3}}, {'old_val':{'id':1},'new_val':{'id':1, 'x':3}}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0, "x": 1}, "new_val": map[interface{}]interface{}{"id": 0, "x": 3}}, map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "x": 3}}}}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0, "x": 1}, "new_val": map[interface{}]interface{}{"id": 0, "x": 3}}, map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 1}, "new_val": map[interface{}]interface{}{"id": 1, "x": 3}}}}
 		/* tbl.update({'x':3}, return_changes=True).pluck('changes', 'first_error').do(lambda d:d.merge({'changes':d['changes'].order_by(lambda a:a['old_val']['id'])})) */
 
 		suite.T().Log("About to run line #41: tbl.Update(map[interface{}]interface{}{'x': 3, }).OptArgs(r.UpdateOpts{ReturnChanges: true, }).Pluck('changes', 'first_error').Do(func(d r.Term) interface{} { return d.Merge(map[interface{}]interface{}{'changes': d.AtIndex('changes').OrderBy(func(a r.Term) interface{} { return a.AtIndex('old_val').AtIndex('id')}), })})")
@@ -192,7 +192,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #46
 		/* ({'changes':[{'old_val':{'id':0,'x':3},'new_val':{'id':0,'x':2}}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0, "x": 3}, "new_val": map[interface{}]interface{}{"id": 0, "x": 2}}}}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0, "x": 3}, "new_val": map[interface{}]interface{}{"id": 0, "x": 2}}}}
 		/* tbl.get(0).replace({'id':0,'x':2}, return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #46: tbl.Get(0).Replace(map[interface{}]interface{}{'id': 0, 'x': 2, }).OptArgs(r.ReplaceOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -207,7 +207,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #50
 		/* ({'changes':[],'first_error':'a'}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "a"}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{}, "first_error": "a"}
 		/* tbl.get(0).replace(lambda y:{'x':r.error('a')}, return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #50: tbl.Get(0).Replace(func(y r.Term) interface{} { return map[interface{}]interface{}{'x': r.Error('a'), }}).OptArgs(r.ReplaceOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -222,7 +222,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #54
 		/* ({'first_error':'a','changes':[{'old_val':{'id':0,'x':2},'new_val':{'id':0,'x':2},'error':'a'}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "a", "changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0, "x": 2}, "new_val": map[interface{}]interface{}{"id": 0, "x": 2}, "error": "a"}}}
+		var expected_ = map[interface{}]interface{}{"first_error": "a", "changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0, "x": 2}, "new_val": map[interface{}]interface{}{"id": 0, "x": 2}, "error": "a"}}}
 		/* tbl.get(0).replace(lambda y:{'x':r.error('a')}, return_changes='always').pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #54: tbl.Get(0).Replace(func(y r.Term) interface{} { return map[interface{}]interface{}{'x': r.Error('a'), }}).OptArgs(r.ReplaceOpts{ReturnChanges: 'always', }).Pluck('changes', 'first_error')")
@@ -237,7 +237,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #58
 		/* ({'changes':[{'new_val':{'id':0},'old_val':{'id':0, 'x':2}}, {'new_val':{'id':1},'old_val':{'id':1,'x':3}}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 0}, "old_val": map[interface{}]interface{}{"id": 0, "x": 2}}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}, "old_val": map[interface{}]interface{}{"id": 1, "x": 3}}}}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 0}, "old_val": map[interface{}]interface{}{"id": 0, "x": 2}}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}, "old_val": map[interface{}]interface{}{"id": 1, "x": 3}}}}
 		/* tbl.replace(lambda y:y.without('x'), return_changes=True).pluck('changes', 'first_error').do(lambda d:d.merge({'changes':d['changes'].order_by(lambda a:a['old_val']['id'])})) */
 
 		suite.T().Log("About to run line #58: tbl.Replace(func(y r.Term) interface{} { return y.Without('x')}).OptArgs(r.ReplaceOpts{ReturnChanges: true, }).Pluck('changes', 'first_error').Do(func(d r.Term) interface{} { return d.Merge(map[interface{}]interface{}{'changes': d.AtIndex('changes').OrderBy(func(a r.Term) interface{} { return a.AtIndex('old_val').AtIndex('id')}), })})")
@@ -254,7 +254,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #62
 		/* ({'first_error':"Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}", 'changes':[{'new_val':{'id':0},'old_val':{'id':0}, 'error':"Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}"}, {'new_val':{'id':1},'old_val':{'id':1},'error':"Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}"}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}", "changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 0}, "old_val": map[interface{}]interface{}{"id": 0}, "error": "Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}, "old_val": map[interface{}]interface{}{"id": 1}, "error": "Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}"}}}
+		var expected_ = map[interface{}]interface{}{"first_error": "Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}", "changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 0}, "old_val": map[interface{}]interface{}{"id": 0}, "error": "Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}"}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 1}, "old_val": map[interface{}]interface{}{"id": 1}, "error": "Inserted object must have primary key `id`:\n{\n\t\"x\":\t1\n}"}}}
 		/* tbl.replace({'x':1}, return_changes='always').pluck('changes', 'first_error').do(lambda d:d.merge({'changes':d['changes'].order_by(lambda a:a['old_val']['id'])})) */
 
 		suite.T().Log("About to run line #62: tbl.Replace(map[interface{}]interface{}{'x': 1, }).OptArgs(r.ReplaceOpts{ReturnChanges: 'always', }).Pluck('changes', 'first_error').Do(func(d r.Term) interface{} { return d.Merge(map[interface{}]interface{}{'changes': d.AtIndex('changes').OrderBy(func(a r.Term) interface{} { return a.AtIndex('old_val').AtIndex('id')}), })})")
@@ -271,7 +271,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #86
 		/* ({'changes':[{'old_val':{'id':0},'new_val':null}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0}, "new_val": nil}}}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": map[interface{}]interface{}{"id": 0}, "new_val": nil}}}
 		/* tbl.get(0).delete(return_changes=True).pluck('changes', 'first_error') */
 
 		suite.T().Log("About to run line #86: tbl.Get(0).Delete().OptArgs(r.DeleteOpts{ReturnChanges: true, }).Pluck('changes', 'first_error')")
@@ -286,7 +286,7 @@ func (suite *MutationAtomicGetSetSuite) TestCases() {
 	{
 		// mutation/atomic_get_set.yaml line #90
 		/* ({'deleted':1,'errors':0,'inserted':0,'replaced':0,'skipped':0,'unchanged':0,'changes':[{'new_val':null, 'old_val':{'id':1}}]}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 1, "errors": 0, "inserted": 0, "replaced": 0, "skipped": 0, "unchanged": 0, "changes": []interface{}{map[interface{}]interface{}{"new_val": nil, "old_val": map[interface{}]interface{}{"id": 1}}}}
+		var expected_ = map[interface{}]interface{}{"deleted": 1, "errors": 0, "inserted": 0, "replaced": 0, "skipped": 0, "unchanged": 0, "changes": []interface{}{map[interface{}]interface{}{"new_val": nil, "old_val": map[interface{}]interface{}{"id": 1}}}}
 		/* tbl.delete(return_changes=True) */
 
 		suite.T().Log("About to run line #90: tbl.Delete().OptArgs(r.DeleteOpts{ReturnChanges: true, })")

--- a/internal/integration/reql_tests/reql_mutation_delete_test.go
+++ b/internal/integration/reql_tests/reql_mutation_delete_test.go
@@ -70,7 +70,7 @@ func (suite *MutationDeleteSuite) TestCases() {
 	{
 		// mutation/delete.yaml line #7
 		/* ({'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':100}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 100}
 		/* tbl.insert([{'id':i} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #7: tbl.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, })\n    }\n    return res\n}()))")
@@ -92,7 +92,7 @@ func (suite *MutationDeleteSuite) TestCases() {
 	{
 		// mutation/delete.yaml line #19
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #19: tbl.Count()")
@@ -107,7 +107,7 @@ func (suite *MutationDeleteSuite) TestCases() {
 	{
 		// mutation/delete.yaml line #24
 		/* ({'deleted':1,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 1, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 1, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
 		/* tbl.get(12).delete() */
 
 		suite.T().Log("About to run line #24: tbl.Get(12).Delete()")
@@ -122,7 +122,7 @@ func (suite *MutationDeleteSuite) TestCases() {
 	{
 		// mutation/delete.yaml line #31
 		/* err('ReqlQueryLogicError', 'Durability option `wrong` unrecognized (options are "hard" and "soft").', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Durability option `wrong` unrecognized (options are \"hard\" and \"soft\").")
+		var expected_ = err("ReqlQueryLogicError", "Durability option `wrong` unrecognized (options are \"hard\" and \"soft\").")
 		/* tbl.skip(50).delete(durability='wrong') */
 
 		suite.T().Log("About to run line #31: tbl.Skip(50).Delete().OptArgs(r.DeleteOpts{Durability: 'wrong', })")
@@ -137,7 +137,7 @@ func (suite *MutationDeleteSuite) TestCases() {
 	{
 		// mutation/delete.yaml line #38
 		/* ({'deleted':49,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 49, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 49, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
 		/* tbl.skip(50).delete(durability='soft') */
 
 		suite.T().Log("About to run line #38: tbl.Skip(50).Delete().OptArgs(r.DeleteOpts{Durability: 'soft', })")
@@ -152,7 +152,7 @@ func (suite *MutationDeleteSuite) TestCases() {
 	{
 		// mutation/delete.yaml line #45
 		/* ({'deleted':50,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 50, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 50, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
 		/* tbl.delete(durability='hard') */
 
 		suite.T().Log("About to run line #45: tbl.Delete().OptArgs(r.DeleteOpts{Durability: 'hard', })")
@@ -167,7 +167,7 @@ func (suite *MutationDeleteSuite) TestCases() {
 	{
 		// mutation/delete.yaml line #49
 		/* err('ReqlQueryLogicError', 'Expected type SELECTION but found DATUM:', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type SELECTION but found DATUM:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type SELECTION but found DATUM:")
 		/* r.expr([1, 2]).delete() */
 
 		suite.T().Log("About to run line #49: r.Expr([]interface{}{1, 2}).Delete()")

--- a/internal/integration/reql_tests/reql_mutation_insert_test.go
+++ b/internal/integration/reql_tests/reql_mutation_insert_test.go
@@ -70,7 +70,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #6
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.db('test').table_create('test2') */
 
 		suite.T().Log("About to run line #6: r.DB('test').TableCreate('test2')")
@@ -92,7 +92,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #12
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tbl.insert({'id':0,'a':0}) */
 
 		suite.T().Log("About to run line #12: tbl.Insert(map[interface{}]interface{}{'id': 0, 'a': 0, })")
@@ -107,7 +107,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #14
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #14: tbl.Count()")
@@ -122,7 +122,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #18
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tbl.insert({'id':1, 'a':1}, durability='hard') */
 
 		suite.T().Log("About to run line #18: tbl.Insert(map[interface{}]interface{}{'id': 1, 'a': 1, }).OptArgs(r.InsertOpts{Durability: 'hard', })")
@@ -137,7 +137,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #22
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #22: tbl.Count()")
@@ -152,7 +152,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #26
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tbl.insert({'id':2, 'a':2}, durability='soft') */
 
 		suite.T().Log("About to run line #26: tbl.Insert(map[interface{}]interface{}{'id': 2, 'a': 2, }).OptArgs(r.InsertOpts{Durability: 'soft', })")
@@ -167,7 +167,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #30
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #30: tbl.Count()")
@@ -182,7 +182,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #34
 		/* err('ReqlQueryLogicError', 'Durability option `wrong` unrecognized (options are "hard" and "soft").', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Durability option `wrong` unrecognized (options are \"hard\" and \"soft\").")
+		var expected_ = err("ReqlQueryLogicError", "Durability option `wrong` unrecognized (options are \"hard\" and \"soft\").")
 		/* tbl.insert({'id':3, 'a':3}, durability='wrong') */
 
 		suite.T().Log("About to run line #34: tbl.Insert(map[interface{}]interface{}{'id': 3, 'a': 3, }).OptArgs(r.InsertOpts{Durability: 'wrong', })")
@@ -197,7 +197,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #38
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #38: tbl.Count()")
@@ -212,7 +212,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #42
 		/* {'deleted':1,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 1, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 1, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
 		/* tbl.get(2).delete() */
 
 		suite.T().Log("About to run line #42: tbl.Get(2).Delete()")
@@ -227,7 +227,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #46
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':2} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 2}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 2}
 		/* tbl.insert([{'id':2,'a':2}, {'id':3,'a':3}]) */
 
 		suite.T().Log("About to run line #46: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 2, 'a': 2, }, map[interface{}]interface{}{'id': 3, 'a': 3, }})")
@@ -242,7 +242,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #50
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':4} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 4}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 4}
 		/* tbl2.insert(tbl) */
 
 		suite.T().Log("About to run line #50: tbl2.Insert(tbl)")
@@ -257,7 +257,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #54
 		/* {'first_error':"Duplicate primary key `id`:\n{\n\t\"a\":\t2,\n\t\"id\":\t2\n}\n{\n\t\"b\":\t20,\n\t\"id\":\t2\n}",'deleted':0,'replaced':0,'unchanged':0,'errors':1,'skipped':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"a\":\t2,\n\t\"id\":\t2\n}\n{\n\t\"b\":\t20,\n\t\"id\":\t2\n}", "deleted": 0, "replaced": 0, "unchanged": 0, "errors": 1, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"a\":\t2,\n\t\"id\":\t2\n}\n{\n\t\"b\":\t20,\n\t\"id\":\t2\n}", "deleted": 0, "replaced": 0, "unchanged": 0, "errors": 1, "skipped": 0, "inserted": 0}
 		/* tbl.insert({'id':2,'b':20}) */
 
 		suite.T().Log("About to run line #54: tbl.Insert(map[interface{}]interface{}{'id': 2, 'b': 20, })")
@@ -272,7 +272,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #58
 		/* {'first_error':"Duplicate primary key `id`:\n{\n\t\"a\":\t2,\n\t\"id\":\t2\n}\n{\n\t\"b\":\t20,\n\t\"id\":\t2\n}",'deleted':0,'replaced':0,'unchanged':0,'errors':1,'skipped':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"a\":\t2,\n\t\"id\":\t2\n}\n{\n\t\"b\":\t20,\n\t\"id\":\t2\n}", "deleted": 0, "replaced": 0, "unchanged": 0, "errors": 1, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"first_error": "Duplicate primary key `id`:\n{\n\t\"a\":\t2,\n\t\"id\":\t2\n}\n{\n\t\"b\":\t20,\n\t\"id\":\t2\n}", "deleted": 0, "replaced": 0, "unchanged": 0, "errors": 1, "skipped": 0, "inserted": 0}
 		/* tbl.insert({'id':2,'b':20}, conflict='error') */
 
 		suite.T().Log("About to run line #58: tbl.Insert(map[interface{}]interface{}{'id': 2, 'b': 20, }).OptArgs(r.InsertOpts{Conflict: 'error', })")
@@ -287,7 +287,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #64
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tbl.insert({'id':15,'b':20}, conflict='error') */
 
 		suite.T().Log("About to run line #64: tbl.Insert(map[interface{}]interface{}{'id': 15, 'b': 20, }).OptArgs(r.InsertOpts{Conflict: 'error', })")
@@ -302,7 +302,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #69
 		/* {'id':15,'b':20} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 15, "b": 20}
+		var expected_ = map[interface{}]interface{}{"id": 15, "b": 20}
 		/* tbl.get(15) */
 
 		suite.T().Log("About to run line #69: tbl.Get(15)")
@@ -317,7 +317,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #73
 		/* {'deleted':0,'replaced':1,'unchanged':0,'errors':0,'skipped':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 1, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 1, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
 		/* tbl.insert({'id':2,'b':20}, conflict='replace') */
 
 		suite.T().Log("About to run line #73: tbl.Insert(map[interface{}]interface{}{'id': 2, 'b': 20, }).OptArgs(r.InsertOpts{Conflict: 'replace', })")
@@ -332,7 +332,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #78
 		/* {'id':2,'b':20} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 2, "b": 20}
+		var expected_ = map[interface{}]interface{}{"id": 2, "b": 20}
 		/* tbl.get(2) */
 
 		suite.T().Log("About to run line #78: tbl.Get(2)")
@@ -347,7 +347,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #82
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tbl.insert({'id':20,'b':20}, conflict='replace') */
 
 		suite.T().Log("About to run line #82: tbl.Insert(map[interface{}]interface{}{'id': 20, 'b': 20, }).OptArgs(r.InsertOpts{Conflict: 'replace', })")
@@ -362,7 +362,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #87
 		/* {'id':20,'b':20} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 20, "b": 20}
+		var expected_ = map[interface{}]interface{}{"id": 20, "b": 20}
 		/* tbl.get(20) */
 
 		suite.T().Log("About to run line #87: tbl.Get(20)")
@@ -377,7 +377,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #91
 		/* {'deleted':0,'replaced':1,'unchanged':0,'errors':0,'skipped':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 1, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 1, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 0}
 		/* tbl.insert({'id':2,'c':30}, conflict='update') */
 
 		suite.T().Log("About to run line #91: tbl.Insert(map[interface{}]interface{}{'id': 2, 'c': 30, }).OptArgs(r.InsertOpts{Conflict: 'update', })")
@@ -392,7 +392,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #96
 		/* {'id':2, 'b':20, 'c':30} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 2, "b": 20, "c": 30}
+		var expected_ = map[interface{}]interface{}{"id": 2, "b": 20, "c": 30}
 		/* tbl.get(2) */
 
 		suite.T().Log("About to run line #96: tbl.Get(2)")
@@ -407,7 +407,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #100
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tbl.insert({'id':30,'b':20}, conflict='update') */
 
 		suite.T().Log("About to run line #100: tbl.Insert(map[interface{}]interface{}{'id': 30, 'b': 20, }).OptArgs(r.InsertOpts{Conflict: 'update', })")
@@ -422,7 +422,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #105
 		/* {'id':30,'b':20} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 30, "b": 20}
+		var expected_ = map[interface{}]interface{}{"id": 30, "b": 20}
 		/* tbl.get(30) */
 
 		suite.T().Log("About to run line #105: tbl.Get(30)")
@@ -437,7 +437,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #109
 		/* err('ReqlQueryLogicError', 'Conflict option `wrong` unrecognized (options are "error", "replace" and "update").', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Conflict option `wrong` unrecognized (options are \"error\", \"replace\" and \"update\").")
+		var expected_ = err("ReqlQueryLogicError", "Conflict option `wrong` unrecognized (options are \"error\", \"replace\" and \"update\").")
 		/* tbl.insert({'id':3, 'a':3}, conflict='wrong') */
 
 		suite.T().Log("About to run line #109: tbl.Insert(map[interface{}]interface{}{'id': 3, 'a': 3, }).OptArgs(r.InsertOpts{Conflict: 'wrong', })")
@@ -459,7 +459,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #115
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.db('test').table_create('testpkey', primary_key='foo') */
 
 		suite.T().Log("About to run line #115: r.DB('test').TableCreate('testpkey').OptArgs(r.TableCreateOpts{PrimaryKey: 'foo', })")
@@ -474,7 +474,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #122
 		/* {'deleted':0,'replaced':0,'generated_keys':arrlen(1,uuid()),'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tblpkey.insert({}) */
 
 		suite.T().Log("About to run line #122: tblpkey.Insert(map[interface{}]interface{}{})")
@@ -489,7 +489,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #125
 		/* [{'foo':uuid()}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"foo": compare.IsUUID()}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"foo": compare.IsUUID()}}
 		/* tblpkey */
 
 		suite.T().Log("About to run line #125: tblpkey")
@@ -504,7 +504,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #129
 		/* {'deleted':0,'replaced':0,'generated_keys':arrlen(1,uuid()),'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tblpkey.insert({'b':20}, conflict='replace') */
 
 		suite.T().Log("About to run line #129: tblpkey.Insert(map[interface{}]interface{}{'b': 20, }).OptArgs(r.InsertOpts{Conflict: 'replace', })")
@@ -519,7 +519,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #135
 		/* {'deleted':0,'replaced':0,'generated_keys':arrlen(1,uuid()),'unchanged':0,'errors':0,'skipped':0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "generated_keys": arrlen(1, compare.IsUUID()), "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 1}
 		/* tblpkey.insert({'b':20}, conflict='update') */
 
 		suite.T().Log("About to run line #135: tblpkey.Insert(map[interface{}]interface{}{'b': 20, }).OptArgs(r.InsertOpts{Conflict: 'update', })")
@@ -534,7 +534,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #140
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* r.db('test').table_drop('testpkey') */
 
 		suite.T().Log("About to run line #140: r.DB('test').TableDrop('testpkey')")
@@ -549,7 +549,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #144
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':7} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 7}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 7}
 		/* tbl.for_each(lambda  row:          tbl2.insert(row.merge({'id':row['id']  +  100 }))   ) */
 
 		suite.T().Log("About to run line #144: tbl.ForEach(func(row r.Term) interface{} { return tbl2.Insert(row.Merge(map[interface{}]interface{}{'id': row.AtIndex('id').Add(100), }))})")
@@ -566,7 +566,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #150
 		/* partial({'errors':1,'first_error':'`r.minval` and `r.maxval` cannot be written to disk.'}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 1, "first_error": "`r.minval` and `r.maxval` cannot be written to disk."})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 1, "first_error": "`r.minval` and `r.maxval` cannot be written to disk."})
 		/* tbl.insert({'value':r.minval}) */
 
 		suite.T().Log("About to run line #150: tbl.Insert(map[interface{}]interface{}{'value': r.MinVal, })")
@@ -581,7 +581,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #154
 		/* partial({'errors':1,'first_error':'`r.minval` and `r.maxval` cannot be written to disk.'}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"errors": 1, "first_error": "`r.minval` and `r.maxval` cannot be written to disk."})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"errors": 1, "first_error": "`r.minval` and `r.maxval` cannot be written to disk."})
 		/* tbl.insert({'value':r.maxval}) */
 
 		suite.T().Log("About to run line #154: tbl.Insert(map[interface{}]interface{}{'value': r.MaxVal, })")
@@ -596,7 +596,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #159
 		/* {'changes': [{'new_val': {'id': 666}, 'old_val': None},{'error': 'Duplicate primary key `id`:\n{\n\t"id":\t666\n}\n{\n\t"id":\t666\n}','new_val': {'id': 666},'old_val': {'id': 666}}],'deleted': 0,'errors': 1,'first_error': 'Duplicate primary key `id`:\n{\n\t"id":\t666\n}\n{\n\t"id":\t666\n}','inserted': 1,'replaced': 0,'skipped': 0,'unchanged': 0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 666}, "old_val": nil}, map[interface{}]interface{}{"error": "Duplicate primary key `id`:\n{\n\t\"id\":\t666\n}\n{\n\t\"id\":\t666\n}", "new_val": map[interface{}]interface{}{"id": 666}, "old_val": map[interface{}]interface{}{"id": 666}}}, "deleted": 0, "errors": 1, "first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t666\n}\n{\n\t\"id\":\t666\n}", "inserted": 1, "replaced": 0, "skipped": 0, "unchanged": 0}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 666}, "old_val": nil}, map[interface{}]interface{}{"error": "Duplicate primary key `id`:\n{\n\t\"id\":\t666\n}\n{\n\t\"id\":\t666\n}", "new_val": map[interface{}]interface{}{"id": 666}, "old_val": map[interface{}]interface{}{"id": 666}}}, "deleted": 0, "errors": 1, "first_error": "Duplicate primary key `id`:\n{\n\t\"id\":\t666\n}\n{\n\t\"id\":\t666\n}", "inserted": 1, "replaced": 0, "skipped": 0, "unchanged": 0}
 		/* tbl.insert([{'id':666}, {'id':666}], return_changes="always") */
 
 		suite.T().Log("About to run line #159: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 666, }, map[interface{}]interface{}{'id': 666, }}).OptArgs(r.InsertOpts{ReturnChanges: 'always', })")
@@ -611,7 +611,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #163
 		/* partial({'changes':[{'old_val': None, 'new_val': {'id': 100+i, 'ordered-num': i}} for i in range(1,100)] }) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
 			res := []interface{}{}
 			for iterator_ := 1; iterator_ < 100; iterator_++ {
 				i := iterator_
@@ -640,7 +640,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #167
 		/* partial({'changes':[{'old_val': None, 'new_val': {'id': [1,"blah", 200+i], 'ordered-num': i}} for i in range(1,100)] }) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
 			res := []interface{}{}
 			for iterator_ := 1; iterator_ < 100; iterator_++ {
 				i := iterator_
@@ -669,7 +669,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #171
 		/* partial({'changes':[{'old_val': None, 'new_val': {'id': [1,"blah", 300+i], 'ordered-num': i}} for i in range(1,100)] }) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
 			res := []interface{}{}
 			for iterator_ := 1; iterator_ < 100; iterator_++ {
 				i := iterator_
@@ -698,7 +698,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #175
 		/* partial({'changes':[{'old_val': {'id':100+i, 'ordered-num':i}, 'new_val': {'id':100+i, 'ordered-num':i}, 'error':'Duplicate primary key `id`:\n{\n\t"id":\t'+str(100+i)+',\n\t"ordered-num":\t'+str(i)+'\n}\n{\n\t"id":\t'+str(100+i)+',\n\t"ordered-num":\t'+str(i)+'\n}'} for i in range(1,100)]}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"changes": (func() []interface{} {
 			res := []interface{}{}
 			for iterator_ := 1; iterator_ < 100; iterator_++ {
 				i := iterator_
@@ -727,7 +727,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #179
 		/* {'changes': [{'error': 'Duplicate primary key `id`:\n{\n\t"id":\t123,\n\t"ordered-num":\t23\n}\n{\n\t"id":\t123\n}', 'new_val': {'id': 123, 'ordered-num': 23}, 'old_val': {'id': 123, 'ordered-num': 23}}, {'error': 'Primary key too long (max 127 characters): "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"', 'new_val': None, 'old_val': None}, {'new_val': {'id': 321}, 'old_val': None}], 'deleted': 0, 'errors': 2, 'first_error': 'Primary key too long (max 127 characters): "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"', 'inserted': 1, 'replaced': 0, 'skipped': 0, 'unchanged': 0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"error": "Duplicate primary key `id`:\n{\n\t\"id\":\t123,\n\t\"ordered-num\":\t23\n}\n{\n\t\"id\":\t123\n}", "new_val": map[interface{}]interface{}{"id": 123, "ordered-num": 23}, "old_val": map[interface{}]interface{}{"id": 123, "ordered-num": 23}}, map[interface{}]interface{}{"error": "Primary key too long (max 127 characters): \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"", "new_val": nil, "old_val": nil}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 321}, "old_val": nil}}, "deleted": 0, "errors": 2, "first_error": "Primary key too long (max 127 characters): \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"", "inserted": 1, "replaced": 0, "skipped": 0, "unchanged": 0}
+		var expected_ = map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"error": "Duplicate primary key `id`:\n{\n\t\"id\":\t123,\n\t\"ordered-num\":\t23\n}\n{\n\t\"id\":\t123\n}", "new_val": map[interface{}]interface{}{"id": 123, "ordered-num": 23}, "old_val": map[interface{}]interface{}{"id": 123, "ordered-num": 23}}, map[interface{}]interface{}{"error": "Primary key too long (max 127 characters): \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"", "new_val": nil, "old_val": nil}, map[interface{}]interface{}{"new_val": map[interface{}]interface{}{"id": 321}, "old_val": nil}}, "deleted": 0, "errors": 2, "first_error": "Primary key too long (max 127 characters): \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"", "inserted": 1, "replaced": 0, "skipped": 0, "unchanged": 0}
 		/* tbl.insert([{'id':123}, {'id':'a'*500}, {'id':321}], return_changes="always") */
 
 		suite.T().Log("About to run line #179: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 123, }, map[interface{}]interface{}{'id': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', }, map[interface{}]interface{}{'id': 321, }}).OptArgs(r.InsertOpts{ReturnChanges: 'always', })")
@@ -742,7 +742,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #183
 		/* partial({'changes':[]}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"changes": []interface{}{}})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"changes": []interface{}{}})
 		/* tbl.insert([{'id':100 + i, 'ordered-num':i} for i in range(1,100)], return_changes=true) */
 
 		suite.T().Log("About to run line #183: tbl.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 1; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': r.Add(100, i), 'ordered-num': i, })\n    }\n    return res\n}())).OptArgs(r.InsertOpts{ReturnChanges: true, })")
@@ -764,7 +764,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #186
 		/* partial({'changes': [{'old_val': None, 'new_val': None, 'error': '`r.minval` and `r.maxval` cannot be written to disk.'}]}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": nil, "error": "`r.minval` and `r.maxval` cannot be written to disk."}}})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"changes": []interface{}{map[interface{}]interface{}{"old_val": nil, "new_val": nil, "error": "`r.minval` and `r.maxval` cannot be written to disk."}}})
 		/* tbl.insert({'a':r.minval}, return_changes="always") */
 
 		suite.T().Log("About to run line #186: tbl.Insert(map[interface{}]interface{}{'a': r.MinVal, }).OptArgs(r.InsertOpts{ReturnChanges: 'always', })")
@@ -779,7 +779,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #192
 		/* partial({'inserted':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"inserted": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"inserted": 1})
 		/* tbl.insert({'id':42, 'foo':1, 'bar':1}) */
 
 		suite.T().Log("About to run line #192: tbl.Insert(map[interface{}]interface{}{'id': 42, 'foo': 1, 'bar': 1, })")
@@ -794,7 +794,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #194
 		/* partial({'replaced':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"replaced": 1})
 		/* tbl.insert({'id':42, 'foo':5, 'bar':5}, conflict=lambda id, old_row, new_row: old_row.merge(new_row.pluck("bar"))) */
 
 		suite.T().Log("About to run line #194: tbl.Insert(map[interface{}]interface{}{'id': 42, 'foo': 5, 'bar': 5, }).OptArgs(r.InsertOpts{Conflict: func(id r.Term, old_row r.Term, new_row r.Term) interface{} { return old_row.Merge(new_row.Pluck('bar'))}, })")
@@ -811,7 +811,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #196
 		/* {'id':42, 'foo':1, 'bar':5} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 42, "foo": 1, "bar": 5}
+		var expected_ = map[interface{}]interface{}{"id": 42, "foo": 1, "bar": 5}
 		/* tbl.get(42) */
 
 		suite.T().Log("About to run line #196: tbl.Get(42)")
@@ -826,7 +826,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #214
 		/* partial({'first_error': 'Inserted value must be an OBJECT (got NUMBER):\n2'}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"first_error": "Inserted value must be an OBJECT (got NUMBER):\n2"})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"first_error": "Inserted value must be an OBJECT (got NUMBER):\n2"})
 		/* tbl.insert({'id':42, 'foo':1, 'bar':1}, conflict=lambda a,b,c: 2) */
 
 		suite.T().Log("About to run line #214: tbl.Insert(map[interface{}]interface{}{'id': 42, 'foo': 1, 'bar': 1, }).OptArgs(r.InsertOpts{Conflict: func(a r.Term, b r.Term, c r.Term) interface{} { return 2}, })")
@@ -841,7 +841,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #218
 		/* err("ReqlQueryLogicError", "The conflict function passed to `insert` should expect 3 arguments.") */
-		var expected_ Err = err("ReqlQueryLogicError", "The conflict function passed to `insert` should expect 3 arguments.")
+		var expected_ = err("ReqlQueryLogicError", "The conflict function passed to `insert` should expect 3 arguments.")
 		/* tbl.insert({'id':42}, conflict=lambda a,b: a) */
 
 		suite.T().Log("About to run line #218: tbl.Insert(map[interface{}]interface{}{'id': 42, }).OptArgs(r.InsertOpts{Conflict: func(a r.Term, b r.Term) interface{} { return a}, })")
@@ -856,7 +856,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #222
 		/* err("ReqlQueryLogicError", "The conflict function passed to `insert` must be deterministic.") */
-		var expected_ Err = err("ReqlQueryLogicError", "The conflict function passed to `insert` must be deterministic.")
+		var expected_ = err("ReqlQueryLogicError", "The conflict function passed to `insert` must be deterministic.")
 		/* tbl.insert({'id':42}, conflict=lambda a,b,c: tbl.get(42)) */
 
 		suite.T().Log("About to run line #222: tbl.Insert(map[interface{}]interface{}{'id': 42, }).OptArgs(r.InsertOpts{Conflict: func(a r.Term, b r.Term, c r.Term) interface{} { return tbl.Get(42)}, })")
@@ -871,7 +871,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #225
 		/* partial({'replaced': 1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"replaced": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"replaced": 1})
 		/* tbl.insert({'id':42}, conflict=lambda a,b,c: {'id':42, 'num':'424'}) */
 
 		suite.T().Log("About to run line #225: tbl.Insert(map[interface{}]interface{}{'id': 42, }).OptArgs(r.InsertOpts{Conflict: func(a r.Term, b r.Term, c r.Term) interface{} { return map[interface{}]interface{}{'id': 42, 'num': '424', }}, })")
@@ -888,7 +888,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #227
 		/* {'id':42, 'num':'424'} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 42, "num": "424"}
+		var expected_ = map[interface{}]interface{}{"id": 42, "num": "424"}
 		/* tbl.get(42) */
 
 		suite.T().Log("About to run line #227: tbl.Get(42)")
@@ -903,7 +903,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #231
 		/* err('ReqlQueryLogicError','Cannot convert `r.minval` to JSON.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert `r.minval` to JSON.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert `r.minval` to JSON.")
 		/* r.minval */
 
 		suite.T().Log("About to run line #231: r.MinVal")
@@ -918,7 +918,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #234
 		/* err('ReqlQueryLogicError','Cannot convert `r.maxval` to JSON.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert `r.maxval` to JSON.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert `r.maxval` to JSON.")
 		/* r.maxval */
 
 		suite.T().Log("About to run line #234: r.MaxVal")
@@ -933,7 +933,7 @@ func (suite *MutationInsertSuite) TestCases() {
 	{
 		// mutation/insert.yaml line #238
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* r.db('test').table_drop('test2') */
 
 		suite.T().Log("About to run line #238: r.DB('test').TableDrop('test2')")

--- a/internal/integration/reql_tests/reql_mutation_replace_test.go
+++ b/internal/integration/reql_tests/reql_mutation_replace_test.go
@@ -70,7 +70,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #7
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl.insert([{'id':i} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #7: tbl.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, })\n    }\n    return res\n}()))")
@@ -92,7 +92,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #19
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #19: tbl.Count()")
@@ -107,7 +107,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #24
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':1,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(12).replace(lambda row:{'id':row['id']}) */
 
 		suite.T().Log("About to run line #24: tbl.Get(12).Replace(func(row r.Term) interface{} { return map[interface{}]interface{}{'id': row.AtIndex('id'), }})")
@@ -122,7 +122,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #31
 		/* ({'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(12).replace(lambda row:{'id':row['id'], 'a':row['id']}) */
 
 		suite.T().Log("About to run line #31: tbl.Get(12).Replace(func(row r.Term) interface{} { return map[interface{}]interface{}{'id': row.AtIndex('id'), 'a': row.AtIndex('id'), }})")
@@ -139,7 +139,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #36
 		/* ({'deleted':1,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 1, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 1, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(13).replace(lambda row:null) */
 
 		suite.T().Log("About to run line #36: tbl.Get(13).Replace(func(row r.Term) interface{} { return nil})")
@@ -154,7 +154,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #43
 		/* ({'first_error':'Inserted object must have primary key `id`:\n{\n\t\"a\":\t1\n}','deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':10,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Inserted object must have primary key `id`:\n{\n\t\"a\":\t1\n}", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 10, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"first_error": "Inserted object must have primary key `id`:\n{\n\t\"a\":\t1\n}", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 10, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.between(10, 20, right_bound='closed').replace(lambda row:{'a':1}) */
 
 		suite.T().Log("About to run line #43: tbl.Between(10, 20).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Replace(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': 1, }})")
@@ -169,7 +169,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #47
 		/* ({'deleted':0.0,'replaced':8,'unchanged':1,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 8, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 8, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.filter(lambda row:(row['id'] >= 10) & (row['id'] < 20)).replace(lambda row:{'id':row['id'], 'a':row['id']}) */
 
 		suite.T().Log("About to run line #47: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('id').Ge(10).And(row.AtIndex('id').Lt(20))}).Replace(func(row r.Term) interface{} { return map[interface{}]interface{}{'id': row.AtIndex('id'), 'a': row.AtIndex('id'), }})")
@@ -186,7 +186,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #56
 		/* ({'first_error':"Primary key `id` cannot be changed (`{\n\t\"id\":\t1\n}` -> `{\n\t\"a\":\t1,\n\t\"id\":\t2\n}`).",'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':1,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Primary key `id` cannot be changed (`{\n\t\"id\":\t1\n}` -> `{\n\t\"a\":\t1,\n\t\"id\":\t2\n}`).", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 1, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"first_error": "Primary key `id` cannot be changed (`{\n\t\"id\":\t1\n}` -> `{\n\t\"a\":\t1,\n\t\"id\":\t2\n}`).", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 1, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).replace({'id':2,'a':1}) */
 
 		suite.T().Log("About to run line #56: tbl.Get(1).Replace(map[interface{}]interface{}{'id': 2, 'a': 1, })")
@@ -201,7 +201,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #61
 		/* ({'first_error':"Inserted object must have primary key `id`:\n{\n\t\"a\":\t1\n}",'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':1,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Inserted object must have primary key `id`:\n{\n\t\"a\":\t1\n}", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 1, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"first_error": "Inserted object must have primary key `id`:\n{\n\t\"a\":\t1\n}", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 1, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).replace({'a':1}) */
 
 		suite.T().Log("About to run line #61: tbl.Get(1).Replace(map[interface{}]interface{}{'a': 1, })")
@@ -216,7 +216,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #65
 		/* ({'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).replace({'id':r.row['id'],'a':'b'}) */
 
 		suite.T().Log("About to run line #65: tbl.Get(1).Replace(map[interface{}]interface{}{'id': r.Row.AtIndex('id'), 'a': 'b', })")
@@ -231,7 +231,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #70
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':1,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).replace(r.row.merge({'a':'b'})) */
 
 		suite.T().Log("About to run line #70: tbl.Get(1).Replace(r.Row.Merge(map[interface{}]interface{}{'a': 'b', }))")
@@ -246,7 +246,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #75
 		/* err('ReqlQueryLogicError', 'Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
+		var expected_ = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
 		/* tbl.get(1).replace(r.row.merge({'c':r.js('5')})) */
 
 		suite.T().Log("About to run line #75: tbl.Get(1).Replace(r.Row.Merge(map[interface{}]interface{}{'c': r.JS('5'), }))")
@@ -261,7 +261,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #79
 		/* err('ReqlQueryLogicError', 'Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
+		var expected_ = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
 		/* tbl.get(1).replace(r.row.merge({'c':tbl.nth(0)})) */
 
 		suite.T().Log("About to run line #79: tbl.Get(1).Replace(r.Row.Merge(map[interface{}]interface{}{'c': tbl.Nth(0), }))")
@@ -276,7 +276,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #83
 		/* ({'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).replace(r.row.merge({'c':r.js('5')}), non_atomic=True) */
 
 		suite.T().Log("About to run line #83: tbl.Get(1).Replace(r.Row.Merge(map[interface{}]interface{}{'c': r.JS('5'), })).OptArgs(r.ReplaceOpts{NonAtomic: true, })")
@@ -291,7 +291,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #99
 		/* ({'deleted':99,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 99, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 99, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.replace(lambda row:null) */
 
 		suite.T().Log("About to run line #99: tbl.Replace(func(row r.Term) interface{} { return nil})")
@@ -306,7 +306,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #104
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get('sdfjk').replace({'id':'sdfjk'})['inserted'] */
 
 		suite.T().Log("About to run line #104: tbl.Get('sdfjk').Replace(map[interface{}]interface{}{'id': 'sdfjk', }).AtIndex('inserted')")
@@ -321,7 +321,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #107
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get('sdfjki').replace({'id':'sdfjk'})['errors'] */
 
 		suite.T().Log("About to run line #107: tbl.Get('sdfjki').Replace(map[interface{}]interface{}{'id': 'sdfjk', }).AtIndex('errors')")
@@ -336,7 +336,7 @@ func (suite *MutationReplaceSuite) TestCases() {
 	{
 		// mutation/replace.yaml line #111
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':1,'inserted':0.0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 1, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 1, "inserted": 0.0}
 		/* tbl.get('non-existent').replace(null) */
 
 		suite.T().Log("About to run line #111: tbl.Get('non-existent').Replace(nil)")

--- a/internal/integration/reql_tests/reql_mutation_sync_test.go
+++ b/internal/integration/reql_tests/reql_mutation_sync_test.go
@@ -61,7 +61,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #5
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.db('test').table_create('test1') */
 
 		suite.T().Log("About to run line #5: r.DB('test').TableCreate('test1')")
@@ -76,7 +76,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #7
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.db('test').table_create('test1soft') */
 
 		suite.T().Log("About to run line #7: r.DB('test').TableCreate('test1soft')")
@@ -91,7 +91,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #9
 		/* {'skipped':0, 'deleted':0, 'unchanged':0, 'errors':0, 'replaced':1, 'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"skipped": 0, "deleted": 0, "unchanged": 0, "errors": 0, "replaced": 1, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"skipped": 0, "deleted": 0, "unchanged": 0, "errors": 0, "replaced": 1, "inserted": 0}
 		/* r.db('test').table('test1soft').config().update({'durability':'soft'}) */
 
 		suite.T().Log("About to run line #9: r.DB('test').Table('test1soft').Config().Update(map[interface{}]interface{}{'durability': 'soft', })")
@@ -120,7 +120,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #13
 		/* partial({'created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"created": 1})
 		/* tbl.index_create('x') */
 
 		suite.T().Log("About to run line #13: tbl.IndexCreate('x')")
@@ -135,7 +135,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #15
 		/* [{'ready':True, 'index':'x'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"ready": true, "index": "x"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"ready": true, "index": "x"}}
 		/* tbl.index_wait('x').pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #15: tbl.IndexWait('x').Pluck('index', 'ready')")
@@ -150,7 +150,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #19
 		/* {'synced':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"synced": 1}
+		var expected_ = map[interface{}]interface{}{"synced": 1}
 		/* tbl.sync() */
 
 		suite.T().Log("About to run line #19: tbl.Sync()")
@@ -165,7 +165,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #21
 		/* {'synced':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"synced": 1}
+		var expected_ = map[interface{}]interface{}{"synced": 1}
 		/* tbl_soft.sync() */
 
 		suite.T().Log("About to run line #21: tbl_soft.Sync()")
@@ -180,7 +180,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #23
 		/* {'synced':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"synced": 1}
+		var expected_ = map[interface{}]interface{}{"synced": 1}
 		/* tbl.sync() */
 
 		suite.T().Log("About to run line #23: tbl.Sync()")
@@ -196,7 +196,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #27
 		/* {'synced':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"synced": 1}
+		var expected_ = map[interface{}]interface{}{"synced": 1}
 		/* tbl.sync() */
 
 		suite.T().Log("About to run line #27: tbl.Sync()")
@@ -212,7 +212,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #48
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* r.db('test').table_drop('test1') */
 
 		suite.T().Log("About to run line #48: r.DB('test').TableDrop('test1')")
@@ -227,7 +227,7 @@ func (suite *MutationSyncSuite) TestCases() {
 	{
 		// mutation/sync.yaml line #50
 		/* partial({'tables_dropped':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_dropped": 1})
 		/* r.db('test').table_drop('test1soft') */
 
 		suite.T().Log("About to run line #50: r.DB('test').TableDrop('test1soft')")

--- a/internal/integration/reql_tests/reql_mutation_update_test.go
+++ b/internal/integration/reql_tests/reql_mutation_update_test.go
@@ -78,7 +78,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #6
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl.insert([{'id':i} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #6: tbl.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, })\n    }\n    return res\n}()))")
@@ -100,7 +100,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #18
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #18: tbl.Count()")
@@ -115,7 +115,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #21
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl2.insert([{'id':i, 'foo':{'bar':i}} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #21: tbl2.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, 'foo': map[interface{}]interface{}{'bar': i, }, })\n    }\n    return res\n}()))")
@@ -137,7 +137,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #33
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl2.count() */
 
 		suite.T().Log("About to run line #33: tbl2.Count()")
@@ -152,7 +152,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #37
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':1,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(12).update(lambda row:row) */
 
 		suite.T().Log("About to run line #37: tbl.Get(12).Update(func(row r.Term) interface{} { return row})")
@@ -167,7 +167,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #43
 		/* {'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(12).update(lambda row:{'a':row['id'] + 1}, durability='soft') */
 
 		suite.T().Log("About to run line #43: tbl.Get(12).Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id').Add(1), }}).OptArgs(r.UpdateOpts{Durability: 'soft', })")
@@ -182,7 +182,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #48
 		/* {'id':12, 'a':13} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 12, "a": 13}
+		var expected_ = map[interface{}]interface{}{"id": 12, "a": 13}
 		/* tbl.get(12) */
 
 		suite.T().Log("About to run line #48: tbl.Get(12)")
@@ -197,7 +197,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #52
 		/* {'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(12).update(lambda row:{'a':row['id'] + 2}, durability='hard') */
 
 		suite.T().Log("About to run line #52: tbl.Get(12).Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id').Add(2), }}).OptArgs(r.UpdateOpts{Durability: 'hard', })")
@@ -212,7 +212,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #57
 		/* {'id':12, 'a':14} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 12, "a": 14}
+		var expected_ = map[interface{}]interface{}{"id": 12, "a": 14}
 		/* tbl.get(12) */
 
 		suite.T().Log("About to run line #57: tbl.Get(12)")
@@ -227,7 +227,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #61
 		/* err('ReqlQueryLogicError', 'Durability option `wrong` unrecognized (options are "hard" and "soft").', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Durability option `wrong` unrecognized (options are \"hard\" and \"soft\").")
+		var expected_ = err("ReqlQueryLogicError", "Durability option `wrong` unrecognized (options are \"hard\" and \"soft\").")
 		/* tbl.get(12).update(lambda row:{'a':row['id'] + 3}, durability='wrong') */
 
 		suite.T().Log("About to run line #61: tbl.Get(12).Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id').Add(3), }}).OptArgs(r.UpdateOpts{Durability: 'wrong', })")
@@ -242,7 +242,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #66
 		/* {'id':12, 'a':14} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 12, "a": 14}
+		var expected_ = map[interface{}]interface{}{"id": 12, "a": 14}
 		/* tbl.get(12) */
 
 		suite.T().Log("About to run line #66: tbl.Get(12)")
@@ -257,7 +257,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #70
 		/* {'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(12).update(lambda row:{'a':row['id']}) */
 
 		suite.T().Log("About to run line #70: tbl.Get(12).Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id'), }})")
@@ -272,7 +272,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #75
 		/* {'id':12, 'a':12} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 12, "a": 12}
+		var expected_ = map[interface{}]interface{}{"id": 12, "a": 12}
 		/* tbl.get(12) */
 
 		suite.T().Log("About to run line #75: tbl.Get(12)")
@@ -287,7 +287,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #79
 		/* {'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(12).update({'a':r.literal()}) */
 
 		suite.T().Log("About to run line #79: tbl.Get(12).Update(map[interface{}]interface{}{'a': r.Literal(), })")
@@ -302,7 +302,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #84
 		/* {'deleted':0.0,'replaced':10,'unchanged':0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 10, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 10, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.between(10, 20).update(lambda row:{'a':row['id']}) */
 
 		suite.T().Log("About to run line #84: tbl.Between(10, 20).Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id'), }})")
@@ -317,7 +317,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #89
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':10,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 10, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 10, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.filter(lambda row:(row['id'] >= 10) & (row['id'] < 20)).update(lambda row:{'a':row['id']}) */
 
 		suite.T().Log("About to run line #89: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('id').Ge(10).And(row.AtIndex('id').Lt(20))}).Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id'), }})")
@@ -332,7 +332,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #94
 		/* {'deleted':0.0,'replaced':10,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 10, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 10, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.filter(lambda row:(row['id'] >= 10) & (row['id'] < 20)).update(lambda row:{'b':row['id']}) */
 
 		suite.T().Log("About to run line #94: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('id').Ge(10).And(row.AtIndex('id').Lt(20))}).Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'b': row.AtIndex('id'), }})")
@@ -347,7 +347,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #100
 		/* {'deleted':0.0,'replaced':10,'unchanged':0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 10, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 10, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.between(10, 20).update({'a':r.literal()}) */
 
 		suite.T().Log("About to run line #100: tbl.Between(10, 20).Update(map[interface{}]interface{}{'a': r.Literal(), })")
@@ -362,7 +362,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #104
 		/* {'first_error':"Primary key `id` cannot be changed (`{\n\t\"id\":\t1\n}` -> `{\n\t\"d\":\t1,\n\t\"id\":\t2\n}`).",'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':1,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"first_error": "Primary key `id` cannot be changed (`{\n\t\"id\":\t1\n}` -> `{\n\t\"d\":\t1,\n\t\"id\":\t2\n}`).", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 1, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"first_error": "Primary key `id` cannot be changed (`{\n\t\"id\":\t1\n}` -> `{\n\t\"d\":\t1,\n\t\"id\":\t2\n}`).", "deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 1, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).update({'id':2,'d':1}) */
 
 		suite.T().Log("About to run line #104: tbl.Get(1).Update(map[interface{}]interface{}{'id': 2, 'd': 1, })")
@@ -377,7 +377,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #108
 		/* {'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).update({'id':r.row['id'],'d':'b'}) */
 
 		suite.T().Log("About to run line #108: tbl.Get(1).Update(map[interface{}]interface{}{'id': r.Row.AtIndex('id'), 'd': 'b', })")
@@ -392,7 +392,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #114
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':1,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).update(r.row.merge({'d':'b'})) */
 
 		suite.T().Log("About to run line #114: tbl.Get(1).Update(r.Row.Merge(map[interface{}]interface{}{'d': 'b', }))")
@@ -407,7 +407,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #119
 		/* err('ReqlQueryLogicError', 'Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
+		var expected_ = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
 		/* tbl.get(1).update({'d':r.js('5')}) */
 
 		suite.T().Log("About to run line #119: tbl.Get(1).Update(map[interface{}]interface{}{'d': r.JS('5'), })")
@@ -422,7 +422,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #122
 		/* err('ReqlQueryLogicError', 'Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
+		var expected_ = err("ReqlQueryLogicError", "Could not prove argument deterministic.  Maybe you want to use the non_atomic flag?")
 		/* tbl.get(1).update({'d':tbl.nth(0)}) */
 
 		suite.T().Log("About to run line #122: tbl.Get(1).Update(map[interface{}]interface{}{'d': tbl.Nth(0), })")
@@ -437,7 +437,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #125
 		/* {'deleted':0.0,'replaced':1,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 1, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.get(1).update({'d':r.js('5')}, non_atomic=True) */
 
 		suite.T().Log("About to run line #125: tbl.Get(1).Update(map[interface{}]interface{}{'d': r.JS('5'), }).OptArgs(r.UpdateOpts{NonAtomic: true, })")
@@ -452,7 +452,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #137
 		/* {'deleted':0.0,'replaced':100,'unchanged':0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.update(lambda row:{'a':row['id']}) */
 
 		suite.T().Log("About to run line #137: tbl.Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id'), }})")
@@ -467,7 +467,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #143
 		/* {'deleted':0.0,'replaced':100,'unchanged':0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl.update({'a':r.literal()}) */
 
 		suite.T().Log("About to run line #143: tbl.Update(map[interface{}]interface{}{'a': r.Literal(), })")
@@ -482,7 +482,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #147
 		/* {'deleted':0.0,'replaced':99,'unchanged':1,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 99, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 99, "unchanged": 1, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl2.update({'foo':{'bar':2}}) */
 
 		suite.T().Log("About to run line #147: tbl2.Update(map[interface{}]interface{}{'foo': map[interface{}]interface{}{'bar': 2, }, })")
@@ -497,7 +497,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #150
 		/* {'deleted':0.0,'replaced':0,'unchanged':100,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0, "unchanged": 100, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0, "unchanged": 100, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl2.update({'foo':r.literal({'bar':2})}) */
 
 		suite.T().Log("About to run line #150: tbl2.Update(map[interface{}]interface{}{'foo': r.Literal(map[interface{}]interface{}{'bar': 2, }), })")
@@ -512,7 +512,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #156
 		/* {'id':0,'foo':{'bar':2}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "foo": map[interface{}]interface{}{"bar": 2}}
+		var expected_ = map[interface{}]interface{}{"id": 0, "foo": map[interface{}]interface{}{"bar": 2}}
 		/* tbl2.order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #156: tbl2.OrderBy('id').Nth(0)")
@@ -527,7 +527,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #159
 		/* {'deleted':0.0,'replaced':100,'unchanged':0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl2.update({'foo':{'buzz':2}}) */
 
 		suite.T().Log("About to run line #159: tbl2.Update(map[interface{}]interface{}{'foo': map[interface{}]interface{}{'buzz': 2, }, })")
@@ -542,7 +542,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #162
 		/* {'id':0,'foo':{'bar':2,'buzz':2}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "foo": map[interface{}]interface{}{"bar": 2, "buzz": 2}}
+		var expected_ = map[interface{}]interface{}{"id": 0, "foo": map[interface{}]interface{}{"bar": 2, "buzz": 2}}
 		/* tbl2.order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #162: tbl2.OrderBy('id').Nth(0)")
@@ -557,7 +557,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #165
 		/* {'deleted':0.0,'replaced':100,'unchanged':0,'errors':0.0,'skipped':0.0,'inserted':0.0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 100, "unchanged": 0, "errors": 0.0, "skipped": 0.0, "inserted": 0.0}
 		/* tbl2.update({'foo':r.literal(1)}) */
 
 		suite.T().Log("About to run line #165: tbl2.Update(map[interface{}]interface{}{'foo': r.Literal(1), })")
@@ -572,7 +572,7 @@ func (suite *MutationUpdateSuite) TestCases() {
 	{
 		// mutation/update.yaml line #168
 		/* {'id':0,'foo':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "foo": 1}
+		var expected_ = map[interface{}]interface{}{"id": 0, "foo": 1}
 		/* tbl2.order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #168: tbl2.OrderBy('id').Nth(0)")

--- a/internal/integration/reql_tests/reql_polymorphism_test.go
+++ b/internal/integration/reql_tests/reql_polymorphism_test.go
@@ -77,7 +77,7 @@ func (suite *PolymorphismSuite) TestCases() {
 	{
 		// polymorphism.yaml line #7
 		/* ({'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':3}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 3}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 3}
 		/* tbl.insert([{'id':i, 'a':i} for i in xrange(3)]) */
 
 		suite.T().Log("About to run line #7: tbl.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 3; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, 'a': i, })\n    }\n    return res\n}()))")
@@ -99,7 +99,7 @@ func (suite *PolymorphismSuite) TestCases() {
 	{
 		// polymorphism.yaml line #21
 		/* ({'id':0,'c':1,'a':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "c": 1, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "c": 1, "a": 0}
 		/* tbl.merge({'c':1}).nth(0) */
 
 		suite.T().Log("About to run line #21: tbl.Merge(map[interface{}]interface{}{'c': 1, }).Nth(0)")
@@ -114,7 +114,7 @@ func (suite *PolymorphismSuite) TestCases() {
 	{
 		// polymorphism.yaml line #22
 		/* ({'id':0,'c':1,'a':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "c": 1, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "c": 1, "a": 0}
 		/* obj.merge({'c':1}) */
 
 		suite.T().Log("About to run line #22: obj.Merge(map[interface{}]interface{}{'c': 1, })")
@@ -129,7 +129,7 @@ func (suite *PolymorphismSuite) TestCases() {
 	{
 		// polymorphism.yaml line #26
 		/* ({'id':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl.without('a').nth(0) */
 
 		suite.T().Log("About to run line #26: tbl.Without('a').Nth(0)")
@@ -144,7 +144,7 @@ func (suite *PolymorphismSuite) TestCases() {
 	{
 		// polymorphism.yaml line #27
 		/* ({'id':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* obj.without('a') */
 
 		suite.T().Log("About to run line #27: obj.Without('a')")
@@ -159,7 +159,7 @@ func (suite *PolymorphismSuite) TestCases() {
 	{
 		// polymorphism.yaml line #31
 		/* ({'a':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0}
+		var expected_ = map[interface{}]interface{}{"a": 0}
 		/* tbl.pluck('a').nth(0) */
 
 		suite.T().Log("About to run line #31: tbl.Pluck('a').Nth(0)")
@@ -174,7 +174,7 @@ func (suite *PolymorphismSuite) TestCases() {
 	{
 		// polymorphism.yaml line #32
 		/* ({'a':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 0}
+		var expected_ = map[interface{}]interface{}{"a": 0}
 		/* obj.pluck('a') */
 
 		suite.T().Log("About to run line #32: obj.Pluck('a')")

--- a/internal/integration/reql_tests/reql_random_test.go
+++ b/internal/integration/reql_tests/reql_random_test.go
@@ -61,7 +61,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #5
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.expr([1,2,3]).sample(3).distinct().count() */
 
 		suite.T().Log("About to run line #5: r.Expr([]interface{}{1, 2, 3}).Sample(3).Distinct().Count()")
@@ -76,7 +76,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #7
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.expr([1,2,3]).sample(3).count() */
 
 		suite.T().Log("About to run line #7: r.Expr([]interface{}{1, 2, 3}).Sample(3).Count()")
@@ -91,7 +91,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #9
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.expr([1,2,3,4,5,6]).sample(3).distinct().count() */
 
 		suite.T().Log("About to run line #9: r.Expr([]interface{}{1, 2, 3, 4, 5, 6}).Sample(3).Distinct().Count()")
@@ -106,7 +106,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #11
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* r.expr([1,2,3]).sample(4).distinct().count() */
 
 		suite.T().Log("About to run line #11: r.Expr([]interface{}{1, 2, 3}).Sample(4).Distinct().Count()")
@@ -121,7 +121,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #15
 		/* err('ReqlQueryLogicError', 'Number of items to sample must be non-negative, got `-1`.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Number of items to sample must be non-negative, got `-1`.")
+		var expected_ = err("ReqlQueryLogicError", "Number of items to sample must be non-negative, got `-1`.")
 		/* r.expr([1,2,3]).sample(-1) */
 
 		suite.T().Log("About to run line #15: r.Expr([]interface{}{1, 2, 3}).Sample(-1)")
@@ -136,7 +136,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #17
 		/* err('ReqlQueryLogicError', 'Cannot convert NUMBER to SEQUENCE', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert NUMBER to SEQUENCE")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert NUMBER to SEQUENCE")
 		/* r.expr(1).sample(1) */
 
 		suite.T().Log("About to run line #17: r.Expr(1).Sample(1)")
@@ -151,7 +151,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #19
 		/* err('ReqlQueryLogicError', 'Cannot convert OBJECT to SEQUENCE', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert OBJECT to SEQUENCE")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert OBJECT to SEQUENCE")
 		/* r.expr({}).sample(1) */
 
 		suite.T().Log("About to run line #19: r.Expr(map[interface{}]interface{}{}).Sample(1)")
@@ -166,7 +166,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #25
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random().do(lambda x:r.and_(x.ge(0), x.lt(1))) */
 
 		suite.T().Log("About to run line #25: r.Random().Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(1))})")
@@ -181,7 +181,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #26
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(1, float=True).do(lambda x:r.and_(x.ge(0), x.lt(1))) */
 
 		suite.T().Log("About to run line #26: r.Random(1).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(1))})")
@@ -196,7 +196,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #27
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(0, 1, float=True).do(lambda x:r.and_(x.ge(0), x.lt(1))) */
 
 		suite.T().Log("About to run line #27: r.Random(0, 1).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(1))})")
@@ -211,7 +211,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #28
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(1, 0, float=True).do(lambda x:r.and_(x.le(1), x.gt(0))) */
 
 		suite.T().Log("About to run line #28: r.Random(1, 0).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(1), x.Gt(0))})")
@@ -226,7 +226,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #29
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(r.expr(0), 1, float=True).do(lambda x:r.and_(x.ge(0), x.lt(1))) */
 
 		suite.T().Log("About to run line #29: r.Random(r.Expr(0), 1).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(1))})")
@@ -241,7 +241,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #30
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(1, r.expr(0), float=True).do(lambda x:r.and_(x.le(1), x.gt(0))) */
 
 		suite.T().Log("About to run line #30: r.Random(1, r.Expr(0)).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(1), x.Gt(0))})")
@@ -256,7 +256,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #31
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(r.expr(1), r.expr(0), float=True).do(lambda x:r.and_(x.le(1), x.gt(0))) */
 
 		suite.T().Log("About to run line #31: r.Random(r.Expr(1), r.Expr(0)).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(1), x.Gt(0))})")
@@ -271,7 +271,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #36
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(0.495, float=True).do(lambda x:r.and_(x.ge(0), x.lt(0.495))) */
 
 		suite.T().Log("About to run line #36: r.Random(0.495).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(0.495))})")
@@ -286,7 +286,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #37
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-0.495, float=True).do(lambda x:r.and_(x.le(0), x.gt(-0.495))) */
 
 		suite.T().Log("About to run line #37: r.Random(-0.495).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(0), x.Gt(-0.495))})")
@@ -301,7 +301,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #38
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(1823756.24, float=True).do(lambda x:r.and_(x.ge(0), x.lt(1823756.24))) */
 
 		suite.T().Log("About to run line #38: r.Random(1823756.24).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(1823756.24))})")
@@ -316,7 +316,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #39
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-1823756.24, float=True).do(lambda x:r.and_(x.le(0), x.gt(-1823756.24))) */
 
 		suite.T().Log("About to run line #39: r.Random(-1823756.24).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(0), x.Gt(-1823756.24))})")
@@ -331,7 +331,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #44
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(10.5, 20.153, float=True).do(lambda x:r.and_(x.ge(10.5), x.lt(20.153))) */
 
 		suite.T().Log("About to run line #44: r.Random(10.5, 20.153).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(10.5), x.Lt(20.153))})")
@@ -346,7 +346,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #45
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(20.153, 10.5, float=True).do(lambda x:r.and_(x.le(20.153), x.gt(10.5))) */
 
 		suite.T().Log("About to run line #45: r.Random(20.153, 10.5).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(20.153), x.Gt(10.5))})")
@@ -361,7 +361,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #46
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(31415926.1, 31415926, float=True).do(lambda x:r.and_(x.le(31415926.1), x.gt(31415926))) */
 
 		suite.T().Log("About to run line #46: r.Random(31415926.1, 31415926).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(31415926.1), x.Gt(31415926))})")
@@ -376,7 +376,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #51
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-10.5, 20.153, float=True).do(lambda x:r.and_(x.ge(-10.5), x.lt(20.153))) */
 
 		suite.T().Log("About to run line #51: r.Random(-10.5, 20.153).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(-10.5), x.Lt(20.153))})")
@@ -391,7 +391,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #52
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-20.153, -10.5, float=True).do(lambda x:r.and_(x.ge(-20.153), x.lt(-10.5))) */
 
 		suite.T().Log("About to run line #52: r.Random(-20.153, -10.5).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(-20.153), x.Lt(-10.5))})")
@@ -406,7 +406,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #53
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-31415926, -31415926.1, float=True).do(lambda x:r.and_(x.le(-31415926), x.gt(-31415926.1))) */
 
 		suite.T().Log("About to run line #53: r.Random(-31415926, -31415926.1).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(-31415926), x.Gt(-31415926.1))})")
@@ -421,7 +421,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #58
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([r.random(), r.random()]).distinct().count() */
 
 		suite.T().Log("About to run line #58: r.Expr([]interface{}{r.Random(), r.Random()}).Distinct().Count()")
@@ -436,7 +436,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #59
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([r.random(1, float=True), r.random(1, float=True)]).distinct().count() */
 
 		suite.T().Log("About to run line #59: r.Expr([]interface{}{r.Random(1).OptArgs(r.RandomOpts{Float: true, }), r.Random(1).OptArgs(r.RandomOpts{Float: true, })}).Distinct().Count()")
@@ -451,7 +451,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #60
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([r.random(0, 1, float=True), r.random(0, 1, float=True)]).distinct().count() */
 
 		suite.T().Log("About to run line #60: r.Expr([]interface{}{r.Random(0, 1).OptArgs(r.RandomOpts{Float: true, }), r.Random(0, 1).OptArgs(r.RandomOpts{Float: true, })}).Distinct().Count()")
@@ -466,7 +466,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #65
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(0, float=True).eq(0) */
 
 		suite.T().Log("About to run line #65: r.Random(0).OptArgs(r.RandomOpts{Float: true, }).Eq(0)")
@@ -481,7 +481,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #66
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(5, 5, float=True).eq(5) */
 
 		suite.T().Log("About to run line #66: r.Random(5, 5).OptArgs(r.RandomOpts{Float: true, }).Eq(5)")
@@ -496,7 +496,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #67
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-499384756758, -499384756758, float=True).eq(-499384756758) */
 
 		suite.T().Log("About to run line #67: r.Random(-499384756758, -499384756758).OptArgs(r.RandomOpts{Float: true, }).Eq(-499384756758)")
@@ -511,7 +511,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #68
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-93.94757, -93.94757, float=True).eq(-93.94757) */
 
 		suite.T().Log("About to run line #68: r.Random(-93.94757, -93.94757).OptArgs(r.RandomOpts{Float: true, }).Eq(-93.94757)")
@@ -526,7 +526,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #69
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(294.69148, 294.69148, float=True).eq(294.69148) */
 
 		suite.T().Log("About to run line #69: r.Random(294.69148, 294.69148).OptArgs(r.RandomOpts{Float: true, }).Eq(294.69148)")
@@ -555,7 +555,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #82
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-float_max, float_max, float=True).do(lambda x:r.and_(x.ge(-float_max), x.lt(float_max))) */
 
 		suite.T().Log("About to run line #82: r.Random(-float_max, float_max).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(-float_max), x.Lt(float_max))})")
@@ -570,7 +570,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #83
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(float_max, -float_max, float=True).do(lambda x:r.and_(x.le(float_max), x.gt(-float_max))) */
 
 		suite.T().Log("About to run line #83: r.Random(float_max, -float_max).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(float_max), x.Gt(-float_max))})")
@@ -585,7 +585,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #84
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(float_min, float_max, float=True).do(lambda x:r.and_(x.ge(float_min), x.lt(float_max))) */
 
 		suite.T().Log("About to run line #84: r.Random(float_min, float_max).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(float_min), x.Lt(float_max))})")
@@ -600,7 +600,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #85
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(float_min, -float_max, float=True).do(lambda x:r.and_(x.le(float_min), x.gt(-float_max))) */
 
 		suite.T().Log("About to run line #85: r.Random(float_min, -float_max).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(float_min), x.Gt(-float_max))})")
@@ -615,7 +615,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #86
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-float_min, float_max, float=True).do(lambda x:r.and_(x.ge(-float_min), x.lt(float_max))) */
 
 		suite.T().Log("About to run line #86: r.Random(-float_min, float_max).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Ge(-float_min), x.Lt(float_max))})")
@@ -630,7 +630,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #87
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-float_min, -float_max, float=True).do(lambda x:r.and_(x.le(-float_min), x.gt(-float_max))) */
 
 		suite.T().Log("About to run line #87: r.Random(-float_min, -float_max).OptArgs(r.RandomOpts{Float: true, }).Do(func(x r.Term) interface{} { return r.And(x.Le(-float_min), x.Gt(-float_max))})")
@@ -659,7 +659,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #101
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(256).do(lambda x:r.and_(x.ge(0), x.lt(256))) */
 
 		suite.T().Log("About to run line #101: r.Random(256).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(256))})")
@@ -674,7 +674,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #102
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(0, 256).do(lambda x:r.and_(x.ge(0), x.lt(256))) */
 
 		suite.T().Log("About to run line #102: r.Random(0, 256).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(256))})")
@@ -689,7 +689,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #103
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(r.expr(256)).do(lambda x:r.and_(x.ge(0), x.lt(256))) */
 
 		suite.T().Log("About to run line #103: r.Random(r.Expr(256)).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(256))})")
@@ -704,7 +704,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #104
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(r.expr(0), 256).do(lambda x:r.and_(x.ge(0), x.lt(256))) */
 
 		suite.T().Log("About to run line #104: r.Random(r.Expr(0), 256).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(256))})")
@@ -719,7 +719,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #105
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(0, r.expr(256)).do(lambda x:r.and_(x.ge(0), x.lt(256))) */
 
 		suite.T().Log("About to run line #105: r.Random(0, r.Expr(256)).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(256))})")
@@ -734,7 +734,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #106
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(r.expr(0), r.expr(256)).do(lambda x:r.and_(x.ge(0), x.lt(256))) */
 
 		suite.T().Log("About to run line #106: r.Random(r.Expr(0), r.Expr(256)).Do(func(x r.Term) interface{} { return r.And(x.Ge(0), x.Lt(256))})")
@@ -749,7 +749,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #111
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(10, 20).do(lambda x:r.and_(x.ge(10), x.lt(20))) */
 
 		suite.T().Log("About to run line #111: r.Random(10, 20).Do(func(x r.Term) interface{} { return r.And(x.Ge(10), x.Lt(20))})")
@@ -764,7 +764,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #112
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(9347849, 120937493).do(lambda x:r.and_(x.ge(9347849), x.lt(120937493))) */
 
 		suite.T().Log("About to run line #112: r.Random(9347849, 120937493).Do(func(x r.Term) interface{} { return r.And(x.Ge(9347849), x.Lt(120937493))})")
@@ -779,7 +779,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #123
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-10, 20).do(lambda x:r.and_(x.ge(-10), x.lt(20))) */
 
 		suite.T().Log("About to run line #123: r.Random(-10, 20).Do(func(x r.Term) interface{} { return r.And(x.Ge(-10), x.Lt(20))})")
@@ -794,7 +794,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #124
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-20, -10).do(lambda x:r.and_(x.ge(-20), x.lt(-10))) */
 
 		suite.T().Log("About to run line #124: r.Random(-20, -10).Do(func(x r.Term) interface{} { return r.And(x.Ge(-20), x.Lt(-10))})")
@@ -809,7 +809,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #125
 		/* True */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.random(-120937493, -9347849).do(lambda x:r.and_(x.ge(-120937493), x.lt(-9347849))) */
 
 		suite.T().Log("About to run line #125: r.Random(-120937493, -9347849).Do(func(x r.Term) interface{} { return r.And(x.Ge(-120937493), x.Lt(-9347849))})")
@@ -824,7 +824,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #137
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([r.random(upper_limit), r.random(upper_limit)]).distinct().count() */
 
 		suite.T().Log("About to run line #137: r.Expr([]interface{}{r.Random(upper_limit), r.Random(upper_limit)}).Distinct().Count()")
@@ -839,7 +839,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #139
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([upper_limit,upper_limit]).map(lambda x:r.random(x)).distinct().count() */
 
 		suite.T().Log("About to run line #139: r.Expr([]interface{}{upper_limit, upper_limit}).Map(func(x r.Term) interface{} { return r.Random(x)}).Distinct().Count()")
@@ -854,7 +854,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #147
 		/* err("ReqlQueryLogicError", "Upper bound (-0.5) could not be safely converted to an integer.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Upper bound (-0.5) could not be safely converted to an integer.")
+		var expected_ = err("ReqlQueryLogicError", "Upper bound (-0.5) could not be safely converted to an integer.")
 		/* r.random(-0.5) */
 
 		suite.T().Log("About to run line #147: r.Random(-0.5)")
@@ -869,7 +869,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #149
 		/* err("ReqlQueryLogicError", "Upper bound (0.25) could not be safely converted to an integer.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Upper bound (0.25) could not be safely converted to an integer.")
+		var expected_ = err("ReqlQueryLogicError", "Upper bound (0.25) could not be safely converted to an integer.")
 		/* r.random(0.25) */
 
 		suite.T().Log("About to run line #149: r.Random(0.25)")
@@ -884,7 +884,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #151
 		/* err("ReqlQueryLogicError", "Upper bound (0.75) could not be safely converted to an integer.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Upper bound (0.75) could not be safely converted to an integer.")
+		var expected_ = err("ReqlQueryLogicError", "Upper bound (0.75) could not be safely converted to an integer.")
 		/* r.random(-10, 0.75) */
 
 		suite.T().Log("About to run line #151: r.Random(-10, 0.75)")
@@ -899,7 +899,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #153
 		/* err("ReqlQueryLogicError", "Lower bound (-120549.25) could not be safely converted to an integer.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (-120549.25) could not be safely converted to an integer.")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (-120549.25) could not be safely converted to an integer.")
 		/* r.random(-120549.25, 39458) */
 
 		suite.T().Log("About to run line #153: r.Random(-120549.25, 39458)")
@@ -914,7 +914,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #155
 		/* err("ReqlQueryLogicError", "Lower bound (-6.5) could not be safely converted to an integer.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (-6.5) could not be safely converted to an integer.")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (-6.5) could not be safely converted to an integer.")
 		/* r.random(-6.5, 8.125) */
 
 		suite.T().Log("About to run line #155: r.Random(-6.5, 8.125)")
@@ -929,7 +929,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #159
 		/* err("ReqlQueryLogicError", "Generating a random integer requires one or two bounds.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Generating a random integer requires one or two bounds.")
+		var expected_ = err("ReqlQueryLogicError", "Generating a random integer requires one or two bounds.")
 		/* r.random(float=False) */
 
 		suite.T().Log("About to run line #159: r.Random().OptArgs(r.RandomOpts{Float: false, })")
@@ -944,7 +944,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #165
 		/* err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (0).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (0).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (0).")
 		/* r.random(0) */
 
 		suite.T().Log("About to run line #165: r.Random(0)")
@@ -959,7 +959,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #167
 		/* err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (0).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (0).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (0).")
 		/* r.random(0, 0) */
 
 		suite.T().Log("About to run line #167: r.Random(0, 0)")
@@ -974,7 +974,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #169
 		/* err("ReqlQueryLogicError", "Lower bound (515) is not less than upper bound (515).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (515) is not less than upper bound (515).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (515) is not less than upper bound (515).")
 		/* r.random(515, 515) */
 
 		suite.T().Log("About to run line #169: r.Random(515, 515)")
@@ -989,7 +989,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #171
 		/* err("ReqlQueryLogicError", "Lower bound (-956) is not less than upper bound (-956).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (-956) is not less than upper bound (-956).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (-956) is not less than upper bound (-956).")
 		/* r.random(-956, -956) */
 
 		suite.T().Log("About to run line #171: r.Random(-956, -956)")
@@ -1004,7 +1004,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #173
 		/* err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (-10).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (-10).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (0) is not less than upper bound (-10).")
 		/* r.random(-10) */
 
 		suite.T().Log("About to run line #173: r.Random(-10)")
@@ -1019,7 +1019,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #175
 		/* err("ReqlQueryLogicError", "Lower bound (20) is not less than upper bound (2).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (20) is not less than upper bound (2).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (20) is not less than upper bound (2).")
 		/* r.random(20, 2) */
 
 		suite.T().Log("About to run line #175: r.Random(20, 2)")
@@ -1034,7 +1034,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #177
 		/* err("ReqlQueryLogicError", "Lower bound (2) is not less than upper bound (-20).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (2) is not less than upper bound (-20).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (2) is not less than upper bound (-20).")
 		/* r.random(2, -20) */
 
 		suite.T().Log("About to run line #177: r.Random(2, -20)")
@@ -1049,7 +1049,7 @@ func (suite *RandomSuite) TestCases() {
 	{
 		// random.yaml line #179
 		/* err("ReqlQueryLogicError", "Lower bound (1456) is not less than upper bound (0).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Lower bound (1456) is not less than upper bound (0).")
+		var expected_ = err("ReqlQueryLogicError", "Lower bound (1456) is not less than upper bound (0).")
 		/* r.random(1456, 0) */
 
 		suite.T().Log("About to run line #179: r.Random(1456, 0)")

--- a/internal/integration/reql_tests/reql_range_test.go
+++ b/internal/integration/reql_tests/reql_range_test.go
@@ -61,7 +61,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #3
 		/* 'STREAM' */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* r.range().type_of() */
 
 		suite.T().Log("About to run line #3: r.Range().TypeOf()")
@@ -76,7 +76,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #6
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* r.range().limit(4) */
 
 		suite.T().Log("About to run line #6: r.Range().Limit(4)")
@@ -91,7 +91,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #9
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* r.range(4) */
 
 		suite.T().Log("About to run line #9: r.Range(4)")
@@ -106,7 +106,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #12
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* r.range(2, 5) */
 
 		suite.T().Log("About to run line #12: r.Range(2, 5)")
@@ -121,7 +121,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #15
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.range(0) */
 
 		suite.T().Log("About to run line #15: r.Range(0)")
@@ -136,7 +136,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #18
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.range(5, 2) */
 
 		suite.T().Log("About to run line #18: r.Range(5, 2)")
@@ -151,7 +151,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #21
 		/* [-5, -4, -3] */
-		var expected_ []interface{} = []interface{}{-5, -4, -3}
+		var expected_ = []interface{}{-5, -4, -3}
 		/* r.range(-5, -2) */
 
 		suite.T().Log("About to run line #21: r.Range(-5, -2)")
@@ -166,7 +166,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #24
 		/* [-5, -4, -3, -2, -1, 0, 1] */
-		var expected_ []interface{} = []interface{}{-5, -4, -3, -2, -1, 0, 1}
+		var expected_ = []interface{}{-5, -4, -3, -2, -1, 0, 1}
 		/* r.range(-5, 2) */
 
 		suite.T().Log("About to run line #24: r.Range(-5, 2)")
@@ -181,7 +181,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #30
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* r.range("foo") */
 
 		suite.T().Log("About to run line #30: r.Range('foo')")
@@ -196,7 +196,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #34
 		/* err_regex("ReqlQueryLogicError", "Number not an integer \\(>2\\^53\\). 9007199254740994", []) */
-		var expected_ Err = err_regex("ReqlQueryLogicError", "Number not an integer \\(>2\\^53\\). 9007199254740994")
+		var expected_ = err_regex("ReqlQueryLogicError", "Number not an integer \\(>2\\^53\\). 9007199254740994")
 		/* r.range(9007199254740994) */
 
 		suite.T().Log("About to run line #34: r.Range(9007199254740994)")
@@ -211,7 +211,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #37
 		/* err_regex("ReqlQueryLogicError", "Number not an integer \\(<-2\\^53\\). -9007199254740994", []) */
-		var expected_ Err = err_regex("ReqlQueryLogicError", "Number not an integer \\(<-2\\^53\\). -9007199254740994")
+		var expected_ = err_regex("ReqlQueryLogicError", "Number not an integer \\(<-2\\^53\\). -9007199254740994")
 		/* r.range(-9007199254740994) */
 
 		suite.T().Log("About to run line #37: r.Range(-9007199254740994)")
@@ -226,7 +226,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #40
 		/* err_regex("ReqlQueryLogicError", "Number not an integer. 0\\.5", []) */
-		var expected_ Err = err_regex("ReqlQueryLogicError", "Number not an integer. 0\\.5")
+		var expected_ = err_regex("ReqlQueryLogicError", "Number not an integer. 0\\.5")
 		/* r.range(0.5) */
 
 		suite.T().Log("About to run line #40: r.Range(0.5)")
@@ -241,7 +241,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #43
 		/* err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
 		/* r.range().count() */
 
 		suite.T().Log("About to run line #43: r.Range().Count()")
@@ -256,7 +256,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #46
 		/* err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
 		/* r.range().coerce_to("ARRAY") */
 
 		suite.T().Log("About to run line #46: r.Range().CoerceTo('ARRAY')")
@@ -271,7 +271,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #49
 		/* err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
 		/* r.range().coerce_to("OBJECT") */
 
 		suite.T().Log("About to run line #49: r.Range().CoerceTo('OBJECT')")
@@ -286,7 +286,7 @@ func (suite *RangeSuite) TestCases() {
 	{
 		// range.yaml line #52
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* r.range(4).count() */
 
 		suite.T().Log("About to run line #52: r.Range(4).Count()")

--- a/internal/integration/reql_tests/reql_selection_test.go
+++ b/internal/integration/reql_tests/reql_selection_test.go
@@ -86,7 +86,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #6
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl.insert([{'id':i, 'a':i%4} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #6: tbl.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, 'a': r.Mod(i, 4), })\n    }\n    return res\n}()))")
@@ -108,7 +108,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #18
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl2.insert([{'id':i, 'b':i%4} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #18: tbl2.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, 'b': r.Mod(i, 4), })\n    }\n    return res\n}()))")
@@ -130,7 +130,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #31
 		/* 'TABLE' */
-		var expected_ string = "TABLE"
+		var expected_ = "TABLE"
 		/* tbl.type_of() */
 
 		suite.T().Log("About to run line #31: tbl.TypeOf()")
@@ -145,7 +145,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #35
 		/* err("ReqlOpFailedError", 'Database `missing` does not exist.', [0]) */
-		var expected_ Err = err("ReqlOpFailedError", "Database `missing` does not exist.")
+		var expected_ = err("ReqlOpFailedError", "Database `missing` does not exist.")
 		/* r.db('missing').table('bar') */
 
 		suite.T().Log("About to run line #35: r.DB('missing').Table('bar')")
@@ -160,7 +160,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #39
 		/* err("ReqlOpFailedError", 'Table `test.missing` does not exist.', [0]) */
-		var expected_ Err = err("ReqlOpFailedError", "Table `test.missing` does not exist.")
+		var expected_ = err("ReqlOpFailedError", "Table `test.missing` does not exist.")
 		/* r.db('test').table('missing') */
 
 		suite.T().Log("About to run line #39: r.DB('test').Table('missing')")
@@ -175,7 +175,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #43
 		/* ({"errors":1,"inserted":0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"errors": 1, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"errors": 1, "inserted": 0}
 		/* tbl.insert({"id":"\x00"}).pluck("errors","inserted") */
 
 		suite.T().Log("About to run line #43: tbl.Insert(map[interface{}]interface{}{'id': '\\u0000', }).Pluck('errors', 'inserted')")
@@ -190,7 +190,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #46
 		/* ({"errors":1,"inserted":0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"errors": 1, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"errors": 1, "inserted": 0}
 		/* tbl.insert({"id":["embedded",["null\x00"]]}).pluck("errors","inserted") */
 
 		suite.T().Log("About to run line #46: tbl.Insert(map[interface{}]interface{}{'id': []interface{}{'embedded', []interface{}{'null\\u0000'}}, }).Pluck('errors', 'inserted')")
@@ -205,7 +205,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #51
 		/* ({'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
 		/* tbl3.insert({'id':u'Здравствуй','value':u'Земля!'}) */
 
 		suite.T().Log("About to run line #51: tbl3.Insert(map[interface{}]interface{}{'id': 'Здравствуй', 'value': 'Земля!', })")
@@ -220,7 +220,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #60
 		/* {u'id':u'Здравствуй',u'value':u'Земля!'} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": "Здравствуй", "value": "Земля!"}
+		var expected_ = map[interface{}]interface{}{"id": "Здравствуй", "value": "Земля!"}
 		/* tbl3.get('Здравствуй') */
 
 		suite.T().Log("About to run line #60: tbl3.Get('Здравствуй')")
@@ -235,7 +235,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #73
 		/* [{u'id':u'Здравствуй',u'value':u'Земля!'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": "Здравствуй", "value": "Земля!"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": "Здравствуй", "value": "Земля!"}}
 		/* tbl3.filter({'value':'Земля!'}) */
 
 		suite.T().Log("About to run line #73: tbl3.Filter(map[interface{}]interface{}{'value': 'Земля!', })")
@@ -250,7 +250,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #86
 		/* err("ReqlQueryLogicError", 'Database name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Database name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).")
+		var expected_ = err("ReqlQueryLogicError", "Database name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).")
 		/* r.db('%') */
 
 		suite.T().Log("About to run line #86: r.DB('%')")
@@ -265,7 +265,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #89
 		/* err("ReqlQueryLogicError", 'Table name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Table name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).")
+		var expected_ = err("ReqlQueryLogicError", "Table name `%` invalid (Use A-Z, a-z, 0-9, _ and - only).")
 		/* r.db('test').table('%') */
 
 		suite.T().Log("About to run line #89: r.DB('test').Table('%')")
@@ -280,7 +280,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #93
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.count() */
 
 		suite.T().Log("About to run line #93: tbl.Count()")
@@ -309,7 +309,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #101
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* r.db(tbl2DbName).table(tbl2Name, read_mode='outdated').count() */
 
 		suite.T().Log("About to run line #101: r.DB(tbl2DbName).Table(tbl2Name).OptArgs(r.TableOpts{ReadMode: 'outdated', }).Count()")
@@ -324,7 +324,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #102
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* r.db(tbl2DbName).table(tbl2Name, read_mode='single').count() */
 
 		suite.T().Log("About to run line #102: r.DB(tbl2DbName).Table(tbl2Name).OptArgs(r.TableOpts{ReadMode: 'single', }).Count()")
@@ -339,7 +339,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #103
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* r.db(tbl2DbName).table(tbl2Name, read_mode='majority').count() */
 
 		suite.T().Log("About to run line #103: r.DB(tbl2DbName).Table(tbl2Name).OptArgs(r.TableOpts{ReadMode: 'majority', }).Count()")
@@ -354,7 +354,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #120
 		/* err("ReqlQueryLogicError", 'Expected type STRING but found BOOL.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found BOOL.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found BOOL.")
 		/* r.db(tbl2DbName).table(tbl2Name, read_mode=true).count() */
 
 		suite.T().Log("About to run line #120: r.DB(tbl2DbName).Table(tbl2Name).OptArgs(r.TableOpts{ReadMode: true, }).Count()")
@@ -369,7 +369,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #125
 		/* err("ReqlQueryLogicError", 'Read mode `fake` unrecognized (options are "majority", "single", and "outdated").') */
-		var expected_ Err = err("ReqlQueryLogicError", "Read mode `fake` unrecognized (options are \"majority\", \"single\", and \"outdated\").")
+		var expected_ = err("ReqlQueryLogicError", "Read mode `fake` unrecognized (options are \"majority\", \"single\", and \"outdated\").")
 		/* r.db(tbl2DbName).table(tbl2Name, read_mode='fake').count() */
 
 		suite.T().Log("About to run line #125: r.DB(tbl2DbName).Table(tbl2Name).OptArgs(r.TableOpts{ReadMode: 'fake', }).Count()")
@@ -384,7 +384,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #130
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl.get(20).count() */
 
 		suite.T().Log("About to run line #130: tbl.Get(20).Count()")
@@ -399,7 +399,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #134
 		/* {'id':20,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 20, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 20, "a": 0}
 		/* tbl.get(20) */
 
 		suite.T().Log("About to run line #134: tbl.Get(20)")
@@ -436,7 +436,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #149
 		/* partial({'tables_created':1}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"tables_created": 1})
 		/* r.db('test').table_create('testpkey', primary_key='foo') */
 
 		suite.T().Log("About to run line #149: r.DB('test').TableCreate('testpkey').OptArgs(r.TableCreateOpts{PrimaryKey: 'foo', })")
@@ -451,7 +451,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #155
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 1}
 		/* tblpkey.insert({'foo':10,'a':10}) */
 
 		suite.T().Log("About to run line #155: tblpkey.Insert(map[interface{}]interface{}{'foo': 10, 'a': 10, })")
@@ -466,7 +466,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #159
 		/* {'foo':10,'a':10} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"foo": 10, "a": 10}
+		var expected_ = map[interface{}]interface{}{"foo": 10, "a": 10}
 		/* tblpkey.get(10) */
 
 		suite.T().Log("About to run line #159: tblpkey.Get(10)")
@@ -481,7 +481,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #163
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all() */
 
 		suite.T().Log("About to run line #163: tbl.GetAll()")
@@ -496,7 +496,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #165
 		/* [{"id":20,"a":0}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 20, "a": 0}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 20, "a": 0}}
 		/* tbl.get_all(20) */
 
 		suite.T().Log("About to run line #165: tbl.GetAll(20)")
@@ -511,7 +511,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #167
 		/* "SELECTION<STREAM>" */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.get_all().type_of() */
 
 		suite.T().Log("About to run line #167: tbl.GetAll().TypeOf()")
@@ -526,7 +526,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #169
 		/* "SELECTION<STREAM>" */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.get_all(20).type_of() */
 
 		suite.T().Log("About to run line #169: tbl.GetAll(20).TypeOf()")
@@ -541,7 +541,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #173
 		/* 'TABLE_SLICE' */
-		var expected_ string = "TABLE_SLICE"
+		var expected_ = "TABLE_SLICE"
 		/* tbl.between(2, 1).type_of() */
 
 		suite.T().Log("About to run line #173: tbl.Between(2, 1).TypeOf()")
@@ -556,7 +556,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #175
 		/* 'TABLE_SLICE' */
-		var expected_ string = "TABLE_SLICE"
+		var expected_ = "TABLE_SLICE"
 		/* tbl.between(1, 2).type_of() */
 
 		suite.T().Log("About to run line #175: tbl.Between(1, 2).TypeOf()")
@@ -571,7 +571,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #177
 		/* 'TABLE_SLICE' */
-		var expected_ string = "TABLE_SLICE"
+		var expected_ = "TABLE_SLICE"
 		/* tbl.between(1, 2, index='id').type_of() */
 
 		suite.T().Log("About to run line #177: tbl.Between(1, 2).OptArgs(r.BetweenOpts{Index: 'id', }).TypeOf()")
@@ -586,7 +586,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #181
 		/* 'TABLE_SLICE' */
-		var expected_ string = "TABLE_SLICE"
+		var expected_ = "TABLE_SLICE"
 		/* tbl.between(1, 1, right_bound='closed').type_of() */
 
 		suite.T().Log("About to run line #181: tbl.Between(1, 1).OptArgs(r.BetweenOpts{RightBound: 'closed', }).TypeOf()")
@@ -601,7 +601,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #185
 		/* 'TABLE_SLICE' */
-		var expected_ string = "TABLE_SLICE"
+		var expected_ = "TABLE_SLICE"
 		/* tbl.between(2, 1).type_of() */
 
 		suite.T().Log("About to run line #185: tbl.Between(2, 1).TypeOf()")
@@ -616,7 +616,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #187
 		/* 'TABLE_SLICE' */
-		var expected_ string = "TABLE_SLICE"
+		var expected_ = "TABLE_SLICE"
 		/* tbl.between(2, 1, index='id').type_of() */
 
 		suite.T().Log("About to run line #187: tbl.Between(2, 1).OptArgs(r.BetweenOpts{Index: 'id', }).TypeOf()")
@@ -631,7 +631,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #192
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.between(21, 20).count() */
 
 		suite.T().Log("About to run line #192: tbl.Between(21, 20).Count()")
@@ -646,7 +646,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #194
 		/* 9 */
-		var expected_ int = 9
+		var expected_ = 9
 		/* tbl.between(20, 29).count() */
 
 		suite.T().Log("About to run line #194: tbl.Between(20, 29).Count()")
@@ -661,7 +661,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #196
 		/* 9 */
-		var expected_ int = 9
+		var expected_ = 9
 		/* tbl.between(-10, 9).count() */
 
 		suite.T().Log("About to run line #196: tbl.Between(-10, 9).Count()")
@@ -676,7 +676,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #198
 		/* 20 */
-		var expected_ int = 20
+		var expected_ = 20
 		/* tbl.between(80, 2000).count() */
 
 		suite.T().Log("About to run line #198: tbl.Between(80, 2000).Count()")
@@ -691,7 +691,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #200
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.between(-2000, 2000).count() */
 
 		suite.T().Log("About to run line #200: tbl.Between(-2000, 2000).Count()")
@@ -706,7 +706,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #205
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* tbl.between(20, 29, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #205: tbl.Between(20, 29).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Count()")
@@ -721,7 +721,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #209
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* tbl.between(-10, 9, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #209: tbl.Between(-10, 9).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Count()")
@@ -736,7 +736,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #213
 		/* 20 */
-		var expected_ int = 20
+		var expected_ = 20
 		/* tbl.between(80, 2000, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #213: tbl.Between(80, 2000).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Count()")
@@ -751,7 +751,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #217
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.between(-2000, 2000, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #217: tbl.Between(-2000, 2000).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Count()")
@@ -766,7 +766,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #223
 		/* 8 */
-		var expected_ int = 8
+		var expected_ = 8
 		/* tbl.between(20, 29, left_bound='open').count() */
 
 		suite.T().Log("About to run line #223: tbl.Between(20, 29).OptArgs(r.BetweenOpts{LeftBound: 'open', }).Count()")
@@ -781,7 +781,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #227
 		/* 9 */
-		var expected_ int = 9
+		var expected_ = 9
 		/* tbl.between(-10, 9, left_bound='open').count() */
 
 		suite.T().Log("About to run line #227: tbl.Between(-10, 9).OptArgs(r.BetweenOpts{LeftBound: 'open', }).Count()")
@@ -796,7 +796,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #231
 		/* 19 */
-		var expected_ int = 19
+		var expected_ = 19
 		/* tbl.between(80, 2000, left_bound='open').count() */
 
 		suite.T().Log("About to run line #231: tbl.Between(80, 2000).OptArgs(r.BetweenOpts{LeftBound: 'open', }).Count()")
@@ -811,7 +811,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #235
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.between(-2000, 2000, left_bound='open').count() */
 
 		suite.T().Log("About to run line #235: tbl.Between(-2000, 2000).OptArgs(r.BetweenOpts{LeftBound: 'open', }).Count()")
@@ -826,7 +826,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #240
 		/* err('ReqlQueryLogicError', 'Expected type TABLE_SLICE but found DATUM:', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type TABLE_SLICE but found DATUM:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type TABLE_SLICE but found DATUM:")
 		/* r.expr([1, 2, 3]).between(-1, 2) */
 
 		suite.T().Log("About to run line #240: r.Expr([]interface{}{1, 2, 3}).Between(-1, 2)")
@@ -841,7 +841,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #244
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl.between(r.minval, 2).count() */
 
 		suite.T().Log("About to run line #244: tbl.Between(r.MinVal, 2).Count()")
@@ -856,7 +856,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #247
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(r.minval, 2, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #247: tbl.Between(r.MinVal, 2).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Count()")
@@ -871,7 +871,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #251
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl.between(r.minval, 2, left_bound='open').count() */
 
 		suite.T().Log("About to run line #251: tbl.Between(r.MinVal, 2).OptArgs(r.BetweenOpts{LeftBound: 'open', }).Count()")
@@ -886,7 +886,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #255
 		/* 98 */
-		var expected_ int = 98
+		var expected_ = 98
 		/* tbl.between(2, r.maxval).count() */
 
 		suite.T().Log("About to run line #255: tbl.Between(2, r.MaxVal).Count()")
@@ -901,7 +901,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #265
 		/* err('ReqlQueryLogicError', 'Cannot use `nu' + 'll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
 		/* tbl.between(null, 2).count() */
 
 		suite.T().Log("About to run line #265: tbl.Between(nil, 2).Count()")
@@ -916,7 +916,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #266
 		/* err('ReqlQueryLogicError', 'Cannot use `nu' + 'll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
 		/* tbl.between(2, null).count() */
 
 		suite.T().Log("About to run line #266: tbl.Between(2, nil).Count()")
@@ -931,7 +931,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #267
 		/* err('ReqlQueryLogicError', 'Cannot use `nu' + 'll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
 		/* tbl.between(null, null).count() */
 
 		suite.T().Log("About to run line #267: tbl.Between(nil, nil).Count()")
@@ -946,7 +946,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #271
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tblpkey.between(9, 11).count() */
 
 		suite.T().Log("About to run line #271: tblpkey.Between(9, 11).Count()")
@@ -961,7 +961,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #274
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tblpkey.between(11, 12).count() */
 
 		suite.T().Log("About to run line #274: tblpkey.Between(11, 12).Count()")
@@ -976,7 +976,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #278
 		/* 25 */
-		var expected_ int = 25
+		var expected_ = 25
 		/* tbl.filter(lambda row:row['a'] > 2).count() */
 
 		suite.T().Log("About to run line #278: tbl.Filter(func(row r.Term) interface{} { return row.AtIndex('a').Gt(2)}).Count()")
@@ -991,7 +991,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #284
 		/* 100 */
-		var expected_ int = 100
+		var expected_ = 100
 		/* tbl.filter(lambda row: 1).count() */
 
 		suite.T().Log("About to run line #284: tbl.Filter(func(row r.Term) interface{} { return 1}).Count()")
@@ -1006,7 +1006,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #290
 		/* [4, 5] */
-		var expected_ []interface{} = []interface{}{4, 5}
+		var expected_ = []interface{}{4, 5}
 		/* r.expr([1, 2, 3, 4, 5]).filter(r.row > 2).filter(r.row > 3) */
 
 		suite.T().Log("About to run line #290: r.Expr([]interface{}{1, 2, 3, 4, 5}).Filter(r.Row.Gt(2)).Filter(r.Row.Gt(3))")
@@ -1028,7 +1028,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #298
 		/* [[3, 4], [5, 6]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{3, 4}, []interface{}{5, 6}}
+		var expected_ = []interface{}{[]interface{}{3, 4}, []interface{}{5, 6}}
 		/* nested.filter(lambda x: x.filter(lambda y: y >= 4).count() > 0) */
 
 		suite.T().Log("About to run line #298: nested.Filter(func(x r.Term) interface{} { return x.Filter(func(y r.Term) interface{} { return r.Ge(y, 4)}).Count().Gt(0)})")
@@ -1045,7 +1045,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #303
 		/* ([[3, 4], [5, 6]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{3, 4}, []interface{}{5, 6}}
+		var expected_ = []interface{}{[]interface{}{3, 4}, []interface{}{5, 6}}
 		/* nested.filter(r.row.filter(lambda y: y >= 4).count() > 0) */
 
 		suite.T().Log("About to run line #303: nested.Filter(r.Row.Filter(func(y r.Term) interface{} { return r.Ge(y, 4)}).Count().Gt(0))")
@@ -1060,7 +1060,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #307
 		/* err("ReqlCompileError", 'Cannot use r.row in nested queries.  Use functions instead.', [0]) */
-		var expected_ Err = err("ReqlCompileError", "Cannot use r.row in nested queries.  Use functions instead.")
+		var expected_ = err("ReqlCompileError", "Cannot use r.row in nested queries.  Use functions instead.")
 		/* nested.filter(lambda x: x.filter(r.row >= 4).count() > 0) */
 
 		suite.T().Log("About to run line #307: nested.Filter(func(x r.Term) interface{} { return x.Filter(r.Row.Ge(4)).Count().Gt(0)})")
@@ -1075,7 +1075,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #311
 		/* err("ReqlCompileError", 'Cannot use r.row in nested queries.  Use functions instead.', [0]) */
-		var expected_ Err = err("ReqlCompileError", "Cannot use r.row in nested queries.  Use functions instead.")
+		var expected_ = err("ReqlCompileError", "Cannot use r.row in nested queries.  Use functions instead.")
 		/* r.expr([[1, 2], [3, 4], [5, 6]]).filter(r.row.filter(r.row >= 4).count() > 0) */
 
 		suite.T().Log("About to run line #311: r.Expr([]interface{}{[]interface{}{1, 2}, []interface{}{3, 4}, []interface{}{5, 6}}).Filter(r.Row.Filter(r.Row.Ge(4)).Count().Gt(0))")
@@ -1090,7 +1090,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #316
 		/* [{'a':1,'b':2,'c':3}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1, "b": 2, "c": 3}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1, "b": 2, "c": 3}}
 		/* r.expr([{'a':1,'b':1,'c':3},{'a':1,'b':2,'c':3}]).filter({'a':1,'b':2}) */
 
 		suite.T().Log("About to run line #316: r.Expr([]interface{}{map[interface{}]interface{}{'a': 1, 'b': 1, 'c': 3, }, map[interface{}]interface{}{'a': 1, 'b': 2, 'c': 3, }}).Filter(map[interface{}]interface{}{'a': 1, 'b': 2, })")
@@ -1105,7 +1105,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #319
 		/* [{'a':1,'b':1,'c':3},{'a':1,'b':2,'c':3}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1, "b": 1, "c": 3}, map[interface{}]interface{}{"a": 1, "b": 2, "c": 3}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1, "b": 1, "c": 3}, map[interface{}]interface{}{"a": 1, "b": 2, "c": 3}}
 		/* r.expr([{'a':1,'b':1,'c':3},{'a':1,'b':2,'c':3}]).filter({'a':1}) */
 
 		suite.T().Log("About to run line #319: r.Expr([]interface{}{map[interface{}]interface{}{'a': 1, 'b': 1, 'c': 3, }, map[interface{}]interface{}{'a': 1, 'b': 2, 'c': 3, }}).Filter(map[interface{}]interface{}{'a': 1, })")
@@ -1120,7 +1120,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #323
 		/* [{'a':1,'b':1,'c':3}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1, "b": 1, "c": 3}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1, "b": 1, "c": 3}}
 		/* r.expr([{'a':1,'b':1,'c':3},{'a':1,'b':2,'c':3}]).filter({'a':r.row['b']}) */
 
 		suite.T().Log("About to run line #323: r.Expr([]interface{}{map[interface{}]interface{}{'a': 1, 'b': 1, 'c': 3, }, map[interface{}]interface{}{'a': 1, 'b': 2, 'c': 3, }}).Filter(map[interface{}]interface{}{'a': r.Row.AtIndex('b'), })")
@@ -1135,7 +1135,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #329
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.expr([{'a':1}]).filter({'b':1}) */
 
 		suite.T().Log("About to run line #329: r.Expr([]interface{}{map[interface{}]interface{}{'a': 1, }}).Filter(map[interface{}]interface{}{'b': 1, })")
@@ -1150,7 +1150,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #335
 		/* 25 */
-		var expected_ int = 25
+		var expected_ = 25
 		/* tbl.count(lambda row: {'a':1}) */
 
 		suite.T().Log("About to run line #335: tbl.Count(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': 1, }})")
@@ -1165,7 +1165,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #341
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([1,2,3,1]).count(1) */
 
 		suite.T().Log("About to run line #341: r.Expr([]interface{}{1, 2, 3, 1}).Count(1)")
@@ -1180,7 +1180,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #344
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([null, 4, null, 'foo']).count(null) */
 
 		suite.T().Log("About to run line #344: r.Expr([]interface{}{nil, 4, nil, 'foo'}).Count(nil)")
@@ -1195,7 +1195,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #348
 		/* err('ReqlQueryLogicError', 'Expected type DATUM but found TABLE:', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type DATUM but found TABLE:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type DATUM but found TABLE:")
 		/* r.expr(5) + tbl */
 
 		suite.T().Log("About to run line #348: r.Expr(5).Add(tbl)")
@@ -1210,7 +1210,7 @@ func (suite *SelectionSuite) TestCases() {
 	{
 		// selection.yaml line #353
 		/* "SELECTION<STREAM>" */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.has_fields('field').type_of() */
 
 		suite.T().Log("About to run line #353: tbl.HasFields('field').TypeOf()")

--- a/internal/integration/reql_tests/reql_sindex_api_test.go
+++ b/internal/integration/reql_tests/reql_sindex_api_test.go
@@ -77,7 +77,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #11
 		/* ({'deleted':0,'inserted':4,'skipped':0,'errors':0,'replaced':0,'unchanged':0}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "inserted": 4, "skipped": 0, "errors": 0, "replaced": 0, "unchanged": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "inserted": 4, "skipped": 0, "errors": 0, "replaced": 0, "unchanged": 0}
 		/* tbl.insert([{'id':0, 'a':0, 'b':0, 'c':0, 'm':[1,2,3]},
 		{'id':1, 'a':0, 'b':0, 'c':0, 'm':[4,5,6]},
 		{'id':2, 'a':0, 'b':0, 'c':1, 'm':7},
@@ -95,7 +95,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #18
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('rename-foo', r.row['b']) */
 
 		suite.T().Log("About to run line #18: tbl.IndexCreateFunc('rename-foo', r.Row.AtIndex('b'))")
@@ -110,7 +110,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #23
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('rename-bar', r.row['c']) */
 
 		suite.T().Log("About to run line #23: tbl.IndexCreateFunc('rename-bar', r.Row.AtIndex('c'))")
@@ -125,7 +125,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #28
 		/* err_regex('ReqlOpFailedError','Index `rename-foo` does not exist or index `rename-bar` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]',[]) */
-		var expected_ Err = err_regex("ReqlOpFailedError", "Index `rename-foo` does not exist or index `rename-bar` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
+		var expected_ = err_regex("ReqlOpFailedError", "Index `rename-foo` does not exist or index `rename-bar` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
 		/* tbl.index_rename('rename-foo','rename-bar') */
 
 		suite.T().Log("About to run line #28: tbl.IndexRename('rename-foo', 'rename-bar')")
@@ -140,7 +140,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #31
 		/* err_regex('ReqlOpFailedError','Index `rename-fake` does not exist or index `rename-stuff` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]',[]) */
-		var expected_ Err = err_regex("ReqlOpFailedError", "Index `rename-fake` does not exist or index `rename-stuff` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
+		var expected_ = err_regex("ReqlOpFailedError", "Index `rename-fake` does not exist or index `rename-stuff` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
 		/* tbl.index_rename('rename-fake','rename-stuff') */
 
 		suite.T().Log("About to run line #31: tbl.IndexRename('rename-fake', 'rename-stuff')")
@@ -155,7 +155,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #34
 		/* err('ReqlQueryLogicError','Index name conflict:'+' `id` is the name of the primary key.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index name conflict:"+" `id` is the name of the primary key.")
+		var expected_ = err("ReqlQueryLogicError", "Index name conflict:"+" `id` is the name of the primary key.")
 		/* tbl.index_rename('id','rename-stuff') */
 
 		suite.T().Log("About to run line #34: tbl.IndexRename('id', 'rename-stuff')")
@@ -170,7 +170,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #37
 		/* err('ReqlQueryLogicError','Index name conflict:'+' `id` is the name of the primary key.',[]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index name conflict:"+" `id` is the name of the primary key.")
+		var expected_ = err("ReqlQueryLogicError", "Index name conflict:"+" `id` is the name of the primary key.")
 		/* tbl.index_rename('rename-stuff','id') */
 
 		suite.T().Log("About to run line #37: tbl.IndexRename('rename-stuff', 'id')")
@@ -185,7 +185,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #40
 		/* {'renamed':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"renamed": 0}
+		var expected_ = map[interface{}]interface{}{"renamed": 0}
 		/* tbl.index_rename('rename-foo','rename-foo') */
 
 		suite.T().Log("About to run line #40: tbl.IndexRename('rename-foo', 'rename-foo')")
@@ -200,7 +200,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #43
 		/* {'renamed':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"renamed": 0}
+		var expected_ = map[interface{}]interface{}{"renamed": 0}
 		/* tbl.index_rename('rename-foo','rename-foo',overwrite=True) */
 
 		suite.T().Log("About to run line #43: tbl.IndexRename('rename-foo', 'rename-foo').OptArgs(r.IndexRenameOpts{Overwrite: true, })")
@@ -215,7 +215,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #48
 		/* {'renamed':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"renamed": 1}
+		var expected_ = map[interface{}]interface{}{"renamed": 1}
 		/* tbl.index_rename('rename-foo','rename-bar',overwrite=True) */
 
 		suite.T().Log("About to run line #48: tbl.IndexRename('rename-foo', 'rename-bar').OptArgs(r.IndexRenameOpts{Overwrite: true, })")
@@ -230,7 +230,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #53
 		/* {'renamed':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"renamed": 1}
+		var expected_ = map[interface{}]interface{}{"renamed": 1}
 		/* tbl.index_rename('rename-bar','rename-stuff',overwrite=True) */
 
 		suite.T().Log("About to run line #53: tbl.IndexRename('rename-bar', 'rename-stuff').OptArgs(r.IndexRenameOpts{Overwrite: true, })")
@@ -245,7 +245,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #58
 		/* {'renamed':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"renamed": 1}
+		var expected_ = map[interface{}]interface{}{"renamed": 1}
 		/* tbl.index_rename('rename-stuff','rename-last') */
 
 		suite.T().Log("About to run line #58: tbl.IndexRename('rename-stuff', 'rename-last')")
@@ -260,7 +260,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #62
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('minval', lambda:r.minval) */
 
 		suite.T().Log("About to run line #62: tbl.IndexCreateFunc('minval', func() interface{} { return r.MinVal})")
@@ -275,7 +275,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #67
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('maxval', lambda:r.maxval) */
 
 		suite.T().Log("About to run line #67: tbl.IndexCreateFunc('maxval', func() interface{} { return r.MaxVal})")
@@ -292,7 +292,7 @@ func (suite *SindexApiSuite) TestCases() {
 		/* bag([{'index':'rename-last','ready':true},
 		{'index':'minval','ready':true},
 		{'index':'maxval','ready':true}]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{map[interface{}]interface{}{"index": "rename-last", "ready": true}, map[interface{}]interface{}{"index": "minval", "ready": true}, map[interface{}]interface{}{"index": "maxval", "ready": true}})
+		var expected_ = compare.UnorderedMatch([]interface{}{map[interface{}]interface{}{"index": "rename-last", "ready": true}, map[interface{}]interface{}{"index": "minval", "ready": true}, map[interface{}]interface{}{"index": "maxval", "ready": true}})
 		/* tbl.index_wait('rename-last', 'minval', 'maxval').pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #71: tbl.IndexWait('rename-last', 'minval', 'maxval').Pluck('index', 'ready')")
@@ -307,7 +307,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #76
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.get_all(0, index='rename-last').count() */
 
 		suite.T().Log("About to run line #76: tbl.GetAll(0).OptArgs(r.GetAllOpts{Index: 'rename-last', }).Count()")
@@ -322,7 +322,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #82
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.get_all(r.minval, index='minval').count() */
 
 		suite.T().Log("About to run line #82: tbl.GetAll(r.MinVal).OptArgs(r.GetAllOpts{Index: 'minval', }).Count()")
@@ -337,7 +337,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #87
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.get_all(r.maxval, index='maxval').count() */
 
 		suite.T().Log("About to run line #87: tbl.GetAll(r.MaxVal).OptArgs(r.GetAllOpts{Index: 'maxval', }).Count()")
@@ -352,7 +352,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #92
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* tbl.between(r.minval, r.maxval, index='minval').count() */
 
 		suite.T().Log("About to run line #92: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'minval', }).Count()")
@@ -367,7 +367,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #97
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('rename-last-dup', tbl.index_status('rename-last').nth(0).get_field('function')) */
 
 		suite.T().Log("About to run line #97: tbl.IndexCreateFunc('rename-last-dup', tbl.IndexStatus('rename-last').Nth(0).Field('function'))")
@@ -382,7 +382,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #100
 		/* [{'index':'rename-last-dup','ready':true}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"index": "rename-last-dup", "ready": true}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"index": "rename-last-dup", "ready": true}}
 		/* tbl.index_wait('rename-last-dup').pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #100: tbl.IndexWait('rename-last-dup').Pluck('index', 'ready')")
@@ -397,7 +397,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #103
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.get_all(0, index='rename-last-dup').count() */
 
 		suite.T().Log("About to run line #103: tbl.GetAll(0).OptArgs(r.GetAllOpts{Index: 'rename-last-dup', }).Count()")
@@ -412,7 +412,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #109
 		/* {'dropped':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"dropped": 1}
+		var expected_ = map[interface{}]interface{}{"dropped": 1}
 		/* tbl.index_drop('rename-last-dup') */
 
 		suite.T().Log("About to run line #109: tbl.IndexDrop('rename-last-dup')")
@@ -427,7 +427,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #110
 		/* {'dropped':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"dropped": 1}
+		var expected_ = map[interface{}]interface{}{"dropped": 1}
 		/* tbl.index_drop('minval') */
 
 		suite.T().Log("About to run line #110: tbl.IndexDrop('minval')")
@@ -442,7 +442,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #111
 		/* {'dropped':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"dropped": 1}
+		var expected_ = map[interface{}]interface{}{"dropped": 1}
 		/* tbl.index_drop('maxval') */
 
 		suite.T().Log("About to run line #111: tbl.IndexDrop('maxval')")
@@ -457,7 +457,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #114
 		/* ['rename-last'] */
-		var expected_ []interface{} = []interface{}{"rename-last"}
+		var expected_ = []interface{}{"rename-last"}
 		/* tbl.index_list() */
 
 		suite.T().Log("About to run line #114: tbl.IndexList()")
@@ -472,7 +472,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #117
 		/* {'dropped':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"dropped": 1}
+		var expected_ = map[interface{}]interface{}{"dropped": 1}
 		/* tbl.index_drop('rename-last') */
 
 		suite.T().Log("About to run line #117: tbl.IndexDrop('rename-last')")
@@ -487,7 +487,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #121
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('ai', r.row['a']) */
 
 		suite.T().Log("About to run line #121: tbl.IndexCreateFunc('ai', r.Row.AtIndex('a'))")
@@ -502,7 +502,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #125
 		/* err_regex("ReqlOpFailedError", "Index `ai` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]", []) */
-		var expected_ Err = err_regex("ReqlOpFailedError", "Index `ai` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
+		var expected_ = err_regex("ReqlOpFailedError", "Index `ai` already exists on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
 		/* tbl.index_create('ai', r.row['a']) */
 
 		suite.T().Log("About to run line #125: tbl.IndexCreateFunc('ai', r.Row.AtIndex('a'))")
@@ -517,7 +517,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #129
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('bi', r.row['b']) */
 
 		suite.T().Log("About to run line #129: tbl.IndexCreateFunc('bi', r.Row.AtIndex('b'))")
@@ -532,7 +532,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #133
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('ci', r.row['c']) */
 
 		suite.T().Log("About to run line #133: tbl.IndexCreateFunc('ci', r.Row.AtIndex('c'))")
@@ -547,7 +547,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #137
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('idi', r.row['id']) */
 
 		suite.T().Log("About to run line #137: tbl.IndexCreateFunc('idi', r.Row.AtIndex('id'))")
@@ -562,7 +562,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #141
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('kdi', [r.row['id']]) */
 
 		suite.T().Log("About to run line #141: tbl.IndexCreateFunc('kdi', []interface{}{r.Row.AtIndex('id')})")
@@ -577,7 +577,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #145
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('mi', r.row['m'], multi=True) */
 
 		suite.T().Log("About to run line #145: tbl.IndexCreateFunc('mi', r.Row.AtIndex('m')).OptArgs(r.IndexCreateOpts{Multi: true, })")
@@ -592,7 +592,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #149
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('brokeni', r.row['broken']) */
 
 		suite.T().Log("About to run line #149: tbl.IndexCreateFunc('brokeni', r.Row.AtIndex('broken'))")
@@ -607,7 +607,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #153
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait().pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #153: tbl.IndexWait().Pluck('index', 'ready')")
@@ -622,7 +622,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #156
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get(True) */
 
 		suite.T().Log("About to run line #156: tbl.Get(true)")
@@ -667,7 +667,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #164
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get(1)['id'] */
 
 		suite.T().Log("About to run line #164: tbl.Get(1).AtIndex('id')")
@@ -682,7 +682,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #168
 		/* 'SELECTION<OBJECT>' */
-		var expected_ string = "SELECTION<OBJECT>"
+		var expected_ = "SELECTION<OBJECT>"
 		/* tbl.get(1).type_of() */
 
 		suite.T().Log("About to run line #168: tbl.Get(1).TypeOf()")
@@ -697,7 +697,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #172
 		/* {'replaced':0,'skipped':0,'deleted':0,'unchanged':1,'errors':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 1, "errors": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 1, "errors": 0, "inserted": 0}
 		/* tbl.get(1).update(lambda x:null) */
 
 		suite.T().Log("About to run line #172: tbl.Get(1).Update(func(x r.Term) interface{} { return nil})")
@@ -712,7 +712,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #180
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get_all(True, index='id') */
 
 		suite.T().Log("About to run line #180: tbl.GetAll(true).OptArgs(r.GetAllOpts{Index: 'id', })")
@@ -727,7 +727,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #185
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all(-1, index='id') */
 
 		suite.T().Log("About to run line #185: tbl.GetAll(-1).OptArgs(r.GetAllOpts{Index: 'id', })")
@@ -742,7 +742,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #189
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all(-1) */
 
 		suite.T().Log("About to run line #189: tbl.GetAll(-1)")
@@ -757,7 +757,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #193
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all([-1]) */
 
 		suite.T().Log("About to run line #193: tbl.GetAll([]interface{}{-1})")
@@ -772,7 +772,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #197
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_all(1, index='id')[0]['id'] */
 
 		suite.T().Log("About to run line #197: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'id', }).AtIndex(0).AtIndex('id')")
@@ -787,7 +787,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #201
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_all(1)[0]['id'] */
 
 		suite.T().Log("About to run line #201: tbl.GetAll(1).AtIndex(0).AtIndex('id')")
@@ -802,7 +802,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #205
 		/* bag([1,2,3]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{1, 2, 3})
+		var expected_ = compare.UnorderedMatch([]interface{}{1, 2, 3})
 		/* tbl.get_all(1,2,3, index='id').map(lambda x:x["id"]).coerce_to("ARRAY") */
 
 		suite.T().Log("About to run line #205: tbl.GetAll(1, 2, 3).OptArgs(r.GetAllOpts{Index: 'id', }).Map(func(x r.Term) interface{} { return x.AtIndex('id')}).CoerceTo('ARRAY')")
@@ -817,7 +817,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #209
 		/* bag([1,2,3]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{1, 2, 3})
+		var expected_ = compare.UnorderedMatch([]interface{}{1, 2, 3})
 		/* tbl.get_all(1,2,3).map(lambda x:x["id"]).coerce_to("ARRAY") */
 
 		suite.T().Log("About to run line #209: tbl.GetAll(1, 2, 3).Map(func(x r.Term) interface{} { return x.AtIndex('id')}).CoerceTo('ARRAY')")
@@ -832,7 +832,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #213
 		/* 'SELECTION<STREAM>' */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.get_all(1, index='id').type_of() */
 
 		suite.T().Log("About to run line #213: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'id', }).TypeOf()")
@@ -847,7 +847,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #217
 		/* 'SELECTION<STREAM>' */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.get_all(1).type_of() */
 
 		suite.T().Log("About to run line #217: tbl.GetAll(1).TypeOf()")
@@ -862,7 +862,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #221
 		/* {'replaced':0,'skipped':0,'deleted':0,'unchanged':1,'errors':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 1, "errors": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 1, "errors": 0, "inserted": 0}
 		/* tbl.get_all(1, index='id').update(lambda x:null) */
 
 		suite.T().Log("About to run line #221: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'id', }).Update(func(x r.Term) interface{} { return nil})")
@@ -877,7 +877,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #225
 		/* {'replaced':0,'skipped':0,'deleted':0,'unchanged':1,'errors':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 1, "errors": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 1, "errors": 0, "inserted": 0}
 		/* tbl.get_all(1).update(lambda x:null) */
 
 		suite.T().Log("About to run line #225: tbl.GetAll(1).Update(func(x r.Term) interface{} { return nil})")
@@ -892,7 +892,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #229
 		/* {'replaced':0,'skipped':0,'deleted':0,'unchanged':3,'errors':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 3, "errors": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 3, "errors": 0, "inserted": 0}
 		/* tbl.get_all(1,2,3, index='id').update(lambda x:null) */
 
 		suite.T().Log("About to run line #229: tbl.GetAll(1, 2, 3).OptArgs(r.GetAllOpts{Index: 'id', }).Update(func(x r.Term) interface{} { return nil})")
@@ -907,7 +907,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #233
 		/* {'replaced':0,'skipped':0,'deleted':0,'unchanged':3,'errors':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 3, "errors": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 3, "errors": 0, "inserted": 0}
 		/* tbl.get_all(1,2,3).update(lambda x:null) */
 
 		suite.T().Log("About to run line #233: tbl.GetAll(1, 2, 3).Update(func(x r.Term) interface{} { return nil})")
@@ -922,7 +922,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #238
 		/* err_regex("ReqlOpFailedError", "Index `fake` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]", []) */
-		var expected_ Err = err_regex("ReqlOpFailedError", "Index `fake` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
+		var expected_ = err_regex("ReqlOpFailedError", "Index `fake` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
 		/* tbl.get_all(0, index='fake') */
 
 		suite.T().Log("About to run line #238: tbl.GetAll(0).OptArgs(r.GetAllOpts{Index: 'fake', })")
@@ -937,7 +937,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #242
 		/* err("ReqlQueryLogicError", "Cannot use a geospatial index with `get_all`. Use `get_intersecting` instead.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a geospatial index with `get_all`. Use `get_intersecting` instead.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a geospatial index with `get_all`. Use `get_intersecting` instead.")
 		/* tbl.get_all(r.point(0, 0)) */
 
 		suite.T().Log("About to run line #242: tbl.GetAll(r.Point(0, 0))")
@@ -952,7 +952,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #246
 		/* err("ReqlQueryLogicError", "Expected type STRING but found BOOL.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found BOOL.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found BOOL.")
 		/* tbl.get_all(0, index=False) */
 
 		suite.T().Log("About to run line #246: tbl.GetAll(0).OptArgs(r.GetAllOpts{Index: false, })")
@@ -967,7 +967,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #251
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get_all(True, index='id') */
 
 		suite.T().Log("About to run line #251: tbl.GetAll(true).OptArgs(r.GetAllOpts{Index: 'id', })")
@@ -982,7 +982,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #256
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all([], index='id') */
 
 		suite.T().Log("About to run line #256: tbl.GetAll([]interface{}{}).OptArgs(r.GetAllOpts{Index: 'id', })")
@@ -997,7 +997,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #260
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.get_all(True, index='idi') */
 
 		suite.T().Log("About to run line #260: tbl.GetAll(true).OptArgs(r.GetAllOpts{Index: 'idi', })")
@@ -1012,7 +1012,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #265
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all([], index='idi') */
 
 		suite.T().Log("About to run line #265: tbl.GetAll([]interface{}{}).OptArgs(r.GetAllOpts{Index: 'idi', })")
@@ -1027,7 +1027,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #270
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_all(1, index='id')[0]['id'] */
 
 		suite.T().Log("About to run line #270: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'id', }).AtIndex(0).AtIndex('id')")
@@ -1042,7 +1042,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #274
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_all(1, index='idi')[0]['id'] */
 
 		suite.T().Log("About to run line #274: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'idi', }).AtIndex(0).AtIndex('id')")
@@ -1057,7 +1057,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #278
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all(1, index='ai') */
 
 		suite.T().Log("About to run line #278: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'ai', })")
@@ -1072,7 +1072,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #282
 		/* [3] */
-		var expected_ []interface{} = []interface{}{3}
+		var expected_ = []interface{}{3}
 		/* tbl.get_all(1, index='bi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #282: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'bi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1087,7 +1087,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #286
 		/* err('ReqlQueryLogicError', 'Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
+		var expected_ = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
 		/* tbl.get_all(1, index='bi').order_by(index='id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #286: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'bi', }).OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1102,7 +1102,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #290
 		/* err('ReqlQueryLogicError', 'Expected type TABLE_SLICE but found SELECTION:', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type TABLE_SLICE but found SELECTION:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type TABLE_SLICE but found SELECTION:")
 		/* tbl.get_all(1, index='bi').between(1, 1, index='id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #290: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'bi', }).Between(1, 1).OptArgs(r.BetweenOpts{Index: 'id', }).Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1117,7 +1117,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #294
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* tbl.get_all(1, index='ci').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #294: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'ci', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1132,7 +1132,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #298
 		/* 'SELECTION<STREAM>' */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.get_all(1, index='ci').type_of() */
 
 		suite.T().Log("About to run line #298: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'ci', }).TypeOf()")
@@ -1147,7 +1147,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #302
 		/* {'replaced':0,'skipped':0,'deleted':0,'unchanged':2,'errors':0,'inserted':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 2, "errors": 0, "inserted": 0}
+		var expected_ = map[interface{}]interface{}{"replaced": 0, "skipped": 0, "deleted": 0, "unchanged": 2, "errors": 0, "inserted": 0}
 		/* tbl.get_all(1, index='ci').update(lambda x:null) */
 
 		suite.T().Log("About to run line #302: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'ci', }).Update(func(x r.Term) interface{} { return nil})")
@@ -1162,7 +1162,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #306
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all(1, index='brokeni') */
 
 		suite.T().Log("About to run line #306: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'brokeni', })")
@@ -1177,7 +1177,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #311
 		/* [rows[0]] */
-		var expected_ []interface{} = []interface{}{rows[0]}
+		var expected_ = []interface{}{rows[0]}
 		/* tbl.get_all(1, index='mi') */
 
 		suite.T().Log("About to run line #311: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'mi', })")
@@ -1192,7 +1192,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #316
 		/* [rows[0]] */
-		var expected_ []interface{} = []interface{}{rows[0]}
+		var expected_ = []interface{}{rows[0]}
 		/* tbl.get_all(2, index='mi') */
 
 		suite.T().Log("About to run line #316: tbl.GetAll(2).OptArgs(r.GetAllOpts{Index: 'mi', })")
@@ -1207,7 +1207,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #321
 		/* [rows[1]] */
-		var expected_ []interface{} = []interface{}{rows[1]}
+		var expected_ = []interface{}{rows[1]}
 		/* tbl.get_all(5, index='mi') */
 
 		suite.T().Log("About to run line #321: tbl.GetAll(5).OptArgs(r.GetAllOpts{Index: 'mi', })")
@@ -1222,7 +1222,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #326
 		/* [rows[2]] */
-		var expected_ []interface{} = []interface{}{rows[2]}
+		var expected_ = []interface{}{rows[2]}
 		/* tbl.get_all(7, index='mi') */
 
 		suite.T().Log("About to run line #326: tbl.GetAll(7).OptArgs(r.GetAllOpts{Index: 'mi', })")
@@ -1237,7 +1237,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #331
 		/* err_regex("ReqlOpFailedError", "Index `fake` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]", []) */
-		var expected_ Err = err_regex("ReqlOpFailedError", "Index `fake` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
+		var expected_ = err_regex("ReqlOpFailedError", "Index `fake` was not found on table `[a-zA-Z0-9_]+.[a-zA-Z0-9_]+`[.]")
 		/* tbl.eq_join('id', tbl, index='fake') */
 
 		suite.T().Log("About to run line #331: tbl.EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'fake', })")
@@ -1252,7 +1252,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #335
 		/* err("ReqlQueryLogicError", "Expected type STRING but found BOOL.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found BOOL.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found BOOL.")
 		/* tbl.eq_join('id', tbl, index=False) */
 
 		suite.T().Log("About to run line #335: tbl.EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: false, })")
@@ -1267,7 +1267,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #340
 		/* [{'left':rows[1],'right':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[1], "right": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[1], "right": rows[0]}}
 		/* tbl.filter({'id':1}).eq_join('id', tbl, index='mi') */
 
 		suite.T().Log("About to run line #340: tbl.Filter(map[interface{}]interface{}{'id': 1, }).EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'mi', })")
@@ -1282,7 +1282,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #345
 		/* [{'left':rows[0],'right':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join('id', tbl) */
 
 		suite.T().Log("About to run line #345: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin('id', tbl)")
@@ -1297,7 +1297,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #350
 		/* [{'left':rows[0],'right':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join(lambda x:x['id'], tbl) */
 
 		suite.T().Log("About to run line #350: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin(func(x r.Term) interface{} { return x.AtIndex('id')}, tbl)")
@@ -1312,7 +1312,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #355
 		/* [{'left':rows[0],'right':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join('id', tbl, index='id') */
 
 		suite.T().Log("About to run line #355: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'id', })")
@@ -1327,7 +1327,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #360
 		/* [{'left':rows[0],'right':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join(lambda x:x['id'], tbl, index='id') */
 
 		suite.T().Log("About to run line #360: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin(func(x r.Term) interface{} { return x.AtIndex('id')}, tbl).OptArgs(r.EqJoinOpts{Index: 'id', })")
@@ -1342,7 +1342,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #365
 		/* [{'left':rows[0],'right':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join('id', tbl, index='idi') */
 
 		suite.T().Log("About to run line #365: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'idi', })")
@@ -1357,7 +1357,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #370
 		/* [{'left':rows[0],'right':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join(lambda x:x['id'], tbl, index='idi') */
 
 		suite.T().Log("About to run line #370: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin(func(x r.Term) interface{} { return x.AtIndex('id')}, tbl).OptArgs(r.EqJoinOpts{Index: 'idi', })")
@@ -1375,7 +1375,7 @@ func (suite *SindexApiSuite) TestCases() {
 		{'right':rows[1],'left':rows[0]},
 		{'right':rows[2],'left':rows[0]},
 		{'right':rows[3],'left':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[0]}, map[interface{}]interface{}{"right": rows[3], "left": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[0]}, map[interface{}]interface{}{"right": rows[3], "left": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join('id', tbl, index='ai').order_by('right') */
 
 		suite.T().Log("About to run line #375: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'ai', }).OrderBy('right')")
@@ -1392,7 +1392,7 @@ func (suite *SindexApiSuite) TestCases() {
 		/* ([{'right':rows[0],'left':rows[0]},
 		{'right':rows[1],'left':rows[0]},
 		{'right':rows[2],'left':rows[0]}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join('id', tbl, index='bi').order_by('right') */
 
 		suite.T().Log("About to run line #382: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'bi', }).OrderBy('right')")
@@ -1407,7 +1407,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #388
 		/* [{'right':rows[0],'left':rows[0]}, {'right':rows[1],'left':rows[0]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}}
 		/* tbl.filter({'id':0}).eq_join('id', tbl, index='ci').order_by('right') */
 
 		suite.T().Log("About to run line #388: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'ci', }).OrderBy('right')")
@@ -1422,7 +1422,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #392
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.filter({'id':0}).eq_join('id', tbl, index='brokeni') */
 
 		suite.T().Log("About to run line #392: tbl.Filter(map[interface{}]interface{}{'id': 0, }).EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'brokeni', })")
@@ -1444,7 +1444,7 @@ func (suite *SindexApiSuite) TestCases() {
 		{'left':rows[1],'right':rows[2]},
 		{'left':rows[2],'right':rows[3]},
 		{'left':rows[3],'right':rows[3]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}, map[interface{}]interface{}{"left": rows[1], "right": rows[0]}, map[interface{}]interface{}{"left": rows[0], "right": rows[1]}, map[interface{}]interface{}{"left": rows[1], "right": rows[1]}, map[interface{}]interface{}{"left": rows[0], "right": rows[2]}, map[interface{}]interface{}{"left": rows[1], "right": rows[2]}, map[interface{}]interface{}{"left": rows[2], "right": rows[3]}, map[interface{}]interface{}{"left": rows[3], "right": rows[3]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"left": rows[0], "right": rows[0]}, map[interface{}]interface{}{"left": rows[1], "right": rows[0]}, map[interface{}]interface{}{"left": rows[0], "right": rows[1]}, map[interface{}]interface{}{"left": rows[1], "right": rows[1]}, map[interface{}]interface{}{"left": rows[0], "right": rows[2]}, map[interface{}]interface{}{"left": rows[1], "right": rows[2]}, map[interface{}]interface{}{"left": rows[2], "right": rows[3]}, map[interface{}]interface{}{"left": rows[3], "right": rows[3]}}
 		/* tbl.eq_join('c', tbl, index='bi').order_by('right', 'left') */
 
 		suite.T().Log("About to run line #397: tbl.EqJoin('c', tbl).OptArgs(r.EqJoinOpts{Index: 'bi', }).OrderBy('right', 'left')")
@@ -1459,7 +1459,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #408
 		/* err("ReqlQueryLogicError", "Index name conflict: `id` is the name of the primary key.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Index name conflict: `id` is the name of the primary key.")
+		var expected_ = err("ReqlQueryLogicError", "Index name conflict: `id` is the name of the primary key.")
 		/* tbl.index_create('id') */
 
 		suite.T().Log("About to run line #408: tbl.IndexCreate('id')")
@@ -1474,7 +1474,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #411
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('c') */
 
 		suite.T().Log("About to run line #411: tbl.IndexCreate('c')")
@@ -1489,7 +1489,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #413
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('broken') */
 
 		suite.T().Log("About to run line #413: tbl.IndexCreate('broken')")
@@ -1504,7 +1504,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #416
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait('broken') */
 
 		suite.T().Log("About to run line #416: tbl.IndexWait('broken')")
@@ -1519,7 +1519,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #419
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* tbl.get_all(1, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #419: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1534,7 +1534,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #423
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all(1, index='broken').order_by('broken').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #423: tbl.GetAll(1).OptArgs(r.GetAllOpts{Index: 'broken', }).OrderBy('broken').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1549,7 +1549,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #428
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('nil', lambda x:null) */
 
 		suite.T().Log("About to run line #428: tbl.IndexCreateFunc('nil', func(x r.Term) interface{} { return nil})")
@@ -1564,7 +1564,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #431
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait().pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #431: tbl.IndexWait().Pluck('index', 'ready')")
@@ -1579,7 +1579,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #434
 		/* err("ReqlNonExistenceError", "Keys cannot be NULL.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Keys cannot be NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Keys cannot be NULL.")
 		/* tbl.get_all(null, index='nil') */
 
 		suite.T().Log("About to run line #434: tbl.GetAll(nil).OptArgs(r.GetAllOpts{Index: 'nil', })")
@@ -1594,7 +1594,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #439
 		/* {'deleted':0,'inserted':1,'skipped':0,'errors':0,'replaced':0,'unchanged':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "inserted": 1, "skipped": 0, "errors": 0, "replaced": 0, "unchanged": 0}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "inserted": 1, "skipped": 0, "errors": 0, "replaced": 0, "unchanged": 0}
 		/* tbl.insert({'id':4, 'a':4, 'b':4, 'c':4, 'm':[14,15,16]}) */
 
 		suite.T().Log("About to run line #439: tbl.Insert(map[interface{}]interface{}{'id': 4, 'a': 4, 'b': 4, 'c': 4, 'm': []interface{}{14, 15, 16}, })")
@@ -1613,7 +1613,7 @@ func (suite *SindexApiSuite) TestCases() {
 		{'right':rows[2],'left':rows[1]},
 		{'right':rows[3],'left':rows[1]},
 		{'right':rows[4],'left':rows[4]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[1]}, map[interface{}]interface{}{"right": rows[3], "left": rows[1]}, map[interface{}]interface{}{"right": rows[4], "left": rows[4]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[1]}, map[interface{}]interface{}{"right": rows[3], "left": rows[1]}, map[interface{}]interface{}{"right": rows[4], "left": rows[4]}}
 		/* tbl.eq_join('id', tbl, index='c').order_by('left', 'right').coerce_to("ARRAY") */
 
 		suite.T().Log("About to run line #446: tbl.EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'c', }).OrderBy('left', 'right').CoerceTo('ARRAY')")
@@ -1632,7 +1632,7 @@ func (suite *SindexApiSuite) TestCases() {
 		{'right':rows[2],'left':rows[1]},
 		{'right':rows[3],'left':rows[1]},
 		{'right':rows[4],'left':rows[4]}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[1]}, map[interface{}]interface{}{"right": rows[3], "left": rows[1]}, map[interface{}]interface{}{"right": rows[4], "left": rows[4]}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"right": rows[0], "left": rows[0]}, map[interface{}]interface{}{"right": rows[1], "left": rows[0]}, map[interface{}]interface{}{"right": rows[2], "left": rows[1]}, map[interface{}]interface{}{"right": rows[3], "left": rows[1]}, map[interface{}]interface{}{"right": rows[4], "left": rows[4]}}
 		/* tbl.eq_join('id', tbl, index='ci').order_by('left', 'right') */
 
 		suite.T().Log("About to run line #455: tbl.EqJoin('id', tbl).OptArgs(r.EqJoinOpts{Index: 'ci', }).OrderBy('left', 'right')")
@@ -1647,7 +1647,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #465
 		/* err('ReqlQueryLogicError', 'Cannot use `nu' + 'll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
 		/* tbl.between(null, 2, index='id').count() */
 
 		suite.T().Log("About to run line #465: tbl.Between(nil, 2).OptArgs(r.BetweenOpts{Index: 'id', }).Count()")
@@ -1662,7 +1662,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #466
 		/* err('ReqlQueryLogicError', 'Cannot use `nu' + 'll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
 		/* tbl.between(2, null, index='id').count() */
 
 		suite.T().Log("About to run line #466: tbl.Between(2, nil).OptArgs(r.BetweenOpts{Index: 'id', }).Count()")
@@ -1677,7 +1677,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #467
 		/* err('ReqlQueryLogicError', 'Cannot use `nu' + 'll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use `nu"+"ll` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness.")
 		/* tbl.between(null, null, index='id').count() */
 
 		suite.T().Log("About to run line #467: tbl.Between(nil, nil).OptArgs(r.BetweenOpts{Index: 'id', }).Count()")
@@ -1692,7 +1692,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #479
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #479: tbl.Between(r.MinVal, r.MaxVal).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1707,7 +1707,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #483
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval).order_by(index='id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #483: tbl.Between(r.MinVal, r.MaxVal).OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1722,7 +1722,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #487
 		/* err('ReqlQueryLogicError', 'Cannot perform multiple BETWEENs on the same table.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform multiple BETWEENs on the same table.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform multiple BETWEENs on the same table.")
 		/* tbl.between(r.minval, r.maxval).between(r.minval, r.maxval).map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #487: tbl.Between(r.MinVal, r.MaxVal).Between(r.MinVal, r.MaxVal).Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1737,7 +1737,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #491
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.order_by(index='id').between(r.minval, 3).map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #491: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Between(r.MinVal, 3).Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1752,7 +1752,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #495
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #495: tbl.Between(0, r.MaxVal).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1767,7 +1767,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #499
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, 4).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #499: tbl.Between(r.MinVal, 4).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1782,7 +1782,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #503
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 4).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #503: tbl.Between(0, 4).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1797,7 +1797,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #507
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, 5).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #507: tbl.Between(-1, 5).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1812,7 +1812,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #511
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, 5).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #511: tbl.Between(5, 5).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1827,7 +1827,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #515
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #515: tbl.Between(5, r.MaxVal).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1842,7 +1842,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #519
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #519: tbl.Between(-1, -1).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1857,7 +1857,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #523
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1).order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #523: tbl.Between(r.MinVal, -1).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1872,7 +1872,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #528
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #528: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1887,7 +1887,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #532
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #532: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1902,7 +1902,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #536
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, 4, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #536: tbl.Between(r.MinVal, 4).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1917,7 +1917,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #540
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, 4, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #540: tbl.Between(0, 4).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1932,7 +1932,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #544
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, 5, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #544: tbl.Between(-1, 5).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1947,7 +1947,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #548
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, 5, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #548: tbl.Between(5, 5).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1962,7 +1962,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #552
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #552: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1977,7 +1977,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #556
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #556: tbl.Between(-1, -1).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -1992,7 +1992,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #560
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1, right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #560: tbl.Between(r.MinVal, -1).OptArgs(r.BetweenOpts{RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2007,7 +2007,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #565
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #565: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2022,7 +2022,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #569
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #569: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2037,7 +2037,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #573
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, 4, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #573: tbl.Between(r.MinVal, 4).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2052,7 +2052,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #577
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 4, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #577: tbl.Between(0, 4).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2067,7 +2067,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #581
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, 5, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #581: tbl.Between(-1, 5).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2082,7 +2082,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #585
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, 5, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #585: tbl.Between(5, 5).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2097,7 +2097,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #589
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #589: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2112,7 +2112,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #593
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #593: tbl.Between(-1, -1).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2127,7 +2127,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #597
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1, index='id').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #597: tbl.Between(r.MinVal, -1).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2142,7 +2142,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #602
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #602: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2157,7 +2157,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #606
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #606: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2172,7 +2172,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #610
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, 4, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #610: tbl.Between(r.MinVal, 4).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2187,7 +2187,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #614
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, 4, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #614: tbl.Between(0, 4).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2202,7 +2202,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #618
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, 5, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #618: tbl.Between(-1, 5).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2217,7 +2217,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #622
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, 5, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #622: tbl.Between(5, 5).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2232,7 +2232,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #626
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #626: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2247,7 +2247,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #630
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #630: tbl.Between(-1, -1).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2262,7 +2262,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #634
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1, index='id', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #634: tbl.Between(r.MinVal, -1).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2277,7 +2277,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #639
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #639: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2292,7 +2292,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #643
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #643: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2307,7 +2307,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #647
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, 4, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #647: tbl.Between(r.MinVal, 4).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2322,7 +2322,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #651
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 4, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #651: tbl.Between(0, 4).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2337,7 +2337,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #655
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, 5, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #655: tbl.Between(-1, 5).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2352,7 +2352,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #659
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, 5, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #659: tbl.Between(5, 5).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2367,7 +2367,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #663
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #663: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2382,7 +2382,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #667
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #667: tbl.Between(-1, -1).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2397,7 +2397,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #671
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1, index='idi').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #671: tbl.Between(r.MinVal, -1).OptArgs(r.BetweenOpts{Index: 'idi', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2412,7 +2412,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #676
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #676: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2427,7 +2427,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #680
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #680: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2442,7 +2442,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #684
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, 4, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #684: tbl.Between(r.MinVal, 4).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2457,7 +2457,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #688
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, 4, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #688: tbl.Between(0, 4).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2472,7 +2472,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #692
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, 5, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #692: tbl.Between(-1, 5).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2487,7 +2487,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #696
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, 5, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #696: tbl.Between(5, 5).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2502,7 +2502,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #700
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #700: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2517,7 +2517,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #704
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #704: tbl.Between(-1, -1).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2532,7 +2532,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #708
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1, index='idi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #708: tbl.Between(r.MinVal, -1).OptArgs(r.BetweenOpts{Index: 'idi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2547,7 +2547,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #713
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #713: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2562,7 +2562,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #717
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #717: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2577,7 +2577,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #721
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, 4, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #721: tbl.Between(r.MinVal, 4).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2592,7 +2592,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #725
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 4, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #725: tbl.Between(0, 4).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2607,7 +2607,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #729
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, 5, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #729: tbl.Between(0, 5).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2622,7 +2622,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #734
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #734: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2637,7 +2637,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #738
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #738: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2652,7 +2652,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #742
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, 4, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #742: tbl.Between(r.MinVal, 4).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2667,7 +2667,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #746
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, 4, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #746: tbl.Between(0, 4).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2682,7 +2682,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #750
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, 5, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #750: tbl.Between(0, 5).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2697,7 +2697,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #755
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 3, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #755: tbl.Between(0, 3).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2712,7 +2712,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #759
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 1, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #759: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2727,7 +2727,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #763
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(0, 0, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #763: tbl.Between(0, 0).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2742,7 +2742,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #767
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(-1, 2, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #767: tbl.Between(-1, 2).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2757,7 +2757,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #772
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 3, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #772: tbl.Between(0, 3).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2772,7 +2772,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #776
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 1, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #776: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2787,7 +2787,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #780
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 0, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #780: tbl.Between(0, 0).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2802,7 +2802,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #784
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(-1, 2, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #784: tbl.Between(-1, 2).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2817,7 +2817,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #789
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(1, 1, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #789: tbl.Between(1, 1).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2832,7 +2832,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #793
 		/* [4] */
-		var expected_ []interface{} = []interface{}{4}
+		var expected_ = []interface{}{4}
 		/* tbl.between(1, r.maxval, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #793: tbl.Between(1, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2847,7 +2847,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #797
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #797: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2862,7 +2862,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #801
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, 0, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #801: tbl.Between(r.MinVal, 0).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2877,7 +2877,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #805
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #805: tbl.Between(-1, -1).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2892,7 +2892,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #809
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1, index='ai').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #809: tbl.Between(r.MinVal, -1).OptArgs(r.BetweenOpts{Index: 'ai', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2907,7 +2907,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #814
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(1, 1, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #814: tbl.Between(1, 1).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2922,7 +2922,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #818
 		/* [4] */
-		var expected_ []interface{} = []interface{}{4}
+		var expected_ = []interface{}{4}
 		/* tbl.between(1, r.maxval, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #818: tbl.Between(1, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2937,7 +2937,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #822
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(5, r.maxval, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #822: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2952,7 +2952,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #826
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, 0, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #826: tbl.Between(r.MinVal, 0).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2967,7 +2967,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #830
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(-1, -1, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #830: tbl.Between(-1, -1).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2982,7 +2982,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #834
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, -1, index='ai', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #834: tbl.Between(r.MinVal, -1).OptArgs(r.BetweenOpts{Index: 'ai', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -2997,7 +2997,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #839
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(0, 1, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #839: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3012,7 +3012,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #843
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(-1, 1, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #843: tbl.Between(-1, 1).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3027,7 +3027,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #847
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(r.minval, 1, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #847: tbl.Between(r.MinVal, 1).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3042,7 +3042,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #851
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #851: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3057,7 +3057,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #855
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, r.maxval, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #855: tbl.Between(-1, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3072,7 +3072,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #859
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #859: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3087,7 +3087,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #863
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between(1, r.maxval, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #863: tbl.Between(1, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3102,7 +3102,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #867
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(1, 1, index='c').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #867: tbl.Between(1, 1).OptArgs(r.BetweenOpts{Index: 'c', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3117,7 +3117,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #872
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(0, 1, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #872: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3132,7 +3132,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #876
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(-1, 1, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #876: tbl.Between(-1, 1).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3147,7 +3147,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #880
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, 1, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #880: tbl.Between(r.MinVal, 1).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3162,7 +3162,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #884
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(0, r.maxval, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #884: tbl.Between(0, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3177,7 +3177,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #888
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(-1, r.maxval, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #888: tbl.Between(-1, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3192,7 +3192,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #892
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #892: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3207,7 +3207,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #896
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between(1, r.maxval, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #896: tbl.Between(1, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3222,7 +3222,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #900
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* tbl.between(1, 1, index='c', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #900: tbl.Between(1, 1).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3237,7 +3237,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #905
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('bc', lambda row:[row['b'], row['c']]) */
 
 		suite.T().Log("About to run line #905: tbl.IndexCreateFunc('bc', func(row r.Term) interface{} { return []interface{}{row.AtIndex('b'), row.AtIndex('c')}})")
@@ -3252,7 +3252,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #909
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('cb', lambda row:[row['c'], row['b']]) */
 
 		suite.T().Log("About to run line #909: tbl.IndexCreateFunc('cb', func(row r.Term) interface{} { return []interface{}{row.AtIndex('c'), row.AtIndex('b')}})")
@@ -3267,7 +3267,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #912
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait().pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #912: tbl.IndexWait().Pluck('index', 'ready')")
@@ -3282,7 +3282,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #915
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, [0, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #915: tbl.Between(r.MinVal, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3297,7 +3297,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #919
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between(r.minval, [0, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #919: tbl.Between(r.MinVal, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3312,7 +3312,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #923
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(r.minval, [0, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #923: tbl.Between(r.MinVal, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3327,7 +3327,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #927
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(r.minval, [0, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #927: tbl.Between(r.MinVal, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3342,7 +3342,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #931
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between(r.minval, [1, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #931: tbl.Between(r.MinVal, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3357,7 +3357,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #935
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(r.minval, [1, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #935: tbl.Between(r.MinVal, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3372,7 +3372,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #939
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between(r.minval, [1, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #939: tbl.Between(r.MinVal, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3387,7 +3387,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #943
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between(r.minval, [1, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #943: tbl.Between(r.MinVal, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3402,7 +3402,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #947
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #947: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3417,7 +3417,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #951
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #951: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3432,7 +3432,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #956
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(r.minval, [0, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #956: tbl.Between(r.MinVal, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3447,7 +3447,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #960
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(r.minval, [0, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #960: tbl.Between(r.MinVal, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3462,7 +3462,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #964
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between(r.minval, [0, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #964: tbl.Between(r.MinVal, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3477,7 +3477,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #968
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between(r.minval, [0, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #968: tbl.Between(r.MinVal, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3492,7 +3492,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #972
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between(r.minval, [1, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #972: tbl.Between(r.MinVal, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3507,7 +3507,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #976
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between(r.minval, [1, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #976: tbl.Between(r.MinVal, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3522,7 +3522,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #980
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, [1, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #980: tbl.Between(r.MinVal, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3537,7 +3537,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #984
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between(r.minval, [1, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #984: tbl.Between(r.MinVal, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3552,7 +3552,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #988
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #988: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3567,7 +3567,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #992
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between(r.minval, r.maxval, index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #992: tbl.Between(r.MinVal, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3582,7 +3582,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #997
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 0], [0, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #997: tbl.Between([]interface{}{0, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3597,7 +3597,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1001
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 0], [0, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1001: tbl.Between([]interface{}{0, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3612,7 +3612,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1005
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between([0, 0], [0, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1005: tbl.Between([]interface{}{0, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3627,7 +3627,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1009
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between([0, 0], [0, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1009: tbl.Between([]interface{}{0, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3642,7 +3642,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1013
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between([0, 0], [1, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1013: tbl.Between([]interface{}{0, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3657,7 +3657,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1017
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between([0, 0], [1, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1017: tbl.Between([]interface{}{0, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3672,7 +3672,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1021
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between([0, 0], [1, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1021: tbl.Between([]interface{}{0, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3687,7 +3687,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1025
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between([0, 0], [1, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1025: tbl.Between([]interface{}{0, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3702,7 +3702,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1029
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between([0, 0], r.maxval, index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1029: tbl.Between([]interface{}{0, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3717,7 +3717,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1033
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between([0, 0], r.maxval, index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1033: tbl.Between([]interface{}{0, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3732,7 +3732,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1038
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between([0, 0], [0, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1038: tbl.Between([]interface{}{0, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3747,7 +3747,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1042
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between([0, 0], [0, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1042: tbl.Between([]interface{}{0, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3762,7 +3762,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1046
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between([0, 0], [0, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1046: tbl.Between([]interface{}{0, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3777,7 +3777,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1050
 		/* [0, 1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* tbl.between([0, 0], [0, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1050: tbl.Between([]interface{}{0, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3792,7 +3792,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1054
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between([0, 0], [1, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1054: tbl.Between([]interface{}{0, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3807,7 +3807,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1058
 		/* [0, 1, 2] */
-		var expected_ []interface{} = []interface{}{0, 1, 2}
+		var expected_ = []interface{}{0, 1, 2}
 		/* tbl.between([0, 0], [1, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1058: tbl.Between([]interface{}{0, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3822,7 +3822,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1062
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between([0, 0], [1, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1062: tbl.Between([]interface{}{0, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3837,7 +3837,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1066
 		/* [0, 1, 2, 3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* tbl.between([0, 0], [1, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1066: tbl.Between([]interface{}{0, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3852,7 +3852,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1070
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between([0, 0], r.maxval, index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1070: tbl.Between([]interface{}{0, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3867,7 +3867,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1074
 		/* [0, 1, 2, 3, 4] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4}
+		var expected_ = []interface{}{0, 1, 2, 3, 4}
 		/* tbl.between([0, 0], r.maxval, index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1074: tbl.Between([]interface{}{0, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3882,7 +3882,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1079
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [0, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1079: tbl.Between([]interface{}{0, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3897,7 +3897,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1083
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [0, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1083: tbl.Between([]interface{}{0, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3912,7 +3912,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1087
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [0, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1087: tbl.Between([]interface{}{0, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3927,7 +3927,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1091
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [0, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1091: tbl.Between([]interface{}{0, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3942,7 +3942,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1095
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([0, 1], [1, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1095: tbl.Between([]interface{}{0, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3957,7 +3957,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1099
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [1, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1099: tbl.Between([]interface{}{0, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3972,7 +3972,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1103
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([0, 1], [1, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1103: tbl.Between([]interface{}{0, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -3987,7 +3987,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1107
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([0, 1], [1, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1107: tbl.Between([]interface{}{0, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4002,7 +4002,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1111
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between([0, 1], r.maxval, index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1111: tbl.Between([]interface{}{0, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4017,7 +4017,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1115
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between([0, 1], r.maxval, index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1115: tbl.Between([]interface{}{0, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4032,7 +4032,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1120
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [0, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1120: tbl.Between([]interface{}{0, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4047,7 +4047,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1124
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [0, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1124: tbl.Between([]interface{}{0, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4062,7 +4062,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1128
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([0, 1], [0, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1128: tbl.Between([]interface{}{0, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4077,7 +4077,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1132
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([0, 1], [0, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1132: tbl.Between([]interface{}{0, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4092,7 +4092,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1136
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([0, 1], [1, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1136: tbl.Between([]interface{}{0, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4107,7 +4107,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1140
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([0, 1], [1, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1140: tbl.Between([]interface{}{0, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4122,7 +4122,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1144
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* tbl.between([0, 1], [1, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1144: tbl.Between([]interface{}{0, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4137,7 +4137,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1148
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* tbl.between([0, 1], [1, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1148: tbl.Between([]interface{}{0, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4152,7 +4152,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1152
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between([0, 1], r.maxval, index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1152: tbl.Between([]interface{}{0, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4167,7 +4167,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1156
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between([0, 1], r.maxval, index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1156: tbl.Between([]interface{}{0, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4182,7 +4182,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1161
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1161: tbl.Between([]interface{}{1, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4197,7 +4197,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1165
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1165: tbl.Between([]interface{}{1, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4212,7 +4212,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1169
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1169: tbl.Between([]interface{}{1, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4227,7 +4227,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1173
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1173: tbl.Between([]interface{}{1, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4242,7 +4242,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1177
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [1, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1177: tbl.Between([]interface{}{1, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4257,7 +4257,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1181
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [1, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1181: tbl.Between([]interface{}{1, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4272,7 +4272,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1185
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [1, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1185: tbl.Between([]interface{}{1, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4287,7 +4287,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1189
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([1, 0], [1, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1189: tbl.Between([]interface{}{1, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4302,7 +4302,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1193
 		/* [3, 4] */
-		var expected_ []interface{} = []interface{}{3, 4}
+		var expected_ = []interface{}{3, 4}
 		/* tbl.between([1, 0], r.maxval, index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1193: tbl.Between([]interface{}{1, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4317,7 +4317,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1197
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between([1, 0], r.maxval, index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1197: tbl.Between([]interface{}{1, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4332,7 +4332,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1202
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1202: tbl.Between([]interface{}{1, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4347,7 +4347,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1206
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1206: tbl.Between([]interface{}{1, 0}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4362,7 +4362,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1210
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1210: tbl.Between([]interface{}{1, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4377,7 +4377,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1214
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [0, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1214: tbl.Between([]interface{}{1, 0}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4392,7 +4392,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1218
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 0], [1, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1218: tbl.Between([]interface{}{1, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4407,7 +4407,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1222
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* tbl.between([1, 0], [1, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1222: tbl.Between([]interface{}{1, 0}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4422,7 +4422,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1226
 		/* [3] */
-		var expected_ []interface{} = []interface{}{3}
+		var expected_ = []interface{}{3}
 		/* tbl.between([1, 0], [1, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1226: tbl.Between([]interface{}{1, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4437,7 +4437,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1230
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* tbl.between([1, 0], [1, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1230: tbl.Between([]interface{}{1, 0}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4452,7 +4452,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1234
 		/* [3, 4] */
-		var expected_ []interface{} = []interface{}{3, 4}
+		var expected_ = []interface{}{3, 4}
 		/* tbl.between([1, 0], r.maxval, index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1234: tbl.Between([]interface{}{1, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4467,7 +4467,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1238
 		/* [2, 3, 4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* tbl.between([1, 0], r.maxval, index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1238: tbl.Between([]interface{}{1, 0}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4482,7 +4482,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1243
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1243: tbl.Between([]interface{}{1, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4497,7 +4497,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1247
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1247: tbl.Between([]interface{}{1, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4512,7 +4512,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1251
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1251: tbl.Between([]interface{}{1, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4527,7 +4527,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1255
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1255: tbl.Between([]interface{}{1, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4542,7 +4542,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1259
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [1, 0], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1259: tbl.Between([]interface{}{1, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4557,7 +4557,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1263
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [1, 0], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1263: tbl.Between([]interface{}{1, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4572,7 +4572,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1267
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [1, 1], index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1267: tbl.Between([]interface{}{1, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4587,7 +4587,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1271
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [1, 1], index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1271: tbl.Between([]interface{}{1, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4602,7 +4602,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1275
 		/* [3, 4] */
-		var expected_ []interface{} = []interface{}{3, 4}
+		var expected_ = []interface{}{3, 4}
 		/* tbl.between([1, 1], r.maxval, index='bc').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1275: tbl.Between([]interface{}{1, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4617,7 +4617,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1279
 		/* [3, 4] */
-		var expected_ []interface{} = []interface{}{3, 4}
+		var expected_ = []interface{}{3, 4}
 		/* tbl.between([1, 1], r.maxval, index='cb').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1279: tbl.Between([]interface{}{1, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4632,7 +4632,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1284
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1284: tbl.Between([]interface{}{1, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4647,7 +4647,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1288
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1288: tbl.Between([]interface{}{1, 1}, []interface{}{0, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4662,7 +4662,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1292
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1292: tbl.Between([]interface{}{1, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4677,7 +4677,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1296
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [0, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1296: tbl.Between([]interface{}{1, 1}, []interface{}{0, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4692,7 +4692,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1300
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [1, 0], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1300: tbl.Between([]interface{}{1, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4707,7 +4707,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1304
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.between([1, 1], [1, 0], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1304: tbl.Between([]interface{}{1, 1}, []interface{}{1, 0}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4722,7 +4722,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1308
 		/* [3] */
-		var expected_ []interface{} = []interface{}{3}
+		var expected_ = []interface{}{3}
 		/* tbl.between([1, 1], [1, 1], index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1308: tbl.Between([]interface{}{1, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4737,7 +4737,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1312
 		/* [3] */
-		var expected_ []interface{} = []interface{}{3}
+		var expected_ = []interface{}{3}
 		/* tbl.between([1, 1], [1, 1], index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1312: tbl.Between([]interface{}{1, 1}, []interface{}{1, 1}).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4752,7 +4752,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1316
 		/* [3, 4] */
-		var expected_ []interface{} = []interface{}{3, 4}
+		var expected_ = []interface{}{3, 4}
 		/* tbl.between([1, 1], r.maxval, index='bc', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1316: tbl.Between([]interface{}{1, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'bc', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4767,7 +4767,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1320
 		/* [3, 4] */
-		var expected_ []interface{} = []interface{}{3, 4}
+		var expected_ = []interface{}{3, 4}
 		/* tbl.between([1, 1], r.maxval, index='cb', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1320: tbl.Between([]interface{}{1, 1}, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'cb', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4782,7 +4782,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1325
 		/* [0,0,0] */
-		var expected_ []interface{} = []interface{}{0, 0, 0}
+		var expected_ = []interface{}{0, 0, 0}
 		/* tbl.between(1, 3, index='mi', right_bound='closed').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1325: tbl.Between(1, 3).OptArgs(r.BetweenOpts{Index: 'mi', RightBound: 'closed', }).Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4797,7 +4797,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1330
 		/* [0,0,0,1,1,1,2,3,3,3,4,4,4] */
-		var expected_ []interface{} = []interface{}{0, 0, 0, 1, 1, 1, 2, 3, 3, 3, 4, 4, 4}
+		var expected_ = []interface{}{0, 0, 0, 1, 1, 1, 2, 3, 3, 3, 4, 4, 4}
 		/* tbl.between(1, 16, index='mi', right_bound='closed').order_by('id').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1330: tbl.Between(1, 16).OptArgs(r.BetweenOpts{Index: 'mi', RightBound: 'closed', }).OrderBy('id').Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4812,7 +4812,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1335
 		/* [0,0,0,1,1,1,2,3,3,3,4,4,4] */
-		var expected_ []interface{} = []interface{}{0, 0, 0, 1, 1, 1, 2, 3, 3, 3, 4, 4, 4}
+		var expected_ = []interface{}{0, 0, 0, 1, 1, 1, 2, 3, 3, 3, 4, 4, 4}
 		/* tbl.order_by(index='mi').map(lambda x:x['id']) */
 
 		suite.T().Log("About to run line #1335: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'mi', }).Map(func(x r.Term) interface{} { return x.AtIndex('id')})")
@@ -4827,7 +4827,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1341
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* tbl.between(0, 1, index='c', right_bound='closed', left_bound='open').order_by('id')['id'] */
 
 		suite.T().Log("About to run line #1341: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'c', RightBound: 'closed', LeftBound: 'open', }).OrderBy('id').AtIndex('id')")
@@ -4842,7 +4842,7 @@ func (suite *SindexApiSuite) TestCases() {
 	{
 		// sindex/api.yaml line #1345
 		/* [1] */
-		var expected_ []interface{} = []interface{}{1}
+		var expected_ = []interface{}{1}
 		/* tbl.between(0, 1, index='id', right_bound='closed', left_bound='open').order_by('id')['id'] */
 
 		suite.T().Log("About to run line #1345: tbl.Between(0, 1).OptArgs(r.BetweenOpts{Index: 'id', RightBound: 'closed', LeftBound: 'open', }).OrderBy('id').AtIndex('id')")

--- a/internal/integration/reql_tests/reql_sindex_nullsinstrings_test.go
+++ b/internal/integration/reql_tests/reql_sindex_nullsinstrings_test.go
@@ -70,7 +70,7 @@ func (suite *SindexNullsinstringsSuite) TestCases() {
 	{
 		// sindex/nullsinstrings.yaml line #4
 		/* ({"created":1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create("key") */
 
 		suite.T().Log("About to run line #4: tbl.IndexCreate('key')")
@@ -85,7 +85,7 @@ func (suite *SindexNullsinstringsSuite) TestCases() {
 	{
 		// sindex/nullsinstrings.yaml line #6
 		/* ([{"ready":true}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"ready": true}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"ready": true}}
 		/* tbl.index_wait().pluck("ready") */
 
 		suite.T().Log("About to run line #6: tbl.IndexWait().Pluck('ready')")
@@ -100,7 +100,7 @@ func (suite *SindexNullsinstringsSuite) TestCases() {
 	{
 		// sindex/nullsinstrings.yaml line #10
 		/* ({"inserted":2}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"inserted": 2}
+		var expected_ = map[interface{}]interface{}{"inserted": 2}
 		/* tbl.insert([{"id":1,"key":["a","b"]},{"id":2,"key":["a\u0000Sb"]}]).pluck("inserted") */
 
 		suite.T().Log("About to run line #10: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': 1, 'key': []interface{}{'a', 'b'}, }, map[interface{}]interface{}{'id': 2, 'key': []interface{}{'a\\u0000Sb'}, }}).Pluck('inserted')")
@@ -115,7 +115,7 @@ func (suite *SindexNullsinstringsSuite) TestCases() {
 	{
 		// sindex/nullsinstrings.yaml line #13
 		/* ([{"id":2}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 2}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 2}}
 		/* tbl.get_all(["a\u0000Sb"], index="key").pluck("id") */
 
 		suite.T().Log("About to run line #13: tbl.GetAll([]interface{}{'a\\u0000Sb'}).OptArgs(r.GetAllOpts{Index: 'key', }).Pluck('id')")
@@ -130,7 +130,7 @@ func (suite *SindexNullsinstringsSuite) TestCases() {
 	{
 		// sindex/nullsinstrings.yaml line #18
 		/* ([{"id":1}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 1}}
 		/* tbl.get_all(["a","b"], index="key").pluck("id") */
 
 		suite.T().Log("About to run line #18: tbl.GetAll([]interface{}{'a', 'b'}).OptArgs(r.GetAllOpts{Index: 'key', }).Pluck('id')")

--- a/internal/integration/reql_tests/reql_sindex_status_test.go
+++ b/internal/integration/reql_tests/reql_sindex_status_test.go
@@ -70,7 +70,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #7
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl2.index_create("a") */
 
 		suite.T().Log("About to run line #7: tbl2.IndexCreate('a')")
@@ -85,7 +85,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #9
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl2.index_create("b") */
 
 		suite.T().Log("About to run line #9: tbl2.IndexCreate('b')")
@@ -100,7 +100,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #12
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl2.index_status().count() */
 
 		suite.T().Log("About to run line #12: tbl2.IndexStatus().Count()")
@@ -115,7 +115,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #14
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl2.index_status("a").count() */
 
 		suite.T().Log("About to run line #14: tbl2.IndexStatus('a').Count()")
@@ -130,7 +130,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #16
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl2.index_status("b").count() */
 
 		suite.T().Log("About to run line #16: tbl2.IndexStatus('b').Count()")
@@ -145,7 +145,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #18
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl2.index_status("a", "b").count() */
 
 		suite.T().Log("About to run line #18: tbl2.IndexStatus('a', 'b').Count()")
@@ -160,7 +160,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #21
 		/* ({'dropped':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"dropped": 1}
+		var expected_ = map[interface{}]interface{}{"dropped": 1}
 		/* tbl2.index_drop("a") */
 
 		suite.T().Log("About to run line #21: tbl2.IndexDrop('a')")
@@ -175,7 +175,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #23
 		/* ({'dropped':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"dropped": 1}
+		var expected_ = map[interface{}]interface{}{"dropped": 1}
 		/* tbl2.index_drop("b") */
 
 		suite.T().Log("About to run line #23: tbl2.IndexDrop('b')")
@@ -190,7 +190,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #28
 		/* partial({'inserted':5000}) */
-		var expected_ compare.Expected = compare.PartialMatch(map[interface{}]interface{}{"inserted": 5000})
+		var expected_ = compare.PartialMatch(map[interface{}]interface{}{"inserted": 5000})
 		/* tbl2.insert(r.range(0, 5000).map({'a':r.row})) */
 
 		suite.T().Log("About to run line #28: tbl2.Insert(r.Range(0, 5000).Map(map[interface{}]interface{}{'a': r.Row, }))")
@@ -205,7 +205,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #33
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl2.index_create("foo") */
 
 		suite.T().Log("About to run line #33: tbl2.IndexCreate('foo')")
@@ -220,7 +220,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #36
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl2.index_create("bar", multi=True) */
 
 		suite.T().Log("About to run line #36: tbl2.IndexCreate('bar').OptArgs(r.IndexCreateOpts{Multi: true, })")
@@ -235,7 +235,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #44
 		/* [true, true] */
-		var expected_ []interface{} = []interface{}{true, true}
+		var expected_ = []interface{}{true, true}
 		/* tbl2.index_status().map(lambda x:x["progress"] < 1) */
 
 		suite.T().Log("About to run line #44: tbl2.IndexStatus().Map(func(x r.Term) interface{} { return x.AtIndex('progress').Lt(1)})")
@@ -250,7 +250,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #49
 		/* ([true, true]) */
-		var expected_ []interface{} = []interface{}{true, true}
+		var expected_ = []interface{}{true, true}
 		/* tbl2.index_wait()['ready'] */
 
 		suite.T().Log("About to run line #49: tbl2.IndexWait().AtIndex('ready')")
@@ -265,7 +265,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #54
 		/* bag([false, false]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{false, false})
+		var expected_ = compare.UnorderedMatch([]interface{}{false, false})
 		/* tbl2.index_wait()['geo'] */
 
 		suite.T().Log("About to run line #54: tbl2.IndexWait().AtIndex('geo')")
@@ -280,7 +280,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #57
 		/* bag([false, true]) */
-		var expected_ compare.Expected = compare.UnorderedMatch([]interface{}{false, true})
+		var expected_ = compare.UnorderedMatch([]interface{}{false, true})
 		/* tbl2.index_wait()['multi'] */
 
 		suite.T().Log("About to run line #57: tbl2.IndexWait().AtIndex('multi')")
@@ -295,7 +295,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #60
 		/* ([false, false]) */
-		var expected_ []interface{} = []interface{}{false, false}
+		var expected_ = []interface{}{false, false}
 		/* tbl2.index_wait()['outdated'] */
 
 		suite.T().Log("About to run line #60: tbl2.IndexWait().AtIndex('outdated')")
@@ -310,7 +310,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #63
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl2.index_create("quux") */
 
 		suite.T().Log("About to run line #63: tbl2.IndexCreate('quux')")
@@ -325,7 +325,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #66
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* tbl2.index_status("quux").do(lambda x:(x[0]["index"] == "quux") & (x[0]["progress"] < 1)) */
 
 		suite.T().Log("About to run line #66: tbl2.IndexStatus('quux').Do(func(x r.Term) interface{} { return x.AtIndex(0).AtIndex('index').Eq('quux').And(x.AtIndex(0).AtIndex('progress').Lt(1))})")
@@ -342,7 +342,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #71
 		/* ([{'index':'quux', 'ready':true}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"index": "quux", "ready": true}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"index": "quux", "ready": true}}
 		/* tbl2.index_wait("quux").pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #71: tbl2.IndexWait('quux').Pluck('index', 'ready')")
@@ -357,7 +357,7 @@ func (suite *SindexStatusSuite) TestCases() {
 	{
 		// sindex/status.yaml line #74
 		/* ("PTYPE<BINARY>") */
-		var expected_ string = "PTYPE<BINARY>"
+		var expected_ = "PTYPE<BINARY>"
 		/* tbl2.index_wait("quux").nth(0).get_field('function').type_of() */
 
 		suite.T().Log("About to run line #74: tbl2.IndexWait('quux').Nth(0).Field('function').TypeOf()")

--- a/internal/integration/reql_tests/reql_timeout_test.go
+++ b/internal/integration/reql_tests/reql_timeout_test.go
@@ -61,7 +61,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #5
 		/* err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 5.000 seconds.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 5.000 seconds.")
+		var expected_ = err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 5.000 seconds.")
 		/* r.js('while(true) {}') */
 
 		suite.T().Log("About to run line #5: r.JS('while(true) {}')")
@@ -76,7 +76,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #8
 		/* err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 1.300 seconds.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 1.300 seconds.")
+		var expected_ = err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 1.300 seconds.")
 		/* r.js('while(true) {}', timeout=1.3) */
 
 		suite.T().Log("About to run line #8: r.JS('while(true) {}').OptArgs(r.JSOpts{Timeout: 1.3, })")
@@ -91,7 +91,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #13
 		/* err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 8.000 seconds.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 8.000 seconds.")
+		var expected_ = err("ReqlQueryLogicError", "JavaScript query `while(true) {}` timed out after 8.000 seconds.")
 		/* r.js('while(true) {}', timeout=8) */
 
 		suite.T().Log("About to run line #13: r.JS('while(true) {}').OptArgs(r.JSOpts{Timeout: 8, })")
@@ -106,7 +106,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #18
 		/* err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 5.000 seconds.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 5.000 seconds.")
+		var expected_ = err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 5.000 seconds.")
 		/* r.expr('foo').do(r.js('(function(x) { while(true) {} })')) */
 
 		suite.T().Log("About to run line #18: r.Expr('foo').Do(r.JS('(function(x) { while(true) {} })'))")
@@ -121,7 +121,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #21
 		/* err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 1.300 seconds.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 1.300 seconds.")
+		var expected_ = err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 1.300 seconds.")
 		/* r.expr('foo').do(r.js('(function(x) { while(true) {} })', timeout=1.3)) */
 
 		suite.T().Log("About to run line #21: r.Expr('foo').Do(r.JS('(function(x) { while(true) {} })').OptArgs(r.JSOpts{Timeout: 1.3, }))")
@@ -136,7 +136,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #26
 		/* err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 8.000 seconds.", [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 8.000 seconds.")
+		var expected_ = err("ReqlQueryLogicError", "JavaScript query `(function(x) { while(true) {} })` timed out after 8.000 seconds.")
 		/* r.expr('foo').do(r.js('(function(x) { while(true) {} })', timeout=8)) */
 
 		suite.T().Log("About to run line #26: r.Expr('foo').Do(r.JS('(function(x) { while(true) {} })').OptArgs(r.JSOpts{Timeout: 8, }))")
@@ -151,7 +151,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #32
 		/* err("ReqlNonExistenceError", "Error in HTTP GET of `httpbin.org/delay/10`:" + " timed out after 0.800 seconds.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Error in HTTP GET of `httpbin.org/delay/10`:"+" timed out after 0.800 seconds.")
+		var expected_ = err("ReqlNonExistenceError", "Error in HTTP GET of `httpbin.org/delay/10`:"+" timed out after 0.800 seconds.")
 		/* r.http('httpbin.org/delay/10', timeout=0.8) */
 
 		suite.T().Log("About to run line #32: r.HTTP('httpbin.org/delay/10').OptArgs(r.HTTPOpts{Timeout: 0.8, })")
@@ -166,7 +166,7 @@ func (suite *TimeoutSuite) TestCases() {
 	{
 		// timeout.yaml line #36
 		/* err("ReqlNonExistenceError", "Error in HTTP PUT of `httpbin.org/delay/10`:" + " timed out after 0.000 seconds.", []) */
-		var expected_ Err = err("ReqlNonExistenceError", "Error in HTTP PUT of `httpbin.org/delay/10`:"+" timed out after 0.000 seconds.")
+		var expected_ = err("ReqlNonExistenceError", "Error in HTTP PUT of `httpbin.org/delay/10`:"+" timed out after 0.000 seconds.")
 		/* r.http('httpbin.org/delay/10', method='PUT', timeout=0.0) */
 
 		suite.T().Log("About to run line #36: r.HTTP('httpbin.org/delay/10').OptArgs(r.HTTPOpts{Method: 'PUT', Timeout: 0.0, })")

--- a/internal/integration/reql_tests/reql_times_api_test.go
+++ b/internal/integration/reql_tests/reql_times_api_test.go
@@ -112,7 +112,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #17
 		/* 1000 */
-		var expected_ int = 1000
+		var expected_ = 1000
 		/* (t1 - (t1 - 1000)) */
 
 		suite.T().Log("About to run line #17: r.Sub(t1, r.Sub(t1, 1000))")
@@ -127,7 +127,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #22
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* (t1 < t1) */
 
 		suite.T().Log("About to run line #22: r.Lt(t1, t1)")
@@ -142,7 +142,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #25
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* (t1 <= t1) */
 
 		suite.T().Log("About to run line #25: r.Le(t1, t1)")
@@ -157,7 +157,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #29
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* (t1 == t1) */
 
 		suite.T().Log("About to run line #29: r.Eq(t1, t1)")
@@ -172,7 +172,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #32
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* (t1 != t1) */
 
 		suite.T().Log("About to run line #32: r.Ne(t1, t1)")
@@ -187,7 +187,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #34
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* (t1 >= t1) */
 
 		suite.T().Log("About to run line #34: r.Ge(t1, t1)")
@@ -202,7 +202,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #37
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* (t1 > t1) */
 
 		suite.T().Log("About to run line #37: r.Gt(t1, t1)")
@@ -217,7 +217,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #40
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* (t1 < t2) */
 
 		suite.T().Log("About to run line #40: r.Lt(t1, t2)")
@@ -232,7 +232,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #43
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* (t1 <= t2) */
 
 		suite.T().Log("About to run line #43: r.Le(t1, t2)")
@@ -247,7 +247,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #47
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* (t1 == t2) */
 
 		suite.T().Log("About to run line #47: r.Eq(t1, t2)")
@@ -262,7 +262,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #50
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* (t1 != t2) */
 
 		suite.T().Log("About to run line #50: r.Ne(t1, t2)")
@@ -277,7 +277,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #52
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* (t1 >= t2) */
 
 		suite.T().Log("About to run line #52: r.Ge(t1, t2)")
@@ -292,7 +292,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #55
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* (t1 > t2) */
 
 		suite.T().Log("About to run line #55: r.Gt(t1, t2)")
@@ -307,7 +307,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #60
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* t1.during(t1, t1 + 1000) */
 
 		suite.T().Log("About to run line #60: t1.During(t1, r.Add(t1, 1000))")
@@ -322,7 +322,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #64
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* t1.during(t1, t1 + 1000, left_bound='open') */
 
 		suite.T().Log("About to run line #64: t1.During(t1, r.Add(t1, 1000)).OptArgs(r.DuringOpts{LeftBound: 'open', })")
@@ -337,7 +337,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #67
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* t1.during(t1, t1) */
 
 		suite.T().Log("About to run line #67: t1.During(t1, t1)")
@@ -352,7 +352,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #70
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* t1.during(t1, t1, right_bound='closed') */
 
 		suite.T().Log("About to run line #70: t1.During(t1, t1).OptArgs(r.DuringOpts{RightBound: 'closed', })")
@@ -367,7 +367,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #77
 		/* 1375142400 */
-		var expected_ int = 1375142400
+		var expected_ = 1375142400
 		/* t1.date().to_epoch_time() */
 
 		suite.T().Log("About to run line #77: t1.Date().ToEpochTime()")
@@ -397,7 +397,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #81
 		/* 2013 */
-		var expected_ int = 2013
+		var expected_ = 2013
 		/* t1.year() */
 
 		suite.T().Log("About to run line #81: t1.Year()")
@@ -412,7 +412,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #83
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* t1.month() */
 
 		suite.T().Log("About to run line #83: t1.Month()")
@@ -427,7 +427,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #85
 		/* 30 */
-		var expected_ int = 30
+		var expected_ = 30
 		/* t1.day() */
 
 		suite.T().Log("About to run line #85: t1.Day()")
@@ -442,7 +442,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #87
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* t1.day_of_week() */
 
 		suite.T().Log("About to run line #87: t1.DayOfWeek()")
@@ -457,7 +457,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #89
 		/* 211 */
-		var expected_ int = 211
+		var expected_ = 211
 		/* t1.day_of_year() */
 
 		suite.T().Log("About to run line #89: t1.DayOfYear()")
@@ -472,7 +472,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #91
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* t1.hours() */
 
 		suite.T().Log("About to run line #91: t1.Hours()")
@@ -487,7 +487,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #93
 		/* 21 */
-		var expected_ int = 21
+		var expected_ = 21
 		/* t1.minutes() */
 
 		suite.T().Log("About to run line #93: t1.Minutes()")
@@ -532,7 +532,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #101
 		/* ("-07:00") */
-		var expected_ string = "-07:00"
+		var expected_ = "-07:00"
 		/* r.time(2013, r.july, 29, 23, 30, 0.1, "-07:00").timezone() */
 
 		suite.T().Log("About to run line #101: r.Time(2013, r.July, 29, 23, 30, 0.1, '-07:00').Timezone()")
@@ -547,7 +547,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #103
 		/* err("ReqlQueryLogicError", "Got 6 arguments to TIME (expected 4 or 7).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Got 6 arguments to TIME (expected 4 or 7).")
+		var expected_ = err("ReqlQueryLogicError", "Got 6 arguments to TIME (expected 4 or 7).")
 		/* r.time(2013, r.july, 29, 23, 30, 0.1).to_epoch_time() */
 
 		suite.T().Log("About to run line #103: r.Time(2013, r.July, 29, 23, 30, 0.1).ToEpochTime()")
@@ -562,7 +562,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #105
 		/* err("ReqlQueryLogicError", "Got 6 arguments to TIME (expected 4 or 7).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Got 6 arguments to TIME (expected 4 or 7).")
+		var expected_ = err("ReqlQueryLogicError", "Got 6 arguments to TIME (expected 4 or 7).")
 		/* r.time(2013, r.july, 29, 23, 30, 0.1).timezone() */
 
 		suite.T().Log("About to run line #105: r.Time(2013, r.July, 29, 23, 30, 0.1).Timezone()")
@@ -577,7 +577,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #107
 		/* err("ReqlQueryLogicError", "Got 5 arguments to TIME (expected 4 or 7).", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Got 5 arguments to TIME (expected 4 or 7).")
+		var expected_ = err("ReqlQueryLogicError", "Got 5 arguments to TIME (expected 4 or 7).")
 		/* r.time(2013, r.july, 29, 23, 30).to_epoch_time() */
 
 		suite.T().Log("About to run line #107: r.Time(2013, r.July, 29, 23, 30).ToEpochTime()")
@@ -592,7 +592,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #109
 		/* err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found NUMBER.")
 		/* r.time(2013, r.july, 29, 23).to_epoch_time() */
 
 		suite.T().Log("About to run line #109: r.Time(2013, r.July, 29, 23).ToEpochTime()")
@@ -607,7 +607,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #111
 		/* 1375081200 */
-		var expected_ int = 1375081200
+		var expected_ = 1375081200
 		/* r.time(2013, r.july, 29, "-07:00").to_epoch_time() */
 
 		suite.T().Log("About to run line #111: r.Time(2013, r.July, 29, '-07:00').ToEpochTime()")
@@ -622,7 +622,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #113
 		/* ("-07:00") */
-		var expected_ string = "-07:00"
+		var expected_ = "-07:00"
 		/* r.time(2013, r.july, 29, "-07:00").timezone() */
 
 		suite.T().Log("About to run line #113: r.Time(2013, r.July, 29, '-07:00').Timezone()")
@@ -637,7 +637,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #119
 		/* 1375242965 */
-		var expected_ int = 1375242965
+		var expected_ = 1375242965
 		/* r.iso8601("2013-07-30T20:56:05-07:00").to_epoch_time() */
 
 		suite.T().Log("About to run line #119: r.ISO8601('2013-07-30T20:56:05-07:00').ToEpochTime()")
@@ -652,7 +652,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #122
 		/* ("2013-07-30T20:56:05-07:00") */
-		var expected_ string = "2013-07-30T20:56:05-07:00"
+		var expected_ = "2013-07-30T20:56:05-07:00"
 		/* r.epoch_time(1375242965).in_timezone("-07:00").to_iso8601() */
 
 		suite.T().Log("About to run line #122: r.EpochTime(1375242965).InTimezone('-07:00').ToISO8601()")
@@ -667,7 +667,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #125
 		/* ("PTYPE<TIME>") */
-		var expected_ string = "PTYPE<TIME>"
+		var expected_ = "PTYPE<TIME>"
 		/* r.now().type_of() */
 
 		suite.T().Log("About to run line #125: r.Now().TypeOf()")
@@ -682,7 +682,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #127
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* (r.now() - r.now()) */
 
 		suite.T().Log("About to run line #127: r.Now().Sub(r.Now())")
@@ -697,7 +697,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #132
 		/* err("ReqlQueryLogicError", "ISO 8601 string has no time zone, and no default time zone was provided.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "ISO 8601 string has no time zone, and no default time zone was provided.")
+		var expected_ = err("ReqlQueryLogicError", "ISO 8601 string has no time zone, and no default time zone was provided.")
 		/* r.iso8601("2013-07-30T20:56:05").to_iso8601() */
 
 		suite.T().Log("About to run line #132: r.ISO8601('2013-07-30T20:56:05').ToISO8601()")
@@ -712,7 +712,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #136
 		/* ("2013-07-30T20:56:05-07:00") */
-		var expected_ string = "2013-07-30T20:56:05-07:00"
+		var expected_ = "2013-07-30T20:56:05-07:00"
 		/* r.iso8601("2013-07-30T20:56:05", default_timezone='-07').to_iso8601() */
 
 		suite.T().Log("About to run line #136: r.ISO8601('2013-07-30T20:56:05').OptArgs(r.ISO8601Opts{DefaultTimezone: '-07', }).ToISO8601()")
@@ -727,7 +727,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #140
 		/* ([1, 2, 3, 4, 5, 6, 7]) */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4, 5, 6, 7}
+		var expected_ = []interface{}{1, 2, 3, 4, 5, 6, 7}
 		/* r.expr([r.monday, r.tuesday, r.wednesday, r.thursday, r.friday, r.saturday, r.sunday]) */
 
 		suite.T().Log("About to run line #140: r.Expr([]interface{}{r.Monday, r.Tuesday, r.Wednesday, r.Thursday, r.Friday, r.Saturday, r.Sunday})")
@@ -742,7 +742,7 @@ func (suite *TimesApiSuite) TestCases() {
 	{
 		// times/api.yaml line #142
 		/* ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]) */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+		var expected_ = []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 		/* r.expr([r.january, r.february, r.march, r.april, r.may, r.june,
 		r.july, r.august, r.september, r.october, r.november, r.december]) */
 

--- a/internal/integration/reql_tests/reql_times_constructors_test.go
+++ b/internal/integration/reql_tests/reql_times_constructors_test.go
@@ -76,7 +76,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #11
 		/* {'stuff':datetime.fromtimestamp(896571240, r.ast.RqlTzinfo('00:00')), 'more':[datetime.fromtimestamp(996571240, r.ast.RqlTzinfo('00:00'))]} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"stuff": Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00")), "more": []interface{}{Ast.Fromtimestamp(996571240, Ast.RqlTzinfo("00:00"))}}
+		var expected_ = map[interface{}]interface{}{"stuff": Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00")), "more": []interface{}{Ast.Fromtimestamp(996571240, Ast.RqlTzinfo("00:00"))}}
 		/* r.expr({'stuff':r.epoch_time(896571240), 'more':[r.epoch_time(996571240)]}) */
 
 		suite.T().Log("About to run line #11: r.Expr(map[interface{}]interface{}{'stuff': r.EpochTime(896571240), 'more': []interface{}{r.EpochTime(996571240)}, })")
@@ -91,7 +91,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #17
 		/* [datetime.fromtimestamp(796571240, r.ast.RqlTzinfo('00:00')), datetime.fromtimestamp(896571240, r.ast.RqlTzinfo('00:00')), {'stuff':datetime.fromtimestamp(996571240, r.ast.RqlTzinfo('00:00'))}] */
-		var expected_ []interface{} = []interface{}{Ast.Fromtimestamp(796571240, Ast.RqlTzinfo("00:00")), Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00")), map[interface{}]interface{}{"stuff": Ast.Fromtimestamp(996571240, Ast.RqlTzinfo("00:00"))}}
+		var expected_ = []interface{}{Ast.Fromtimestamp(796571240, Ast.RqlTzinfo("00:00")), Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00")), map[interface{}]interface{}{"stuff": Ast.Fromtimestamp(996571240, Ast.RqlTzinfo("00:00"))}}
 		/* r.expr([r.epoch_time(796571240), r.epoch_time(896571240), {'stuff':r.epoch_time(996571240)}]) */
 
 		suite.T().Log("About to run line #17: r.Expr([]interface{}{r.EpochTime(796571240), r.EpochTime(896571240), map[interface{}]interface{}{'stuff': r.EpochTime(996571240), }})")
@@ -106,7 +106,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #23
 		/* {'nested':{'time':datetime.fromtimestamp(896571240, r.ast.RqlTzinfo('00:00'))}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"nested": map[interface{}]interface{}{"time": Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00"))}}
+		var expected_ = map[interface{}]interface{}{"nested": map[interface{}]interface{}{"time": Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00"))}}
 		/* r.expr({'nested':{'time':r.epoch_time(896571240)}}) */
 
 		suite.T().Log("About to run line #23: r.Expr(map[interface{}]interface{}{'nested': map[interface{}]interface{}{'time': r.EpochTime(896571240), }, })")
@@ -121,7 +121,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #29
 		/* [1, "two", ["a", datetime.fromtimestamp(896571240, r.ast.RqlTzinfo('00:00')), 3]] */
-		var expected_ []interface{} = []interface{}{1, "two", []interface{}{"a", Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00")), 3}}
+		var expected_ = []interface{}{1, "two", []interface{}{"a", Ast.Fromtimestamp(896571240, Ast.RqlTzinfo("00:00")), 3}}
 		/* r.expr([1, "two", ["a", r.epoch_time(896571240), 3]]) */
 
 		suite.T().Log("About to run line #29: r.Expr([]interface{}{1, 'two', []interface{}{'a', r.EpochTime(896571240), 3}})")
@@ -136,7 +136,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #35
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.epoch_time(1).to_epoch_time() */
 
 		suite.T().Log("About to run line #35: r.EpochTime(1).ToEpochTime()")
@@ -151,7 +151,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #37
 		/* -1 */
-		var expected_ int = -1
+		var expected_ = -1
 		/* r.epoch_time(-1).to_epoch_time() */
 
 		suite.T().Log("About to run line #37: r.EpochTime(-1).ToEpochTime()")
@@ -181,7 +181,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #42
 		/* "1970-01-01T00:00:01.444+00:00" */
-		var expected_ string = "1970-01-01T00:00:01.444+00:00"
+		var expected_ = "1970-01-01T00:00:01.444+00:00"
 		/* r.epoch_time(1.4444445).to_iso8601() */
 
 		suite.T().Log("About to run line #42: r.EpochTime(1.4444445).ToISO8601()")
@@ -211,7 +211,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #49
 		/* "1970-01-01T00:00:01.444+00:00" */
-		var expected_ string = "1970-01-01T00:00:01.444+00:00"
+		var expected_ = "1970-01-01T00:00:01.444+00:00"
 		/* r.epoch_time(1.444).to_iso8601() */
 
 		suite.T().Log("About to run line #49: r.EpochTime(1.444).ToISO8601()")
@@ -226,7 +226,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #52
 		/* "1970-01-01T00:00:01.001+00:00" */
-		var expected_ string = "1970-01-01T00:00:01.001+00:00"
+		var expected_ = "1970-01-01T00:00:01.001+00:00"
 		/* r.epoch_time(1.001).to_iso8601() */
 
 		suite.T().Log("About to run line #52: r.EpochTime(1.001).ToISO8601()")
@@ -241,7 +241,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #55
 		/* "1970-01-01T00:00:02.058+00:00" */
-		var expected_ string = "1970-01-01T00:00:02.058+00:00"
+		var expected_ = "1970-01-01T00:00:02.058+00:00"
 		/* r.epoch_time(2.058).to_iso8601() */
 
 		suite.T().Log("About to run line #55: r.EpochTime(2.058).ToISO8601()")
@@ -256,7 +256,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #66
 		/* 253440000000 */
-		var expected_ int = 253440000000
+		var expected_ = 253440000000
 		/* r.epoch_time(253440000000).to_epoch_time() */
 
 		suite.T().Log("About to run line #66: r.EpochTime(253440000000).ToEpochTime()")
@@ -271,7 +271,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #68
 		/* 1400 */
-		var expected_ int = 1400
+		var expected_ = 1400
 		/* r.epoch_time(-17980000000).year() */
 
 		suite.T().Log("About to run line #68: r.EpochTime(-17980000000).Year()")
@@ -286,7 +286,7 @@ func (suite *TimesConstructorsSuite) TestCases() {
 	{
 		// times/constructors.yaml line #72
 		/* -17990000000 */
-		var expected_ int = -17990000000
+		var expected_ = -17990000000
 		/* r.epoch_time(-17990000000).to_epoch_time() */
 
 		suite.T().Log("About to run line #72: r.EpochTime(-17990000000).ToEpochTime()")

--- a/internal/integration/reql_tests/reql_times_index_test.go
+++ b/internal/integration/reql_tests/reql_times_index_test.go
@@ -126,7 +126,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #37
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* tbl.insert(trows)['inserted'] */
 
 		suite.T().Log("About to run line #37: tbl.Insert(trows).AtIndex('inserted')")
@@ -148,7 +148,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #42
 		/* ("Duplicate primary key `id`:\n{\n\t\"id\":\t{\n\t\t\"$reql_type$\":\t\"TIME\",\n\t\t\"epoch_time\":\t1375445163.087,\n\t\t\"timezone\":\t\"-07:00\"\n\t}\n}\n{\n\t\"id\":\t{\n\t\t\"$reql_type$\":\t\"TIME\",\n\t\t\"epoch_time\":\t1375445163.087,\n\t\t\"timezone\":\t\"+00:00\"\n\t}\n}") */
-		var expected_ string = "Duplicate primary key `id`:\n{\n\t\"id\":\t{\n\t\t\"$reql_type$\":\t\"TIME\",\n\t\t\"epoch_time\":\t1375445163.087,\n\t\t\"timezone\":\t\"-07:00\"\n\t}\n}\n{\n\t\"id\":\t{\n\t\t\"$reql_type$\":\t\"TIME\",\n\t\t\"epoch_time\":\t1375445163.087,\n\t\t\"timezone\":\t\"+00:00\"\n\t}\n}"
+		var expected_ = "Duplicate primary key `id`:\n{\n\t\"id\":\t{\n\t\t\"$reql_type$\":\t\"TIME\",\n\t\t\"epoch_time\":\t1375445163.087,\n\t\t\"timezone\":\t\"-07:00\"\n\t}\n}\n{\n\t\"id\":\t{\n\t\t\"$reql_type$\":\t\"TIME\",\n\t\t\"epoch_time\":\t1375445163.087,\n\t\t\"timezone\":\t\"+00:00\"\n\t}\n}"
 		/* tbl.insert(bad_insert)['first_error'] */
 
 		suite.T().Log("About to run line #42: tbl.Insert(bad_insert).AtIndex('first_error')")
@@ -163,7 +163,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #46
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* tbl.between(ts, te).count() */
 
 		suite.T().Log("About to run line #46: tbl.Between(ts, te).Count()")
@@ -178,7 +178,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #48
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(t1, t4).count() */
 
 		suite.T().Log("About to run line #48: tbl.Between(t1, t4).Count()")
@@ -193,7 +193,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #51
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* tbl.between(t1, t4, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #51: tbl.Between(t1, t4).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Count()")
@@ -208,7 +208,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #54
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* tbl.between(r.expr(ts).in_timezone("+06:00"), te).count() */
 
 		suite.T().Log("About to run line #54: tbl.Between(r.Expr(ts).InTimezone('+06:00'), te).Count()")
@@ -223,7 +223,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #56
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(t1, r.expr(t4).in_timezone("+08:00")).count() */
 
 		suite.T().Log("About to run line #56: tbl.Between(t1, r.Expr(t4).InTimezone('+08:00')).Count()")
@@ -238,7 +238,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #59
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* tbl.between(r.expr(t1).in_timezone("Z"), t4, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #59: tbl.Between(r.Expr(t1).InTimezone('Z'), t4).OptArgs(r.BetweenOpts{RightBound: 'closed', }).Count()")
@@ -253,7 +253,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #64
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* tbl.update(lambda row:{'a':row['id']})['replaced'] */
 
 		suite.T().Log("About to run line #64: tbl.Update(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': row.AtIndex('id'), }}).AtIndex('replaced')")
@@ -268,7 +268,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #67
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('a') */
 
 		suite.T().Log("About to run line #67: tbl.IndexCreate('a')")
@@ -283,7 +283,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #69
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.index_wait('a').count() */
 
 		suite.T().Log("About to run line #69: tbl.IndexWait('a').Count()")
@@ -298,7 +298,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #73
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* tbl.between(ts, te, index='a').count() */
 
 		suite.T().Log("About to run line #73: tbl.Between(ts, te).OptArgs(r.BetweenOpts{Index: 'a', }).Count()")
@@ -313,7 +313,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #77
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(t1, t4, index='a').count() */
 
 		suite.T().Log("About to run line #77: tbl.Between(t1, t4).OptArgs(r.BetweenOpts{Index: 'a', }).Count()")
@@ -328,7 +328,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #81
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* tbl.between(t1, t4, right_bound='closed', index='a').count() */
 
 		suite.T().Log("About to run line #81: tbl.Between(t1, t4).OptArgs(r.BetweenOpts{RightBound: 'closed', Index: 'a', }).Count()")
@@ -343,7 +343,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #85
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* tbl.between(r.expr(ts).in_timezone("+06:00"), te, index='a').count() */
 
 		suite.T().Log("About to run line #85: tbl.Between(r.Expr(ts).InTimezone('+06:00'), te).OptArgs(r.BetweenOpts{Index: 'a', }).Count()")
@@ -358,7 +358,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #89
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(t1, r.expr(t4).in_timezone("+08:00"), index='a').count() */
 
 		suite.T().Log("About to run line #89: tbl.Between(t1, r.Expr(t4).InTimezone('+08:00')).OptArgs(r.BetweenOpts{Index: 'a', }).Count()")
@@ -373,7 +373,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #93
 		/* 4 */
-		var expected_ int = 4
+		var expected_ = 4
 		/* tbl.between(r.expr(t1).in_timezone("Z"), t4, right_bound='closed', index='a').count() */
 
 		suite.T().Log("About to run line #93: tbl.Between(r.Expr(t1).InTimezone('Z'), t4).OptArgs(r.BetweenOpts{RightBound: 'closed', Index: 'a', }).Count()")
@@ -388,7 +388,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #98
 		/* ({'created':1}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('b', lambda row:r.branch(row['id'] < t4, row['a'], null)) */
 
 		suite.T().Log("About to run line #98: tbl.IndexCreateFunc('b', func(row r.Term) interface{} { return r.Branch(row.AtIndex('id').Lt(t4), row.AtIndex('a'), nil)})")
@@ -403,7 +403,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #101
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.index_wait('b').count() */
 
 		suite.T().Log("About to run line #101: tbl.IndexWait('b').Count()")
@@ -418,7 +418,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #105
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.index_wait('b').count() */
 
 		suite.T().Log("About to run line #105: tbl.IndexWait('b').Count()")
@@ -433,7 +433,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #109
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(ts, te, index='b').count() */
 
 		suite.T().Log("About to run line #109: tbl.Between(ts, te).OptArgs(r.BetweenOpts{Index: 'b', }).Count()")
@@ -448,7 +448,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #113
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(t1, t4, index='b').count() */
 
 		suite.T().Log("About to run line #113: tbl.Between(t1, t4).OptArgs(r.BetweenOpts{Index: 'b', }).Count()")
@@ -463,7 +463,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #117
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(t1, t4, right_bound='closed', index='b').count() */
 
 		suite.T().Log("About to run line #117: tbl.Between(t1, t4).OptArgs(r.BetweenOpts{RightBound: 'closed', Index: 'b', }).Count()")
@@ -478,7 +478,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #121
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(r.expr(ts).in_timezone("+06:00"), te, index='b').count() */
 
 		suite.T().Log("About to run line #121: tbl.Between(r.Expr(ts).InTimezone('+06:00'), te).OptArgs(r.BetweenOpts{Index: 'b', }).Count()")
@@ -493,7 +493,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #125
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(t1, r.expr(t4).in_timezone("+08:00"), index='b').count() */
 
 		suite.T().Log("About to run line #125: tbl.Between(t1, r.Expr(t4).InTimezone('+08:00')).OptArgs(r.BetweenOpts{Index: 'b', }).Count()")
@@ -508,7 +508,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #129
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* tbl.between(r.expr(t1).in_timezone("Z"), t4, right_bound='closed', index='b').count() */
 
 		suite.T().Log("About to run line #129: tbl.Between(r.Expr(t1).InTimezone('Z'), t4).OptArgs(r.BetweenOpts{RightBound: 'closed', Index: 'b', }).Count()")
@@ -537,7 +537,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #142
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.insert([{'id':oldtime}])['inserted'] */
 
 		suite.T().Log("About to run line #142: tbl.Insert([]interface{}{map[interface{}]interface{}{'id': oldtime, }}).AtIndex('inserted')")
@@ -552,7 +552,7 @@ func (suite *TimesIndexSuite) TestCases() {
 	{
 		// times/index.yaml line #148
 		/* ("PTYPE<TIME>") */
-		var expected_ string = "PTYPE<TIME>"
+		var expected_ = "PTYPE<TIME>"
 		/* tbl.get(oldtime)['id'].type_of() */
 
 		suite.T().Log("About to run line #148: tbl.Get(oldtime).AtIndex('id').TypeOf()")

--- a/internal/integration/reql_tests/reql_times_portions_test.go
+++ b/internal/integration/reql_tests/reql_times_portions_test.go
@@ -131,7 +131,7 @@ func (suite *TimesPortionsSuite) TestCases() {
 	{
 		// times/portions.yaml line #16
 		/* ([1375142400, 1375142400, 1375142400, 2375136000]) */
-		var expected_ []interface{} = []interface{}{1375142400, 1375142400, 1375142400, 2375136000}
+		var expected_ = []interface{}{1375142400, 1375142400, 1375142400, 2375136000}
 		/* ts.map(lambda x:x.date()).map(lambda x:x.to_epoch_time()) */
 
 		suite.T().Log("About to run line #16: ts.Map(func(x r.Term) interface{} { return x.Date()}).Map(func(x r.Term) interface{} { return x.ToEpochTime()})")
@@ -146,7 +146,7 @@ func (suite *TimesPortionsSuite) TestCases() {
 	{
 		// times/portions.yaml line #20
 		/* ([0, 0, 0, 0]) */
-		var expected_ []interface{} = []interface{}{0, 0, 0, 0}
+		var expected_ = []interface{}{0, 0, 0, 0}
 		/* ts.map(lambda x:x.date().time_of_day()) */
 
 		suite.T().Log("About to run line #20: ts.Map(func(x r.Term) interface{} { return x.Date().TimeOfDay()})")
@@ -161,7 +161,7 @@ func (suite *TimesPortionsSuite) TestCases() {
 	{
 		// times/portions.yaml line #24
 		/* ([4896.681, 4896.682, 4897.681, 11296.681]) */
-		var expected_ []interface{} = []interface{}{4896.681, 4896.682, 4897.681, 11296.681}
+		var expected_ = []interface{}{4896.681, 4896.682, 4897.681, 11296.681}
 		/* ts.map(lambda x:x.time_of_day()) */
 
 		suite.T().Log("About to run line #24: ts.Map(func(x r.Term) interface{} { return x.TimeOfDay()})")
@@ -179,7 +179,7 @@ func (suite *TimesPortionsSuite) TestCases() {
 		[2013, 7, 30, 1, 21, 36.682],
 		[2013, 7, 30, 1, 21, 37.681],
 		[2045, 4, 7, 3, 8, 16.681]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{2013, 7, 30, 1, 21, 36.681}, []interface{}{2013, 7, 30, 1, 21, 36.682}, []interface{}{2013, 7, 30, 1, 21, 37.681}, []interface{}{2045, 4, 7, 3, 8, 16.681}}
+		var expected_ = []interface{}{[]interface{}{2013, 7, 30, 1, 21, 36.681}, []interface{}{2013, 7, 30, 1, 21, 36.682}, []interface{}{2013, 7, 30, 1, 21, 37.681}, []interface{}{2045, 4, 7, 3, 8, 16.681}}
 		/* ts.map(lambda x:[x.year(), x.month(), x.day(), x.hours(), x.minutes(), x.seconds()]) */
 
 		suite.T().Log("About to run line #29: ts.Map(func(x r.Term) interface{} { return []interface{}{x.Year(), x.Month(), x.Day(), x.Hours(), x.Minutes(), x.Seconds()}})")
@@ -196,7 +196,7 @@ func (suite *TimesPortionsSuite) TestCases() {
 	{
 		// times/portions.yaml line #36
 		/* rts */
-		var expected_ []interface{} = rts
+		var expected_ = rts
 		/* ts.map(lambda x:r.time(x.year(), x.month(), x.day(), x.hours(), x.minutes(), x.seconds(), x.timezone())).map(lambda x:x.to_epoch_time()) */
 
 		suite.T().Log("About to run line #36: ts.Map(func(x r.Term) interface{} { return r.Time(x.Year(), x.Month(), x.Day(), x.Hours(), x.Minutes(), x.Seconds(), x.Timezone())}).Map(func(x r.Term) interface{} { return x.ToEpochTime()})")
@@ -213,7 +213,7 @@ func (suite *TimesPortionsSuite) TestCases() {
 	{
 		// times/portions.yaml line #40
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* ts.map(lambda x:r.time(x.year(), x.month(), x.day(), x.hours(), x.minutes(), x.seconds(), x.timezone())).union(ts).map(lambda x:x.to_iso8601()).distinct().count().sub(ts.count()) */
 
 		suite.T().Log("About to run line #40: ts.Map(func(x r.Term) interface{} { return r.Time(x.Year(), x.Month(), x.Day(), x.Hours(), x.Minutes(), x.Seconds(), x.Timezone())}).Union(ts).Map(func(x r.Term) interface{} { return x.ToISO8601()}).Distinct().Count().Sub(ts.Count())")
@@ -230,7 +230,7 @@ func (suite *TimesPortionsSuite) TestCases() {
 	{
 		// times/portions.yaml line #44
 		/* [[2, 211], [2, 211], [2, 211], [5, 97]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{2, 211}, []interface{}{2, 211}, []interface{}{2, 211}, []interface{}{5, 97}}
+		var expected_ = []interface{}{[]interface{}{2, 211}, []interface{}{2, 211}, []interface{}{2, 211}, []interface{}{5, 97}}
 		/* ts.map([r.row.day_of_week(), r.row.day_of_year()]) */
 
 		suite.T().Log("About to run line #44: ts.Map([]interface{}{r.Row.DayOfWeek(), r.Row.DayOfYear()})")

--- a/internal/integration/reql_tests/reql_times_shim_test.go
+++ b/internal/integration/reql_tests/reql_times_shim_test.go
@@ -68,7 +68,7 @@ func (suite *TimesShimSuite) TestCases() {
 	{
 		// times/shim.yaml line #8
 		/* ("2013-07-29T18:21:36.680-07:00") */
-		var expected_ string = "2013-07-29T18:21:36.680-07:00"
+		var expected_ = "2013-07-29T18:21:36.680-07:00"
 		/* r.expr(datetime.fromtimestamp(t, PacificTimeZone())).to_iso8601() */
 
 		suite.T().Log("About to run line #8: r.Expr(Ast.Fromtimestamp(t, PacificTimeZone())).ToISO8601()")
@@ -83,7 +83,7 @@ func (suite *TimesShimSuite) TestCases() {
 	{
 		// times/shim.yaml line #12
 		/* ("2013-07-30T01:21:36.680+00:00") */
-		var expected_ string = "2013-07-30T01:21:36.680+00:00"
+		var expected_ = "2013-07-30T01:21:36.680+00:00"
 		/* r.expr(datetime.fromtimestamp(t, UTCTimeZone())).to_iso8601() */
 
 		suite.T().Log("About to run line #12: r.Expr(Ast.Fromtimestamp(t, UTCTimeZone())).ToISO8601()")

--- a/internal/integration/reql_tests/reql_times_time_arith_test.go
+++ b/internal/integration/reql_tests/reql_times_time_arith_test.go
@@ -131,7 +131,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #17
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ((t2 - t1) * 1000).do(lambda x:(x > 0.99) & (x < 1.01)) */
 
 		suite.T().Log("About to run line #17: r.Sub(t2, t1).Mul(1000).Do(func(x r.Term) interface{} { return r.Gt(x, 0.99).And(r.Lt(x, 1.01))})")
@@ -146,7 +146,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #20
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* t3 - t1 */
 
 		suite.T().Log("About to run line #20: r.Sub(t3, t1)")
@@ -161,7 +161,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #23
 		/* 1000000000 */
-		var expected_ int = 1000000000
+		var expected_ = 1000000000
 		/* t4 - t1 */
 
 		suite.T().Log("About to run line #23: r.Sub(t4, t1)")
@@ -176,7 +176,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #28
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* ((t1 - t2) * 1000).do(lambda x:(x < -0.99) & (x > -1.01)) */
 
 		suite.T().Log("About to run line #28: r.Sub(t1, t2).Mul(1000).Do(func(x r.Term) interface{} { return r.Lt(x, -0.99).And(r.Gt(x, -1.01))})")
@@ -191,7 +191,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #31
 		/* -1 */
-		var expected_ int = -1
+		var expected_ = -1
 		/* t1 - t3 */
 
 		suite.T().Log("About to run line #31: r.Sub(t1, t3)")
@@ -206,7 +206,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #34
 		/* -1000000000 */
-		var expected_ int = -1000000000
+		var expected_ = -1000000000
 		/* t1 - t4 */
 
 		suite.T().Log("About to run line #34: r.Sub(t1, t4)")
@@ -221,7 +221,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #39
 		/* ([rt1, rt2, rt3, rt4]) */
-		var expected_ []interface{} = []interface{}{rt1, rt2, rt3, rt4}
+		var expected_ = []interface{}{rt1, rt2, rt3, rt4}
 		/* ts.map(lambda x:t1 + (x - t1)).map(lambda x:x.to_epoch_time()) */
 
 		suite.T().Log("About to run line #39: ts.Map(func(x r.Term) interface{} { return r.Add(t1, r.Sub(x, t1))}).Map(func(x r.Term) interface{} { return x.ToEpochTime()})")
@@ -236,7 +236,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #43
 		/* err("ReqlQueryLogicError", "Expected type NUMBER but found PTYPE<TIME>.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found PTYPE<TIME>.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found PTYPE<TIME>.")
 		/* ts.map(lambda x:(t1 + x) - t1).map(lambda x:x.to_epoch_time()) */
 
 		suite.T().Log("About to run line #43: ts.Map(func(x r.Term) interface{} { return r.Add(t1, x).Sub(t1)}).Map(func(x r.Term) interface{} { return x.ToEpochTime()})")
@@ -251,7 +251,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #47
 		/* ([rt1, rt2, rt3, rt4]) */
-		var expected_ []interface{} = []interface{}{rt1, rt2, rt3, rt4}
+		var expected_ = []interface{}{rt1, rt2, rt3, rt4}
 		/* ts.map(lambda x:t1 - (t1 - x)).map(lambda x:x.to_epoch_time()) */
 
 		suite.T().Log("About to run line #47: ts.Map(func(x r.Term) interface{} { return r.Sub(t1, r.Sub(t1, x))}).Map(func(x r.Term) interface{} { return x.ToEpochTime()})")
@@ -281,7 +281,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 		[false, false, false, true,  true,  true],
 		[false, false, false, true,  true,  true],
 		[false, true,  true,  false, true,  false]]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{[]interface{}{false, true, true, false, true, false}, []interface{}{true, true, false, true, false, false}, []interface{}{true, true, false, true, false, false}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{false, true, true, false, true, false}, []interface{}{true, true, false, true, false, false}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{false, false, false, true, true, true}, []interface{}{false, true, true, false, true, false}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{false, false, false, true, true, true}, []interface{}{false, false, false, true, true, true}, []interface{}{false, true, true, false, true, false}}}
+		var expected_ = []interface{}{[]interface{}{[]interface{}{false, true, true, false, true, false}, []interface{}{true, true, false, true, false, false}, []interface{}{true, true, false, true, false, false}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{false, true, true, false, true, false}, []interface{}{true, true, false, true, false, false}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{false, false, false, true, true, true}, []interface{}{false, true, true, false, true, false}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{false, false, false, true, true, true}, []interface{}{false, false, false, true, true, true}, []interface{}{false, true, true, false, true, false}}}
 		/* ts.map(lambda x:ts.map(lambda y:[x < y, x <= y, x == y, x != y, x >= y, x > y])) */
 
 		suite.T().Log("About to run line #52: ts.Map(func(x r.Term) interface{} { return ts.Map(func(y r.Term) interface{} { return []interface{}{r.Lt(x, y), r.Le(x, y), r.Eq(x, y), r.Ne(x, y), r.Ge(x, y), r.Gt(x, y)}})})")
@@ -322,7 +322,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 		[false, false, false, true,  true,  true]],
 		[[true,  true,  false, true,  false, false],
 		[false, false, false, true,  true,  true]]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}}
+		var expected_ = []interface{}{[]interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{false, false, false, true, true, true}, []interface{}{true, true, false, true, false, false}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}, []interface{}{[]interface{}{true, true, false, true, false, false}, []interface{}{false, false, false, true, true, true}}}
 		/* datum_types.map(lambda x:r.expr([[x, t1], [t1, x]]).map(lambda xy:xy[0].do(lambda x2:xy[1].do(lambda y:[x2 < y, x2 <= y, x2 == y, x2 != y, x2 >= y, x2 > y])))) */
 
 		suite.T().Log("About to run line #79: datum_types.Map(func(x r.Term) interface{} { return r.Expr([]interface{}{[]interface{}{x, t1}, []interface{}{t1, x}}).Map(func(xy r.Term) interface{} { return xy.AtIndex(0).Do(func(x2 r.Term) interface{} { return xy.AtIndex(1).Do(func(y r.Term) interface{} { return []interface{}{r.Lt(x2, y), r.Le(x2, y), r.Eq(x2, y), r.Ne(x2, y), r.Ge(x2, y), r.Gt(x2, y)}})})})})")
@@ -360,7 +360,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 		[false, false, false, false],
 		[false, false, false, false],
 		[false, false, false, false]]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{[]interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}}
+		var expected_ = []interface{}{[]interface{}{[]interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}}
 		/* ts.map(lambda a:ts.map(lambda b:ts.map(lambda c:b.during(a, c)))) */
 
 		suite.T().Log("About to run line #99: ts.Map(func(a r.Term) interface{} { return ts.Map(func(b r.Term) interface{} { return ts.Map(func(c r.Term) interface{} { return b.During(a, c)})})})")
@@ -392,7 +392,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 		[false, false, false, false],
 		[false, false, false, false],
 		[false, false, false, false]]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}}
+		var expected_ = []interface{}{[]interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}}
 		/* ts.map(lambda a:ts.map(lambda b:ts.map(lambda c:b.during(a, c, left_bound='open')))) */
 
 		suite.T().Log("About to run line #119: ts.Map(func(a r.Term) interface{} { return ts.Map(func(b r.Term) interface{} { return ts.Map(func(c r.Term) interface{} { return b.During(a, c).OptArgs(r.DuringOpts{LeftBound: 'open', })})})})")
@@ -426,7 +426,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 		[false, false, false, false],
 		[false, false, false, false],
 		[false, false, false, true]]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{[]interface{}{true, true, true, true}, []interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}}}
+		var expected_ = []interface{}{[]interface{}{[]interface{}{true, true, true, true}, []interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}}}
 		/* ts.map(lambda a:ts.map(lambda b:ts.map(lambda c:b.during(a, c, right_bound='closed')))) */
 
 		suite.T().Log("About to run line #139: ts.Map(func(a r.Term) interface{} { return ts.Map(func(b r.Term) interface{} { return ts.Map(func(c r.Term) interface{} { return b.During(a, c).OptArgs(r.DuringOpts{RightBound: 'closed', })})})})")
@@ -460,7 +460,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 		[false, false, false, false],
 		[false, false, false, false],
 		[false, false, false, false]]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{[]interface{}{false, false, false, false}, []interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}}
+		var expected_ = []interface{}{[]interface{}{[]interface{}{false, false, false, false}, []interface{}{false, true, true, true}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, true, true}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, true}}, []interface{}{[]interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}, []interface{}{false, false, false, false}}}
 		/* ts.map(lambda a:ts.map(lambda b:ts.map(lambda c:b.during(a, c, left_bound='open', right_bound='closed')))) */
 
 		suite.T().Log("About to run line #159: ts.Map(func(a r.Term) interface{} { return ts.Map(func(b r.Term) interface{} { return ts.Map(func(c r.Term) interface{} { return b.During(a, c).OptArgs(r.DuringOpts{LeftBound: 'open', RightBound: 'closed', })})})})")
@@ -481,7 +481,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #179
 		/* rts */
-		var expected_ []interface{} = rts
+		var expected_ = rts
 		/* ts.map(lambda x:x.date() + x.time_of_day()).map(lambda x:x.to_epoch_time()) */
 
 		suite.T().Log("About to run line #179: ts.Map(func(x r.Term) interface{} { return x.Date().Add(x.TimeOfDay())}).Map(func(x r.Term) interface{} { return x.ToEpochTime()})")
@@ -511,7 +511,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #190
 		/* ("2012-08-01T00:00:00+00:00") */
-		var expected_ string = "2012-08-01T00:00:00+00:00"
+		var expected_ = "2012-08-01T00:00:00+00:00"
 		/* r.do(r.js("new Date('2012-08-01')")).to_iso8601() */
 
 		suite.T().Log("About to run line #190: r.Do(r.JS('new Date('2012-08-01')')).ToISO8601()")
@@ -526,7 +526,7 @@ func (suite *TimesTimeArithSuite) TestCases() {
 	{
 		// times/time_arith.yaml line #195
 		/* ("2012-08-01T00:00:00+00:00") */
-		var expected_ string = "2012-08-01T00:00:00+00:00"
+		var expected_ = "2012-08-01T00:00:00+00:00"
 		/* r.do(r.js("(function(x){doc = new Object(); doc.date = new Date('2012-08-01'); return doc;})"))["date"].to_iso8601() */
 
 		suite.T().Log("About to run line #195: r.Do(r.JS('(function(x){doc = new Object(); doc.date = new Date('2012-08-01'); return doc;})')).AtIndex('date').ToISO8601()")

--- a/internal/integration/reql_tests/reql_times_timezones_test.go
+++ b/internal/integration/reql_tests/reql_times_timezones_test.go
@@ -159,7 +159,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #23
 		/* ([["+00:00", 29], ["+00:00", 29], ["+00:00", 29]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{"+00:00", 29}, []interface{}{"+00:00", 29}, []interface{}{"+00:00", 29}}
+		var expected_ = []interface{}{[]interface{}{"+00:00", 29}, []interface{}{"+00:00", 29}, []interface{}{"+00:00", 29}}
 		/* tutcs.map(lambda x:[x.timezone(), x.day()]) */
 
 		suite.T().Log("About to run line #23: tutcs.Map(func(x r.Term) interface{} { return []interface{}{x.Timezone(), x.Day()}})")
@@ -174,7 +174,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #27
 		/* ([["-00:59", 29], ["-01:00", 29], ["-01:01", 29]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{"-00:59", 29}, []interface{}{"-01:00", 29}, []interface{}{"-01:01", 29}}
+		var expected_ = []interface{}{[]interface{}{"-00:59", 29}, []interface{}{"-01:00", 29}, []interface{}{"-01:01", 29}}
 		/* tms.map(lambda x:[x.timezone(), x.day()]) */
 
 		suite.T().Log("About to run line #27: tms.Map(func(x r.Term) interface{} { return []interface{}{x.Timezone(), x.Day()}})")
@@ -189,7 +189,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #31
 		/* ([["+00:59", 30], ["+01:00", 30], ["+01:01", 30]]) */
-		var expected_ []interface{} = []interface{}{[]interface{}{"+00:59", 30}, []interface{}{"+01:00", 30}, []interface{}{"+01:01", 30}}
+		var expected_ = []interface{}{[]interface{}{"+00:59", 30}, []interface{}{"+01:00", 30}, []interface{}{"+01:01", 30}}
 		/* tps.map(lambda x:[x.timezone(), x.day()]) */
 
 		suite.T().Log("About to run line #31: tps.Map(func(x r.Term) interface{} { return []interface{}{x.Timezone(), x.Day()}})")
@@ -204,7 +204,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #38
 		/* ([0]) */
-		var expected_ []interface{} = []interface{}{0}
+		var expected_ = []interface{}{0}
 		/* ts.concat_map(lambda x:ts.map(lambda y:x - y)).distinct() */
 
 		suite.T().Log("About to run line #38: ts.ConcatMap(func(x r.Term) interface{} { return ts.Map(func(y r.Term) interface{} { return r.Sub(x, y)})}).Distinct()")
@@ -219,7 +219,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #44
 		/* err('ReqlQueryLogicError', 'Timezone `` does not start with `-` or `+`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Timezone `` does not start with `-` or `+`.")
+		var expected_ = err("ReqlQueryLogicError", "Timezone `` does not start with `-` or `+`.")
 		/* r.now().in_timezone("") */
 
 		suite.T().Log("About to run line #44: r.Now().InTimezone('')")
@@ -234,7 +234,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #47
 		/* err('ReqlQueryLogicError', '`-00` is not a valid time offset.') */
-		var expected_ Err = err("ReqlQueryLogicError", "`-00` is not a valid time offset.")
+		var expected_ = err("ReqlQueryLogicError", "`-00` is not a valid time offset.")
 		/* r.now().in_timezone("-00") */
 
 		suite.T().Log("About to run line #47: r.Now().InTimezone('-00')")
@@ -249,7 +249,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #50
 		/* err('ReqlQueryLogicError', '`-00:00` is not a valid time offset.') */
-		var expected_ Err = err("ReqlQueryLogicError", "`-00:00` is not a valid time offset.")
+		var expected_ = err("ReqlQueryLogicError", "`-00:00` is not a valid time offset.")
 		/* r.now().in_timezone("-00:00") */
 
 		suite.T().Log("About to run line #50: r.Now().InTimezone('-00:00')")
@@ -264,7 +264,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #53
 		/* err('ReqlQueryLogicError', 'Timezone `UTC+00` does not start with `-` or `+`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Timezone `UTC+00` does not start with `-` or `+`.")
+		var expected_ = err("ReqlQueryLogicError", "Timezone `UTC+00` does not start with `-` or `+`.")
 		/* r.now().in_timezone("UTC+00") */
 
 		suite.T().Log("About to run line #53: r.Now().InTimezone('UTC+00')")
@@ -279,7 +279,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #56
 		/* err('ReqlQueryLogicError', 'Minutes out of range in `+00:60`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Minutes out of range in `+00:60`.")
+		var expected_ = err("ReqlQueryLogicError", "Minutes out of range in `+00:60`.")
 		/* r.now().in_timezone("+00:60") */
 
 		suite.T().Log("About to run line #56: r.Now().InTimezone('+00:60')")
@@ -294,7 +294,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #59
 		/* err('ReqlQueryLogicError', 'Hours out of range in `+25:00`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Hours out of range in `+25:00`.")
+		var expected_ = err("ReqlQueryLogicError", "Hours out of range in `+25:00`.")
 		/* r.now().in_timezone("+25:00") */
 
 		suite.T().Log("About to run line #59: r.Now().InTimezone('+25:00')")
@@ -309,7 +309,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #63
 		/* err('ReqlQueryLogicError', 'Timezone `` does not start with `-` or `+`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Timezone `` does not start with `-` or `+`.")
+		var expected_ = err("ReqlQueryLogicError", "Timezone `` does not start with `-` or `+`.")
 		/* r.time(2013, 1, 1, "") */
 
 		suite.T().Log("About to run line #63: r.Time(2013, 1, 1, '')")
@@ -324,7 +324,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #66
 		/* err('ReqlQueryLogicError', '`-00` is not a valid time offset.') */
-		var expected_ Err = err("ReqlQueryLogicError", "`-00` is not a valid time offset.")
+		var expected_ = err("ReqlQueryLogicError", "`-00` is not a valid time offset.")
 		/* r.time(2013, 1, 1, "-00") */
 
 		suite.T().Log("About to run line #66: r.Time(2013, 1, 1, '-00')")
@@ -339,7 +339,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #69
 		/* err('ReqlQueryLogicError', '`-00:00` is not a valid time offset.') */
-		var expected_ Err = err("ReqlQueryLogicError", "`-00:00` is not a valid time offset.")
+		var expected_ = err("ReqlQueryLogicError", "`-00:00` is not a valid time offset.")
 		/* r.time(2013, 1, 1, "-00:00") */
 
 		suite.T().Log("About to run line #69: r.Time(2013, 1, 1, '-00:00')")
@@ -354,7 +354,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #72
 		/* err('ReqlQueryLogicError', 'Timezone `UTC+00` does not start with `-` or `+`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Timezone `UTC+00` does not start with `-` or `+`.")
+		var expected_ = err("ReqlQueryLogicError", "Timezone `UTC+00` does not start with `-` or `+`.")
 		/* r.time(2013, 1, 1, "UTC+00") */
 
 		suite.T().Log("About to run line #72: r.Time(2013, 1, 1, 'UTC+00')")
@@ -369,7 +369,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #75
 		/* err('ReqlQueryLogicError', 'Minutes out of range in `+00:60`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Minutes out of range in `+00:60`.")
+		var expected_ = err("ReqlQueryLogicError", "Minutes out of range in `+00:60`.")
 		/* r.time(2013, 1, 1, "+00:60") */
 
 		suite.T().Log("About to run line #75: r.Time(2013, 1, 1, '+00:60')")
@@ -384,7 +384,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #78
 		/* err('ReqlQueryLogicError', 'Hours out of range in `+25:00`.') */
-		var expected_ Err = err("ReqlQueryLogicError", "Hours out of range in `+25:00`.")
+		var expected_ = err("ReqlQueryLogicError", "Hours out of range in `+25:00`.")
 		/* r.time(2013, 1, 1, "+25:00") */
 
 		suite.T().Log("About to run line #78: r.Time(2013, 1, 1, '+25:00')")
@@ -399,7 +399,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #81
 		/* ("2015-07-08T00:00:00-08:00") */
-		var expected_ string = "2015-07-08T00:00:00-08:00"
+		var expected_ = "2015-07-08T00:00:00-08:00"
 		/* r.epoch_time(1436428422.339).in_timezone('-08:00').date().to_iso8601() */
 
 		suite.T().Log("About to run line #81: r.EpochTime(1436428422.339).InTimezone('-08:00').Date().ToISO8601()")
@@ -414,7 +414,7 @@ func (suite *TimesTimezonesSuite) TestCases() {
 	{
 		// times/timezones.yaml line #85
 		/* ("2015-07-09T00:00:00-07:00") */
-		var expected_ string = "2015-07-09T00:00:00-07:00"
+		var expected_ = "2015-07-09T00:00:00-07:00"
 		/* r.epoch_time(1436428422.339).in_timezone('-07:00').date().to_iso8601() */
 
 		suite.T().Log("About to run line #85: r.EpochTime(1436428422.339).InTimezone('-07:00').Date().ToISO8601()")

--- a/internal/integration/reql_tests/reql_transform_array_test.go
+++ b/internal/integration/reql_tests/reql_transform_array_test.go
@@ -89,7 +89,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #12
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* arr.append(4) */
 
 		suite.T().Log("About to run line #12: arr.Append(4)")
@@ -104,7 +104,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #14
 		/* [1,2,3,'a'] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, "a"}
+		var expected_ = []interface{}{1, 2, 3, "a"}
 		/* arr.append('a') */
 
 		suite.T().Log("About to run line #14: arr.Append('a')")
@@ -119,7 +119,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #19
 		/* [0,1,2,3] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3}
+		var expected_ = []interface{}{0, 1, 2, 3}
 		/* arr.prepend(0) */
 
 		suite.T().Log("About to run line #19: arr.Prepend(0)")
@@ -134,7 +134,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #21
 		/* ['a',1,2,3] */
-		var expected_ []interface{} = []interface{}{"a", 1, 2, 3}
+		var expected_ = []interface{}{"a", 1, 2, 3}
 		/* arr.prepend('a') */
 
 		suite.T().Log("About to run line #21: arr.Prepend('a')")
@@ -149,7 +149,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #26
 		/* [3] */
-		var expected_ []interface{} = []interface{}{3}
+		var expected_ = []interface{}{3}
 		/* arr.difference([1,2,2]) */
 
 		suite.T().Log("About to run line #26: arr.Difference([]interface{}{1, 2, 2})")
@@ -164,7 +164,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #28
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* arr.difference([]) */
 
 		suite.T().Log("About to run line #28: arr.Difference([]interface{}{})")
@@ -179,7 +179,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #30
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* arr.difference(["foo", "bar"]) */
 
 		suite.T().Log("About to run line #30: arr.Difference([]interface{}{'foo', 'bar'})")
@@ -194,7 +194,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #34
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* dupe_arr.set_insert(1) */
 
 		suite.T().Log("About to run line #34: dupe_arr.SetInsert(1)")
@@ -209,7 +209,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #36
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* dupe_arr.set_insert(4) */
 
 		suite.T().Log("About to run line #36: dupe_arr.SetInsert(4)")
@@ -224,7 +224,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #39
 		/* [1,2,3,4,5] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4, 5}
+		var expected_ = []interface{}{1, 2, 3, 4, 5}
 		/* dupe_arr.set_union([3,4,5,5]) */
 
 		suite.T().Log("About to run line #39: dupe_arr.SetUnion([]interface{}{3, 4, 5, 5})")
@@ -239,7 +239,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #41
 		/* [1,2,3,5,6] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 5, 6}
+		var expected_ = []interface{}{1, 2, 3, 5, 6}
 		/* dupe_arr.set_union([5,6]) */
 
 		suite.T().Log("About to run line #41: dupe_arr.SetUnion([]interface{}{5, 6})")
@@ -254,7 +254,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #44
 		/* [1,2] */
-		var expected_ []interface{} = []interface{}{1, 2}
+		var expected_ = []interface{}{1, 2}
 		/* dupe_arr.set_intersection([1,1,1,2,2]) */
 
 		suite.T().Log("About to run line #44: dupe_arr.SetIntersection([]interface{}{1, 1, 1, 2, 2})")
@@ -269,7 +269,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #46
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* dupe_arr.set_intersection(["foo"]) */
 
 		suite.T().Log("About to run line #46: dupe_arr.SetIntersection([]interface{}{'foo'})")
@@ -284,7 +284,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #49
 		/* [2,3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* dupe_arr.set_difference([1,1,1,10]) */
 
 		suite.T().Log("About to run line #49: dupe_arr.SetDifference([]interface{}{1, 1, 1, 10})")
@@ -299,7 +299,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #51
 		/* [1,3] */
-		var expected_ []interface{} = []interface{}{1, 3}
+		var expected_ = []interface{}{1, 3}
 		/* dupe_arr.set_difference([2]) */
 
 		suite.T().Log("About to run line #51: dupe_arr.SetDifference([]interface{}{2})")
@@ -314,7 +314,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #58
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* arr[1:3] */
 
 		suite.T().Log("About to run line #58: arr.Slice(1, 3)")
@@ -329,7 +329,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #59
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* arr.slice(1, 3) */
 
 		suite.T().Log("About to run line #59: arr.Slice(1, 3)")
@@ -344,7 +344,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #60
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* arr.slice(1, 2, right_bound='closed') */
 
 		suite.T().Log("About to run line #60: arr.Slice(1, 2).OptArgs(r.SliceOpts{RightBound: 'closed', })")
@@ -359,7 +359,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #72
 		/* [1,2] */
-		var expected_ []interface{} = []interface{}{1, 2}
+		var expected_ = []interface{}{1, 2}
 		/* arr[:2] */
 
 		suite.T().Log("About to run line #72: arr.Slice(0, 2)")
@@ -374,7 +374,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #73
 		/* [1,2] */
-		var expected_ []interface{} = []interface{}{1, 2}
+		var expected_ = []interface{}{1, 2}
 		/* arr.slice(0,2) */
 
 		suite.T().Log("About to run line #73: arr.Slice(0, 2)")
@@ -389,7 +389,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #81
 		/* [2,3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* arr[1:] */
 
 		suite.T().Log("About to run line #81: arr.Slice(1, -1, r.SliceOpts{RightBound: 'closed'})")
@@ -404,7 +404,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #82
 		/* [2,3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* arr.slice(1) */
 
 		suite.T().Log("About to run line #82: arr.Slice(1)")
@@ -419,7 +419,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #89
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* arr.slice(-2, -1) */
 
 		suite.T().Log("About to run line #89: arr.Slice(-2, -1)")
@@ -434,7 +434,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #95
 		/* [2,3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* arr.skip(1) */
 
 		suite.T().Log("About to run line #95: arr.Skip(1)")
@@ -449,7 +449,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #97
 		/* [3] */
-		var expected_ []interface{} = []interface{}{3}
+		var expected_ = []interface{}{3}
 		/* arr.skip(2) */
 
 		suite.T().Log("About to run line #97: arr.Skip(2)")
@@ -464,7 +464,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #99
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* arr.skip(12) */
 
 		suite.T().Log("About to run line #99: arr.Skip(12)")
@@ -479,7 +479,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #104
 		/* [1,2] */
-		var expected_ []interface{} = []interface{}{1, 2}
+		var expected_ = []interface{}{1, 2}
 		/* arr.limit(2) */
 
 		suite.T().Log("About to run line #104: arr.Limit(2)")
@@ -494,7 +494,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #106
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* arr.limit(0) */
 
 		suite.T().Log("About to run line #106: arr.Limit(0)")
@@ -509,7 +509,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #108
 		/* [1,2,3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* arr.limit(12) */
 
 		suite.T().Log("About to run line #108: arr.Limit(12)")
@@ -524,7 +524,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #113
 		/* [{'a':1, 'b':'a'}, {'a':2, 'b':'b'}, {'a':3, 'b':'c'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
 		/* objArr.pluck('a', 'b') */
 
 		suite.T().Log("About to run line #113: objArr.Pluck('a', 'b')")
@@ -539,7 +539,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #115
 		/* [{'a':1}, {'a':2}, {'a':3}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2}, map[interface{}]interface{}{"a": 3}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2}, map[interface{}]interface{}{"a": 3}}
 		/* objArr.pluck('a') */
 
 		suite.T().Log("About to run line #115: objArr.Pluck('a')")
@@ -554,7 +554,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #117
 		/* [{}, {}, {}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}}
 		/* objArr.pluck() */
 
 		suite.T().Log("About to run line #117: objArr.Pluck()")
@@ -576,7 +576,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #122
 		/* ([{'a':1},{'a':2},{'a':3},{'a':1},{'a':2},{'a':3}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2}, map[interface{}]interface{}{"a": 3}, map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2}, map[interface{}]interface{}{"a": 3}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2}, map[interface{}]interface{}{"a": 3}, map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"a": 2}, map[interface{}]interface{}{"a": 3}}
 		/* wftst.with_fields('a') */
 
 		suite.T().Log("About to run line #122: wftst.WithFields('a')")
@@ -591,7 +591,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #124
 		/* ([{'b':'a'},{'b':'b'},{'b':'c'},{'b':'a'},{'b':'b'},{'b':'c'}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"b": "a"}, map[interface{}]interface{}{"b": "b"}, map[interface{}]interface{}{"b": "c"}, map[interface{}]interface{}{"b": "a"}, map[interface{}]interface{}{"b": "b"}, map[interface{}]interface{}{"b": "c"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"b": "a"}, map[interface{}]interface{}{"b": "b"}, map[interface{}]interface{}{"b": "c"}, map[interface{}]interface{}{"b": "a"}, map[interface{}]interface{}{"b": "b"}, map[interface{}]interface{}{"b": "c"}}
 		/* wftst.with_fields('b') */
 
 		suite.T().Log("About to run line #124: wftst.WithFields('b')")
@@ -606,7 +606,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #126
 		/* ([{'a':1,'b':'a'},{'a':2,'b':'b'},{'a':3,'b':'c'}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
 		/* wftst.with_fields('a', 'b') */
 
 		suite.T().Log("About to run line #126: wftst.WithFields('a', 'b')")
@@ -621,7 +621,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #128
 		/* [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}}
 		/* wftst.with_fields() */
 
 		suite.T().Log("About to run line #128: wftst.WithFields()")
@@ -643,7 +643,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #132
 		/* ([{'b':{'c':1}}, {'b':{'c':2}}, {'b':{'c':3}}, {'b':{'c':1}}, {'b':{'c':2}}, {'b':{'c':3}}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 1}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 2}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 3}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 1}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 2}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 3}}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 1}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 2}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 3}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 1}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 2}}, map[interface{}]interface{}{"b": map[interface{}]interface{}{"c": 3}}}
 		/* wftst2.with_fields({'b':'c'}) */
 
 		suite.T().Log("About to run line #132: wftst2.WithFields(map[interface{}]interface{}{'b': 'c', })")
@@ -658,7 +658,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #135
 		/* err("ReqlQueryLogicError", "Invalid path argument `1`.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid path argument `1`.")
+		var expected_ = err("ReqlQueryLogicError", "Invalid path argument `1`.")
 		/* wftst.with_fields(1) */
 
 		suite.T().Log("About to run line #135: wftst.WithFields(1)")
@@ -673,7 +673,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #137
 		/* err("ReqlQueryLogicError", "Cannot perform has_fields on a non-object non-sequence `1`.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform has_fields on a non-object non-sequence `1`.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform has_fields on a non-object non-sequence `1`.")
 		/* r.expr(1).with_fields() */
 
 		suite.T().Log("About to run line #137: r.Expr(1).WithFields()")
@@ -688,7 +688,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #142
 		/* [{}, {}, {}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}}
+		var expected_ = []interface{}{map[interface{}]interface{}{}, map[interface{}]interface{}{}, map[interface{}]interface{}{}}
 		/* objArr.without('a', 'b') */
 
 		suite.T().Log("About to run line #142: objArr.Without('a', 'b')")
@@ -703,7 +703,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #144
 		/* [{'b':'a'}, {'b':'b'}, {'b':'c'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"b": "a"}, map[interface{}]interface{}{"b": "b"}, map[interface{}]interface{}{"b": "c"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"b": "a"}, map[interface{}]interface{}{"b": "b"}, map[interface{}]interface{}{"b": "c"}}
 		/* objArr.without('a') */
 
 		suite.T().Log("About to run line #144: objArr.Without('a')")
@@ -718,7 +718,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #146
 		/* [{'a':1, 'b':'a'}, {'a':2, 'b':'b'}, {'a':3, 'b':'c'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
 		/* objArr.without() */
 
 		suite.T().Log("About to run line #146: objArr.Without()")
@@ -733,7 +733,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #151
 		/* [2,3,4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* arr.map(lambda v: v + 1) */
 
 		suite.T().Log("About to run line #151: arr.Map(func(v r.Term) interface{} { return r.Add(v, 1)})")
@@ -748,7 +748,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #161
 		/* 6 */
-		var expected_ int = 6
+		var expected_ = 6
 		/* arr.reduce(lambda a, b: a + b) */
 
 		suite.T().Log("About to run line #161: arr.Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -763,7 +763,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #166
 		/* 6 */
-		var expected_ int = 6
+		var expected_ = 6
 		/* arr.reduce(lambda a, b:a + b) */
 
 		suite.T().Log("About to run line #166: arr.Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -778,7 +778,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #171
 		/* 12 */
-		var expected_ int = 12
+		var expected_ = 12
 		/* arr.union(arr).reduce(lambda a, b: a + b) */
 
 		suite.T().Log("About to run line #171: arr.Union(arr).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -793,7 +793,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #176
 		/* 12 */
-		var expected_ int = 12
+		var expected_ = 12
 		/* arr.union(arr).reduce(lambda a, b:a + b) */
 
 		suite.T().Log("About to run line #176: arr.Union(arr).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -808,7 +808,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #183
 		/* [{'a':2, 'b':'b'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 2, "b": "b"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 2, "b": "b"}}
 		/* objArr.filter(lambda row: row['b'] == 'b') */
 
 		suite.T().Log("About to run line #183: objArr.Filter(func(row r.Term) interface{} { return row.AtIndex('b').Eq('b')})")
@@ -823,7 +823,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #190
 		/* [1,2,1,2,1,2] */
-		var expected_ []interface{} = []interface{}{1, 2, 1, 2, 1, 2}
+		var expected_ = []interface{}{1, 2, 1, 2, 1, 2}
 		/* arr.concat_map(lambda v: [1,2]) */
 
 		suite.T().Log("About to run line #190: arr.ConcatMap(func(v r.Term) interface{} { return []interface{}{1, 2}})")
@@ -838,7 +838,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #194
 		/* [{'v':1}, {'v2':2}, {'v':2}, {'v2':3}, {'v':3}, {'v2':4}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"v": 1}, map[interface{}]interface{}{"v2": 2}, map[interface{}]interface{}{"v": 2}, map[interface{}]interface{}{"v2": 3}, map[interface{}]interface{}{"v": 3}, map[interface{}]interface{}{"v2": 4}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"v": 1}, map[interface{}]interface{}{"v2": 2}, map[interface{}]interface{}{"v": 2}, map[interface{}]interface{}{"v2": 3}, map[interface{}]interface{}{"v": 3}, map[interface{}]interface{}{"v2": 4}}
 		/* arr.concat_map(lambda v: [{'v':v}, {'v2':v + 1}]) */
 
 		suite.T().Log("About to run line #194: arr.ConcatMap(func(v r.Term) interface{} { return []interface{}{map[interface{}]interface{}{'v': v, }, map[interface{}]interface{}{'v2': r.Add(v, 1), }}})")
@@ -855,7 +855,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #201
 		/* [{'a':1, 'b':'a'}, {'a':2, 'b':'b'}, {'a':3, 'b':'c'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
 		/* objArr.order_by('b') */
 
 		suite.T().Log("About to run line #201: objArr.OrderBy('b')")
@@ -870,7 +870,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #205
 		/* [{'a':3, 'b':'c'}, {'a':2, 'b':'b'}, {'a':1, 'b':'a'}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 3, "b": "c"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 1, "b": "a"}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 3, "b": "c"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 1, "b": "a"}}
 		/* objArr.order_by(r.desc('b')) */
 
 		suite.T().Log("About to run line #205: objArr.OrderBy(r.Desc('b'))")
@@ -885,7 +885,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #208
 		/* [{'-a':1},{'-a':2}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"-a": 1}, map[interface{}]interface{}{"-a": 2}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"-a": 1}, map[interface{}]interface{}{"-a": 2}}
 		/* r.expr([{'-a':1},{'-a':2}]).order_by('-a') */
 
 		suite.T().Log("About to run line #208: r.Expr([]interface{}{map[interface{}]interface{}{'-a': 1, }, map[interface{}]interface{}{'-a': 2, }}).OrderBy('-a')")
@@ -900,7 +900,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #216
 		/* [1,2,3,4] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4}
+		var expected_ = []interface{}{1, 2, 3, 4}
 		/* r.expr([1,1,2,2,2,3,4]).distinct() */
 
 		suite.T().Log("About to run line #216: r.Expr([]interface{}{1, 1, 2, 2, 2, 3, 4}).Distinct()")
@@ -915,7 +915,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #223
 		/* 3 */
-		var expected_ int = 3
+		var expected_ = 3
 		/* objArr.count() */
 
 		suite.T().Log("About to run line #223: objArr.Count()")
@@ -930,7 +930,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #228
 		/* [1, 2, 3, {'a':1, 'b':'a'}, {'a':2, 'b':'b'}, {'a':3, 'b':'c'}] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
+		var expected_ = []interface{}{1, 2, 3, map[interface{}]interface{}{"a": 1, "b": "a"}, map[interface{}]interface{}{"a": 2, "b": "b"}, map[interface{}]interface{}{"a": 3, "b": "c"}}
 		/* arr.union(objArr) */
 
 		suite.T().Log("About to run line #228: arr.Union(objArr)")
@@ -945,7 +945,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #234
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* arr[1] */
 
 		suite.T().Log("About to run line #234: arr.AtIndex(1)")
@@ -960,7 +960,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #235
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* arr.nth(1) */
 
 		suite.T().Log("About to run line #235: arr.Nth(1)")
@@ -975,7 +975,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #238
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* arr[0] */
 
 		suite.T().Log("About to run line #238: arr.AtIndex(0)")
@@ -990,7 +990,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #245
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* r.expr([]).is_empty() */
 
 		suite.T().Log("About to run line #245: r.Expr([]interface{}{}).IsEmpty()")
@@ -1005,7 +1005,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #247
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* arr.is_empty() */
 
 		suite.T().Log("About to run line #247: arr.IsEmpty()")
@@ -1020,7 +1020,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #251
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* arr.contains(2) */
 
 		suite.T().Log("About to run line #251: arr.Contains(2)")
@@ -1035,7 +1035,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #253
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* arr.contains(2, 3) */
 
 		suite.T().Log("About to run line #253: arr.Contains(2, 3)")
@@ -1050,7 +1050,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #255
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* arr.contains(4) */
 
 		suite.T().Log("About to run line #255: arr.Contains(4)")
@@ -1065,7 +1065,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #257
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* arr.contains(2, 4) */
 
 		suite.T().Log("About to run line #257: arr.Contains(2, 4)")
@@ -1080,7 +1080,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #259
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* arr.contains(2, 2) */
 
 		suite.T().Log("About to run line #259: arr.Contains(2, 2)")
@@ -1095,7 +1095,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #261
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* arr.union(arr).contains(2, 2) */
 
 		suite.T().Log("About to run line #261: arr.Union(arr).Contains(2, 2)")
@@ -1110,7 +1110,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #265
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* arr.contains(lambda x:x == 2) */
 
 		suite.T().Log("About to run line #265: arr.Contains(func(x r.Term) interface{} { return r.Eq(x, 2)})")
@@ -1125,7 +1125,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #269
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* arr.contains(lambda x:x == 2, lambda x:x==3) */
 
 		suite.T().Log("About to run line #269: arr.Contains(func(x r.Term) interface{} { return r.Eq(x, 2)}, func(x r.Term) interface{} { return r.Eq(x, 3)})")
@@ -1140,7 +1140,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #273
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* arr.contains(lambda x:x == 4) */
 
 		suite.T().Log("About to run line #273: arr.Contains(func(x r.Term) interface{} { return r.Eq(x, 4)})")
@@ -1155,7 +1155,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #277
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* arr.contains(lambda x:x == 2, lambda x:x==4) */
 
 		suite.T().Log("About to run line #277: arr.Contains(func(x r.Term) interface{} { return r.Eq(x, 2)}, func(x r.Term) interface{} { return r.Eq(x, 4)})")
@@ -1170,7 +1170,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #281
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* arr.contains(lambda x:x == 2, lambda x:x==2) */
 
 		suite.T().Log("About to run line #281: arr.Contains(func(x r.Term) interface{} { return r.Eq(x, 2)}, func(x r.Term) interface{} { return r.Eq(x, 2)})")
@@ -1185,7 +1185,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #285
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* arr.union(arr).contains(lambda x:x == 2, lambda x:x==2) */
 
 		suite.T().Log("About to run line #285: arr.Union(arr).Contains(func(x r.Term) interface{} { return r.Eq(x, 2)}, func(x r.Term) interface{} { return r.Eq(x, 2)})")
@@ -1200,7 +1200,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #290
 		/* [1, 3] */
-		var expected_ []interface{} = []interface{}{1, 3}
+		var expected_ = []interface{}{1, 3}
 		/* r.expr([{'a':1},{'b':2},{'a':3,'c':4}])['a'] */
 
 		suite.T().Log("About to run line #290: r.Expr([]interface{}{map[interface{}]interface{}{'a': 1, }, map[interface{}]interface{}{'b': 2, }, map[interface{}]interface{}{'a': 3, 'c': 4, }}).AtIndex('a')")
@@ -1215,7 +1215,7 @@ func (suite *TransformArraySuite) TestCases() {
 	{
 		// transform/array.yaml line #293
 		/* err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform bracket on a non-object non-sequence `\"a\"`.")
 		/* r.expr([{'a':1},'a',{'b':2},{'a':3,'c':4}])['a'] */
 
 		suite.T().Log("About to run line #293: r.Expr([]interface{}{map[interface{}]interface{}{'a': 1, }, 'a', map[interface{}]interface{}{'b': 2, }, map[interface{}]interface{}{'a': 3, 'c': 4, }}).AtIndex('a')")

--- a/internal/integration/reql_tests/reql_transform_fold_test.go
+++ b/internal/integration/reql_tests/reql_transform_fold_test.go
@@ -70,7 +70,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #6
 		/* {'deleted':0,'replaced':0,'unchanged':0,'errors':0,'skipped':0,'inserted':100} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0, "replaced": 0, "unchanged": 0, "errors": 0, "skipped": 0, "inserted": 100}
 		/* tbl.insert(r.range(100).map(lambda i: {'id':i, 'a':i%4}).coerce_to("array")) */
 
 		suite.T().Log("About to run line #6: tbl.Insert(r.Range(100).Map(func(i r.Term) interface{} { return map[interface{}]interface{}{'id': i, 'a': r.Mod(i, 4), }}).CoerceTo('array'))")
@@ -85,7 +85,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #19
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* r.range(0, 10).fold(0, lambda acc, row: acc.add(1)) */
 
 		suite.T().Log("About to run line #19: r.Range(0, 10).Fold(0, func(acc r.Term, row r.Term) interface{} { return acc.Add(1)})")
@@ -100,7 +100,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #23
 		/* 20 */
-		var expected_ int = 20
+		var expected_ = 20
 		/* r.range(0, 10).fold(0, lambda acc, row: acc.add(1), final_emit=lambda acc: acc.mul(2)) */
 
 		suite.T().Log("About to run line #23: r.Range(0, 10).Fold(0, func(acc r.Term, row r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{FinalEmit: func(acc r.Term) interface{} { return acc.Mul(2)}, })")
@@ -115,7 +115,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #27
 		/* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] */
-		var expected_ []interface{} = []interface{}{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+		var expected_ = []interface{}{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 		/* r.range(0, 10).fold(0, lambda acc, row: acc.add(1), emit=lambda old,row,acc: [row]).coerce_to("array") */
 
 		suite.T().Log("About to run line #27: r.Range(0, 10).Fold(0, func(acc r.Term, row r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return []interface{}{row}}, }).CoerceTo('array')")
@@ -130,7 +130,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #31
 		/* [2, 5, 8, 10] */
-		var expected_ []interface{} = []interface{}{2, 5, 8, 10}
+		var expected_ = []interface{}{2, 5, 8, 10}
 		/* r.range(0, 10).fold(0, lambda acc, row: acc.add(1), emit=lambda old,row,acc: r.branch(acc.mod(3).eq(0),[row],[]),final_emit=lambda acc: [acc]).coerce_to("array") */
 
 		suite.T().Log("About to run line #31: r.Range(0, 10).Fold(0, func(acc r.Term, row r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return r.Branch(acc.Mod(3).Eq(0), []interface{}{row}, []interface{}{})}, FinalEmit: func(acc r.Term) interface{} { return []interface{}{acc}}, }).CoerceTo('array')")
@@ -147,7 +147,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #35
 		/* [1, 2, 3, 5, 8, 13, 21, 34, 55, 89] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 5, 8, 13, 21, 34, 55, 89}
+		var expected_ = []interface{}{1, 2, 3, 5, 8, 13, 21, 34, 55, 89}
 		/* r.range(0, 10).fold([1, 1], lambda acc, row: [acc[1], acc[0].add(acc[1])], emit=lambda old,row,acc: [acc[0]]).coerce_to("array") */
 
 		suite.T().Log("About to run line #35: r.Range(0, 10).Fold([]interface{}{1, 1}, func(acc r.Term, row r.Term) interface{} { return []interface{}{acc.AtIndex(1), acc.AtIndex(0).Add(acc.AtIndex(1))}}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return []interface{}{acc.AtIndex(0)}}, }).CoerceTo('array')")
@@ -164,7 +164,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #37
 		/* "STREAM" */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* r.range(0, 10).fold(0, lambda acc, row: acc, emit=lambda old,row,acc: acc).type_of() */
 
 		suite.T().Log("About to run line #37: r.Range(0, 10).Fold(0, func(acc r.Term, row r.Term) interface{} { return acc}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return acc}, }).TypeOf()")
@@ -179,7 +179,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #39
 		/* [{'a': 0, 'id': 20}, {'a': 3, 'id': 15}, {'a': 2, 'id': 46}, {'a': 2, 'id': 78}, {'a': 2, 'id': 90}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 0, "id": 20}, map[interface{}]interface{}{"a": 3, "id": 15}, map[interface{}]interface{}{"a": 2, "id": 46}, map[interface{}]interface{}{"a": 2, "id": 78}, map[interface{}]interface{}{"a": 2, "id": 90}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 0, "id": 20}, map[interface{}]interface{}{"a": 3, "id": 15}, map[interface{}]interface{}{"a": 2, "id": 46}, map[interface{}]interface{}{"a": 2, "id": 78}, map[interface{}]interface{}{"a": 2, "id": 90}}
 		/* tbl.filter("id").fold(0, lambda acc, row: acc.add(1), emit=lambda old,row,acc: r.branch(old.mod(20).eq(0),[row],[])).coerce_to("array") */
 
 		suite.T().Log("About to run line #39: tbl.Filter('id').Fold(0, func(acc r.Term, row r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return r.Branch(old.Mod(20).Eq(0), []interface{}{row}, []interface{}{})}, }).CoerceTo('array')")
@@ -196,7 +196,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #42
 		/* [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] */
-		var expected_ []interface{} = []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+		var expected_ = []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 		/* r.range().fold(0, lambda acc, row: acc.add(1), emit=lambda old,row,acc: [acc]).limit(10) */
 
 		suite.T().Log("About to run line #42: r.Range().Fold(0, func(acc r.Term, row r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return []interface{}{acc}}, }).Limit(10)")
@@ -211,7 +211,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #45
 		/* err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.") */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
 		/* r.range().fold(0, lambda acc, row: acc.add(1), emit=lambda old,row,acc: [acc]).map(lambda doc: 1).reduce(lambda l, r: l+r) */
 
 		suite.T().Log("About to run line #45: r.Range().Fold(0, func(acc r.Term, row r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return []interface{}{acc}}, }).Map(func(doc r.Term) interface{} { return 1}).Reduce(func(l r.Term, r r.Term) interface{} { return r.Add(l, r)})")
@@ -226,7 +226,7 @@ func (suite *TransformFoldSuite) TestCases() {
 	{
 		// transform/fold.yaml line #48
 		/* [x for x in range(1, 1001)] */
-		var expected_ []interface{} = (func() []interface{} {
+		var expected_ = (func() []interface{} {
 			res := []interface{}{}
 			for iterator_ := 1; iterator_ < 1001; iterator_++ {
 				x := iterator_

--- a/internal/integration/reql_tests/reql_transform_map_test.go
+++ b/internal/integration/reql_tests/reql_transform_map_test.go
@@ -61,7 +61,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #5
 		/* 'STREAM' */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* r.range().map(r.range(), lambda x, y:(x, y)).type_of() */
 
 		suite.T().Log("About to run line #5: r.Range().Map(r.Range(), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}}).TypeOf()")
@@ -76,7 +76,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #10
 		/* 'STREAM' */
-		var expected_ string = "STREAM"
+		var expected_ = "STREAM"
 		/* r.range().map(r.expr([]), lambda x, y:(x, y)).type_of() */
 
 		suite.T().Log("About to run line #10: r.Range().Map(r.Expr([]interface{}{}), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}}).TypeOf()")
@@ -91,7 +91,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #15
 		/* 'ARRAY' */
-		var expected_ string = "ARRAY"
+		var expected_ = "ARRAY"
 		/* r.expr([]).map(r.expr([]), lambda x, y:(x, y)).type_of() */
 
 		suite.T().Log("About to run line #15: r.Expr([]interface{}{}).Map(r.Expr([]interface{}{}), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}}).TypeOf()")
@@ -106,7 +106,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #21
 		/* [0, 0, 0] */
-		var expected_ []interface{} = []interface{}{0, 0, 0}
+		var expected_ = []interface{}{0, 0, 0}
 		/* r.range(3).map(lambda:0) */
 
 		suite.T().Log("About to run line #21: r.Range(3).Map(func() interface{} { return 0})")
@@ -121,7 +121,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #26
 		/* [0, 0, 0] */
-		var expected_ []interface{} = []interface{}{0, 0, 0}
+		var expected_ = []interface{}{0, 0, 0}
 		/* r.range(3).map(r.range(4), lambda x,y:0) */
 
 		suite.T().Log("About to run line #26: r.Range(3).Map(r.Range(4), func(x r.Term, y r.Term) interface{} { return 0})")
@@ -136,7 +136,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #31
 		/* [[1]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{1}}
+		var expected_ = []interface{}{[]interface{}{1}}
 		/* r.expr([1]).map(lambda x:(x,)) */
 
 		suite.T().Log("About to run line #31: r.Expr([]interface{}{1}).Map(func(x r.Term) interface{} { return []interface{}{x}})")
@@ -151,7 +151,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #36
 		/* [[1, 1]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{1, 1}}
+		var expected_ = []interface{}{[]interface{}{1, 1}}
 		/* r.expr([1]).map(r.expr([1]), lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #36: r.Expr([]interface{}{1}).Map(r.Expr([]interface{}{1}), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")
@@ -166,7 +166,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #41
 		/* [[1, 1, 1]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{1, 1, 1}}
+		var expected_ = []interface{}{[]interface{}{1, 1, 1}}
 		/* r.expr([1]).map(r.expr([1]), r.expr([1]), lambda x, y, z:(x, y, z)) */
 
 		suite.T().Log("About to run line #41: r.Expr([]interface{}{1}).Map(r.Expr([]interface{}{1}), r.Expr([]interface{}{1}), func(x r.Term, y r.Term, z r.Term) interface{} { return []interface{}{x, y, z}})")
@@ -181,7 +181,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #47
 		/* err("ReqlQueryLogicError", "The function passed to `map` expects 2 arguments, but 1 sequence was found.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "The function passed to `map` expects 2 arguments, but 1 sequence was found.")
+		var expected_ = err("ReqlQueryLogicError", "The function passed to `map` expects 2 arguments, but 1 sequence was found.")
 		/* r.expr([1]).map(lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #47: r.Expr([]interface{}{1}).Map(func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")
@@ -196,7 +196,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #52
 		/* err("ReqlQueryLogicError", "The function passed to `map` expects 1 argument, but 2 sequences were found.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "The function passed to `map` expects 1 argument, but 2 sequences were found.")
+		var expected_ = err("ReqlQueryLogicError", "The function passed to `map` expects 1 argument, but 2 sequences were found.")
 		/* r.expr([1]).map(r.expr([1]), lambda x:(x,)) */
 
 		suite.T().Log("About to run line #52: r.Expr([]interface{}{1}).Map(r.Expr([]interface{}{1}), func(x r.Term) interface{} { return []interface{}{x}})")
@@ -211,7 +211,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #58
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* r.range().map(r.expr([]), lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #58: r.Range().Map(r.Expr([]interface{}{}), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")
@@ -226,7 +226,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #63
 		/* [[1, 1], [2, 2]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{1, 1}, []interface{}{2, 2}}
+		var expected_ = []interface{}{[]interface{}{1, 1}, []interface{}{2, 2}}
 		/* r.expr([1, 2]).map(r.expr([1, 2, 3, 4]), lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #63: r.Expr([]interface{}{1, 2}).Map(r.Expr([]interface{}{1, 2, 3, 4}), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")
@@ -241,7 +241,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #68
 		/* [[0, 0], [1, 1]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{0, 0}, []interface{}{1, 1}}
+		var expected_ = []interface{}{[]interface{}{0, 0}, []interface{}{1, 1}}
 		/* r.range(2).map(r.range(4), lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #68: r.Range(2).Map(r.Range(4), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")
@@ -256,7 +256,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #73
 		/* [[0, 1], [1, 2], [2, 3], [3, 4]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{0, 1}, []interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 4}}
+		var expected_ = []interface{}{[]interface{}{0, 1}, []interface{}{1, 2}, []interface{}{2, 3}, []interface{}{3, 4}}
 		/* r.range().map(r.expr([1, 2, 3, 4]), lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #73: r.Range().Map(r.Expr([]interface{}{1, 2, 3, 4}), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")
@@ -271,7 +271,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #78
 		/* [[0, 0], [1, 1], [2, 2]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{0, 0}, []interface{}{1, 1}, []interface{}{2, 2}}
+		var expected_ = []interface{}{[]interface{}{0, 0}, []interface{}{1, 1}, []interface{}{2, 2}}
 		/* r.range(3).map(r.range(5), r.js("(function(x, y){return [x, y];})")) */
 
 		suite.T().Log("About to run line #78: r.Range(3).Map(r.Range(5), r.JS('(function(x, y){return [x, y];})'))")
@@ -286,7 +286,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #83
 		/* err("ReqlQueryLogicError", "Cannot convert NUMBER to SEQUENCE", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert NUMBER to SEQUENCE")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert NUMBER to SEQUENCE")
 		/* r.range().map(r.expr(1), lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #83: r.Range().Map(r.Expr(1), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")
@@ -301,7 +301,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #89
 		/* err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use an infinite stream with an aggregation function (`reduce`, `count`, etc.) or coerce it to an array.")
 		/* r.range().map(r.range(), lambda x, y:(x, y)).count() */
 
 		suite.T().Log("About to run line #89: r.Range().Map(r.Range(), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}}).Count()")
@@ -316,7 +316,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #95
 		/* [[0], [1], [2]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{0}, []interface{}{1}, []interface{}{2}}
+		var expected_ = []interface{}{[]interface{}{0}, []interface{}{1}, []interface{}{2}}
 		/* r.map(r.range(3), lambda x:(x,)) */
 
 		suite.T().Log("About to run line #95: r.Map(r.Range(3), func(x r.Term) interface{} { return []interface{}{x}})")
@@ -331,7 +331,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #100
 		/* [1, 2, 3] */
-		var expected_ []interface{} = []interface{}{1, 2, 3}
+		var expected_ = []interface{}{1, 2, 3}
 		/* r.map(r.range(3), r.row + 1) */
 
 		suite.T().Log("About to run line #100: r.Map(r.Range(3), r.Row.Add(1))")
@@ -346,7 +346,7 @@ func (suite *TransformMapSuite) TestCases() {
 	{
 		// transform/map.yaml line #104
 		/* [[0, 0], [1, 1], [2, 2]] */
-		var expected_ []interface{} = []interface{}{[]interface{}{0, 0}, []interface{}{1, 1}, []interface{}{2, 2}}
+		var expected_ = []interface{}{[]interface{}{0, 0}, []interface{}{1, 1}, []interface{}{2, 2}}
 		/* r.map(r.range(3), r.range(5), lambda x, y:(x, y)) */
 
 		suite.T().Log("About to run line #104: r.Map(r.Range(3), r.Range(5), func(x r.Term, y r.Term) interface{} { return []interface{}{x, y}})")

--- a/internal/integration/reql_tests/reql_transform_object_test.go
+++ b/internal/integration/reql_tests/reql_transform_object_test.go
@@ -68,7 +68,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #9
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* obj['a'] */
 
 		suite.T().Log("About to run line #9: obj.AtIndex('a')")
@@ -83,7 +83,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #14
 		/* 'str' */
-		var expected_ string = "str"
+		var expected_ = "str"
 		/* obj['c'] */
 
 		suite.T().Log("About to run line #14: obj.AtIndex('c')")
@@ -98,7 +98,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #22
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* obj.has_fields('b') */
 
 		suite.T().Log("About to run line #22: obj.HasFields('b')")
@@ -113,7 +113,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #24
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* obj.keys().contains('d') */
 
 		suite.T().Log("About to run line #24: obj.Keys().Contains('d')")
@@ -128,7 +128,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #26
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* obj.has_fields('d') */
 
 		suite.T().Log("About to run line #26: obj.HasFields('d')")
@@ -143,7 +143,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #28
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* obj.has_fields({'e':'f'}) */
 
 		suite.T().Log("About to run line #28: obj.HasFields(map[interface{}]interface{}{'e': 'f', })")
@@ -158,7 +158,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #30
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* obj.has_fields({'e':'g'}) */
 
 		suite.T().Log("About to run line #30: obj.HasFields(map[interface{}]interface{}{'e': 'g', })")
@@ -173,7 +173,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #32
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* obj.has_fields('f') */
 
 		suite.T().Log("About to run line #32: obj.HasFields('f')")
@@ -188,7 +188,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #36
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* obj.has_fields('a', 'b') */
 
 		suite.T().Log("About to run line #36: obj.HasFields('a', 'b')")
@@ -203,7 +203,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #38
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* obj.has_fields('a', 'd') */
 
 		suite.T().Log("About to run line #38: obj.HasFields('a', 'd')")
@@ -218,7 +218,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #40
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* obj.has_fields('a', 'f') */
 
 		suite.T().Log("About to run line #40: obj.HasFields('a', 'f')")
@@ -233,7 +233,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #42
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* obj.has_fields('a', {'e':'f'}) */
 
 		suite.T().Log("About to run line #42: obj.HasFields('a', map[interface{}]interface{}{'e': 'f', })")
@@ -248,7 +248,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #46
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([obj, obj.pluck('a', 'b')]).has_fields('a', 'b').count() */
 
 		suite.T().Log("About to run line #46: r.Expr([]interface{}{obj, obj.Pluck('a', 'b')}).HasFields('a', 'b').Count()")
@@ -263,7 +263,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #48
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* r.expr([obj, obj.pluck('a', 'b')]).has_fields('a', 'c').count() */
 
 		suite.T().Log("About to run line #48: r.Expr([]interface{}{obj, obj.Pluck('a', 'b')}).HasFields('a', 'c').Count()")
@@ -278,7 +278,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #50
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* r.expr([obj, obj.pluck('a', 'e')]).has_fields('a', {'e':'f'}).count() */
 
 		suite.T().Log("About to run line #50: r.Expr([]interface{}{obj, obj.Pluck('a', 'e')}).HasFields('a', map[interface{}]interface{}{'e': 'f', }).Count()")
@@ -293,7 +293,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #55
 		/* {'a':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1}
+		var expected_ = map[interface{}]interface{}{"a": 1}
 		/* obj.pluck('a') */
 
 		suite.T().Log("About to run line #55: obj.Pluck('a')")
@@ -308,7 +308,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #57
 		/* {'a':1, 'b':2} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2}
 		/* obj.pluck('a', 'b') */
 
 		suite.T().Log("About to run line #57: obj.Pluck('a', 'b')")
@@ -323,7 +323,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #62
 		/* {'b':2, 'c':'str', 'd':null, 'e':{'f':'buzz'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
+		var expected_ = map[interface{}]interface{}{"b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
 		/* obj.without('a') */
 
 		suite.T().Log("About to run line #62: obj.Without('a')")
@@ -338,7 +338,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #64
 		/* {'c':'str', 'd':null,'e':{'f':'buzz'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
+		var expected_ = map[interface{}]interface{}{"c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
 		/* obj.without('a', 'b') */
 
 		suite.T().Log("About to run line #64: obj.Without('a', 'b')")
@@ -353,7 +353,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #66
 		/* {'e':{'f':'buzz'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"e": map[interface{}]interface{}{"f": "buzz"}}
+		var expected_ = map[interface{}]interface{}{"e": map[interface{}]interface{}{"f": "buzz"}}
 		/* obj.without('a', 'b', 'c', 'd') */
 
 		suite.T().Log("About to run line #66: obj.Without('a', 'b', 'c', 'd')")
@@ -368,7 +368,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #68
 		/* {'a':1, 'b':2, 'c':'str', 'd':null, 'e':{}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{}}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{}}
 		/* obj.without({'e':'f'}) */
 
 		suite.T().Log("About to run line #68: obj.Without(map[interface{}]interface{}{'e': 'f', })")
@@ -383,7 +383,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #70
 		/* {'a':1, 'b':2, 'c':'str', 'd':null, 'e':{'f':'buzz'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
 		/* obj.without({'e':'buzz'}) */
 
 		suite.T().Log("About to run line #70: obj.Without(map[interface{}]interface{}{'e': 'buzz', })")
@@ -398,7 +398,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #77
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* obj.merge(1) */
 
 		suite.T().Log("About to run line #77: obj.Merge(1)")
@@ -413,7 +413,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #81
 		/* {'a':1, 'b':2, 'c':'str', 'd':null, 'e':-2} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": -2}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": -2}
 		/* obj.merge({'e':-2}) */
 
 		suite.T().Log("About to run line #81: obj.Merge(map[interface{}]interface{}{'e': -2, })")
@@ -428,7 +428,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #85
 		/* {'a':1, 'b':2, 'c':'str', 'd':null} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil}
 		/* obj.merge({'e':r.literal()}) */
 
 		suite.T().Log("About to run line #85: obj.Merge(map[interface{}]interface{}{'e': r.Literal(), })")
@@ -443,7 +443,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #89
 		/* {'a':1, 'b':2, 'c':'str', 'd':null, 'e':{'f':'quux'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "quux"}}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "quux"}}
 		/* obj.merge({'e':{'f':'quux'}}) */
 
 		suite.T().Log("About to run line #89: obj.Merge(map[interface{}]interface{}{'e': map[interface{}]interface{}{'f': 'quux', }, })")
@@ -458,7 +458,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #92
 		/* {'a':1, 'b':2, 'c':'str', 'd':null, 'e':{'f':'buzz', 'g':'quux'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz", "g": "quux"}}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz", "g": "quux"}}
 		/* obj.merge({'e':{'g':'quux'}}) */
 
 		suite.T().Log("About to run line #92: obj.Merge(map[interface{}]interface{}{'e': map[interface{}]interface{}{'g': 'quux', }, })")
@@ -473,7 +473,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #95
 		/* {'a':1, 'b':2, 'c':'str', 'd':null, 'e':{'g':'quux'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"g": "quux"}}
+		var expected_ = map[interface{}]interface{}{"a": 1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"g": "quux"}}
 		/* obj.merge({'e':r.literal({'g':'quux'})}) */
 
 		suite.T().Log("About to run line #95: obj.Merge(map[interface{}]interface{}{'e': r.Literal(map[interface{}]interface{}{'g': 'quux', }), })")
@@ -488,7 +488,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #99
 		/* {'a':-1, 'b':2, 'c':'str', 'd':null, 'e':{'f':'buzz'}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": -1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
+		var expected_ = map[interface{}]interface{}{"a": -1, "b": 2, "c": "str", "d": nil, "e": map[interface{}]interface{}{"f": "buzz"}}
 		/* obj.merge({'a':-1}) */
 
 		suite.T().Log("About to run line #99: obj.Merge(map[interface{}]interface{}{'a': -1, })")
@@ -510,7 +510,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #105
 		/* err("ReqlQueryLogicError", errmsg, []) */
-		var expected_ Err = err("ReqlQueryLogicError", errmsg)
+		var expected_ = err("ReqlQueryLogicError", errmsg)
 		/* r.literal('foo') */
 
 		suite.T().Log("About to run line #105: r.Literal('foo')")
@@ -525,7 +525,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #108
 		/* err("ReqlQueryLogicError", errmsg, []) */
-		var expected_ Err = err("ReqlQueryLogicError", errmsg)
+		var expected_ = err("ReqlQueryLogicError", errmsg)
 		/* obj.merge(r.literal('foo')) */
 
 		suite.T().Log("About to run line #108: obj.Merge(r.Literal('foo'))")
@@ -540,7 +540,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #111
 		/* err("ReqlQueryLogicError", errmsg, []) */
-		var expected_ Err = err("ReqlQueryLogicError", errmsg)
+		var expected_ = err("ReqlQueryLogicError", errmsg)
 		/* obj.merge({'foo':r.literal(r.literal('foo'))}) */
 
 		suite.T().Log("About to run line #111: obj.Merge(map[interface{}]interface{}{'foo': r.Literal(r.Literal('foo')), })")
@@ -562,7 +562,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #116
 		/* ({'a':{'b':1, 'c':2}, 'd':3, 'e':4, 'f':5}) */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 3, "e": 4, "f": 5}
+		var expected_ = map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 3, "e": 4, "f": 5}
 		/* o.merge({'e':4}, {'f':5}) */
 
 		suite.T().Log("About to run line #116: o.Merge(map[interface{}]interface{}{'e': 4, }, map[interface{}]interface{}{'f': 5, })")
@@ -577,7 +577,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #120
 		/* ([{'a':{'b':1, 'c':2}, 'd':3, 'e':3}, {'a':{'b':1, 'c':2}, 'd':4, 'e':4}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 3, "e": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 4, "e": 4}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 3, "e": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 4, "e": 4}}
 		/* r.expr([o, o.merge({'d':4})]).merge(lambda row:{'e':row['d']}) */
 
 		suite.T().Log("About to run line #120: r.Expr([]interface{}{o, o.Merge(map[interface{}]interface{}{'d': 4, })}).Merge(func(row r.Term) interface{} { return map[interface{}]interface{}{'e': row.AtIndex('d'), }})")
@@ -592,7 +592,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #124
 		/* ([{'a':{'b':1, 'c':2}, 'd':3, 'e':3}, {'a':{'b':1, 'c':2}, 'd':4, 'e':4}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 3, "e": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 4, "e": 4}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 3, "e": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 1, "c": 2}, "d": 4, "e": 4}}
 		/* r.expr([o, o.merge({'d':4})]).merge({'e':r.row['d']}) */
 
 		suite.T().Log("About to run line #124: r.Expr([]interface{}{o, o.Merge(map[interface{}]interface{}{'d': 4, })}).Merge(map[interface{}]interface{}{'e': r.Row.AtIndex('d'), })")
@@ -607,7 +607,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #129
 		/* ([{'a':{'b':2, 'c':2}, 'd':3}, {'a':{'b':2, 'c':2}, 'd':4}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2, "c": 2}, "d": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2, "c": 2}, "d": 4}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2, "c": 2}, "d": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2, "c": 2}, "d": 4}}
 		/* r.expr([o, o.merge({'d':4})]).merge(lambda row:{'a':{'b':2}}) */
 
 		suite.T().Log("About to run line #129: r.Expr([]interface{}{o, o.Merge(map[interface{}]interface{}{'d': 4, })}).Merge(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': map[interface{}]interface{}{'b': 2, }, }})")
@@ -624,7 +624,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #134
 		/* ([{'a':{'b':2}, 'd':3}, {'a':{'b':2}, 'd':4}]) */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2}, "d": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2}, "d": 4}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2}, "d": 3}, map[interface{}]interface{}{"a": map[interface{}]interface{}{"b": 2}, "d": 4}}
 		/* r.expr([o, o.merge({'d':4})]).merge(lambda row:{'a':r.literal({'b':2})}) */
 
 		suite.T().Log("About to run line #134: r.Expr([]interface{}{o, o.Merge(map[interface{}]interface{}{'d': 4, })}).Merge(func(row r.Term) interface{} { return map[interface{}]interface{}{'a': r.Literal(map[interface{}]interface{}{'b': 2, }), }})")
@@ -641,7 +641,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #139
 		/* (['a', 'b', 'c', 'd', 'e']) */
-		var expected_ []interface{} = []interface{}{"a", "b", "c", "d", "e"}
+		var expected_ = []interface{}{"a", "b", "c", "d", "e"}
 		/* obj.keys() */
 
 		suite.T().Log("About to run line #139: obj.Keys()")
@@ -656,7 +656,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #142
 		/* ([1, 2, 'str', null, {'f':'buzz'}]) */
-		var expected_ []interface{} = []interface{}{1, 2, "str", nil, map[interface{}]interface{}{"f": "buzz"}}
+		var expected_ = []interface{}{1, 2, "str", nil, map[interface{}]interface{}{"f": "buzz"}}
 		/* obj.values() */
 
 		suite.T().Log("About to run line #142: obj.Values()")
@@ -671,7 +671,7 @@ func (suite *TransformObjectSuite) TestCases() {
 	{
 		// transform/object.yaml line #146
 		/* 5 */
-		var expected_ int = 5
+		var expected_ = 5
 		/* obj.count() */
 
 		suite.T().Log("About to run line #146: obj.Count()")

--- a/internal/integration/reql_tests/reql_transform_table_test.go
+++ b/internal/integration/reql_tests/reql_transform_table_test.go
@@ -70,7 +70,7 @@ func (suite *TransformTableSuite) TestCases() {
 	{
 		// transform/table.yaml line #5
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.insert([{"a":["k1","v1"]},{"a":["k2","v2"]}]) */
 
 		suite.T().Log("About to run line #5: tbl.Insert([]interface{}{map[interface{}]interface{}{'a': []interface{}{'k1', 'v1'}, }, map[interface{}]interface{}{'a': []interface{}{'k2', 'v2'}, }})")
@@ -85,7 +85,7 @@ func (suite *TransformTableSuite) TestCases() {
 	{
 		// transform/table.yaml line #10
 		/* {"k1":"v1","k2":"v2"} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"k1": "v1", "k2": "v2"}
+		var expected_ = map[interface{}]interface{}{"k1": "v1", "k2": "v2"}
 		/* tbl.map(r.row["a"]).coerce_to("object") */
 
 		suite.T().Log("About to run line #10: tbl.Map(r.Row.AtIndex('a')).CoerceTo('object')")
@@ -100,7 +100,7 @@ func (suite *TransformTableSuite) TestCases() {
 	{
 		// transform/table.yaml line #14
 		/* "SELECTION<STREAM>" */
-		var expected_ string = "SELECTION<STREAM>"
+		var expected_ = "SELECTION<STREAM>"
 		/* tbl.limit(1).type_of() */
 
 		suite.T().Log("About to run line #14: tbl.Limit(1).TypeOf()")
@@ -115,7 +115,7 @@ func (suite *TransformTableSuite) TestCases() {
 	{
 		// transform/table.yaml line #17
 		/* "ARRAY" */
-		var expected_ string = "ARRAY"
+		var expected_ = "ARRAY"
 		/* tbl.limit(1).coerce_to('array').type_of() */
 
 		suite.T().Log("About to run line #17: tbl.Limit(1).CoerceTo('array').TypeOf()")

--- a/internal/integration/reql_tests/reql_transform_unordered_map_test.go
+++ b/internal/integration/reql_tests/reql_transform_unordered_map_test.go
@@ -86,7 +86,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #6
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* odd.insert([{"id":1, "num":1}, {"id":3, "num":3}, {"id":5, "num":5}]) */
 
 		suite.T().Log("About to run line #6: odd.Insert([]interface{}{map[interface{}]interface{}{'id': 1, 'num': 1, }, map[interface{}]interface{}{'id': 3, 'num': 3, }, map[interface{}]interface{}{'id': 5, 'num': 5, }})")
@@ -101,7 +101,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #7
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* even.insert([{"id":2, "num":2}, {"id":4, "num":4}, {"id":6, "num":6}]) */
 
 		suite.T().Log("About to run line #7: even.Insert([]interface{}{map[interface{}]interface{}{'id': 2, 'num': 2, }, map[interface{}]interface{}{'id': 4, 'num': 4, }, map[interface{}]interface{}{'id': 6, 'num': 6, }})")
@@ -116,7 +116,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #8
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* odd2.insert([{"id":7, "num":1}, {"id":8, "num":3}, {"id":9, "num":2}]) */
 
 		suite.T().Log("About to run line #8: odd2.Insert([]interface{}{map[interface{}]interface{}{'id': 7, 'num': 1, }, map[interface{}]interface{}{'id': 8, 'num': 3, }, map[interface{}]interface{}{'id': 9, 'num': 2, }})")
@@ -131,7 +131,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #11
 		/* [{"id":1, "num":1}, {"id":3, "num":3}, {"id":5, "num":5}, {"id":2, "num":2}, {"id":4, "num":4}, {"id":6, "num":6}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 6, "num": 6}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 6, "num": 6}}
 		/* odd.order_by("num").union(even.order_by("num"), interleave = false) */
 
 		suite.T().Log("About to run line #11: odd.OrderBy('num').Union(even.OrderBy('num')).OptArgs(r.UnionOpts{Interleave: false, })")
@@ -146,7 +146,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #16
 		/* [{"id":2, "num":2}, {"id":4, "num":4}, {"id":6, "num":6}, {"id":1, "num":1}, {"id":3, "num":3}, {"id":5, "num":5}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 6, "num": 6}, map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 5, "num": 5}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 6, "num": 6}, map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 5, "num": 5}}
 		/* even.order_by("num").union(odd.order_by("num"), interleave = false) */
 
 		suite.T().Log("About to run line #16: even.OrderBy('num').Union(odd.OrderBy('num')).OptArgs(r.UnionOpts{Interleave: false, })")
@@ -161,7 +161,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #22
 		/* [{"id":1, "num":1}, {"id":2, "num":2}, {"id":3, "num":3}, {"id":4, "num":4}, {"id":5, "num":5}, {"id":6, "num":6}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 6, "num": 6}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 6, "num": 6}}
 		/* odd.order_by("num").union(even.order_by("num"), interleave="num") */
 
 		suite.T().Log("About to run line #22: odd.OrderBy('num').Union(even.OrderBy('num')).OptArgs(r.UnionOpts{Interleave: 'num', })")
@@ -176,7 +176,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #28
 		/* err("ReqlQueryLogicError","The streams given as arguments are not ordered by given ordering.") */
-		var expected_ Err = err("ReqlQueryLogicError", "The streams given as arguments are not ordered by given ordering.")
+		var expected_ = err("ReqlQueryLogicError", "The streams given as arguments are not ordered by given ordering.")
 		/* odd.order_by("num").union(even.order_by("num"), interleave=r.desc("num")) */
 
 		suite.T().Log("About to run line #28: odd.OrderBy('num').Union(even.OrderBy('num')).OptArgs(r.UnionOpts{Interleave: r.Desc('num'), })")
@@ -191,7 +191,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #34
 		/* [{"id":1, "num":1}, {"id":2, "num":2}, {"id":3, "num":3}, {"id":4, "num":4}, {"id":5, "num":5}, {"id":6, "num":6}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 6, "num": 6}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 6, "num": 6}}
 		/* odd.order_by("num").union(even.order_by("num"), interleave=lambda x: x["num"]) */
 
 		suite.T().Log("About to run line #34: odd.OrderBy('num').Union(even.OrderBy('num')).OptArgs(r.UnionOpts{Interleave: func(x r.Term) interface{} { return x.AtIndex('num')}, })")
@@ -206,7 +206,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #40
 		/* [{"id": 7, "num": 1}, {"id": 2, "num": 2}, {"id": 9, "num": 2}, {"id": 8, "num": 3}, {"id": 4, "num": 4}, {"id": 6, "num": 6}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 7, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 9, "num": 2}, map[interface{}]interface{}{"id": 8, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 6, "num": 6}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 7, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 9, "num": 2}, map[interface{}]interface{}{"id": 8, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 6, "num": 6}}
 		/* odd2.order_by("num", r.desc("id")).union(even.order_by("num", r.desc("id")), interleave=[lambda x: x["num"], lambda x: x["id"]]) */
 
 		suite.T().Log("About to run line #40: odd2.OrderBy('num', r.Desc('id')).Union(even.OrderBy('num', r.Desc('id'))).OptArgs(r.UnionOpts{Interleave: []interface{}{func(x r.Term) interface{} { return x.AtIndex('num')}, func(x r.Term) interface{} { return x.AtIndex('id')}}, })")
@@ -221,7 +221,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #46
 		/* err("ReqlServerCompileError", "DESC may only be used as an argument to ORDER_BY or UNION.") */
-		var expected_ Err = err("ReqlCompileError", "DESC may only be used as an argument to ORDER_BY or UNION.")
+		var expected_ = err("ReqlCompileError", "DESC may only be used as an argument to ORDER_BY or UNION.")
 		/* odd.order_by("num").union(even.order_by("num"), interleave=lambda x: r.desc(x["num"])) */
 
 		suite.T().Log("About to run line #46: odd.OrderBy('num').Union(even.OrderBy('num')).OptArgs(r.UnionOpts{Interleave: func(x r.Term) interface{} { return r.Desc(x.AtIndex('num'))}, })")
@@ -236,7 +236,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #50
 		/* [{"id":6, "num":6}, {"id":5, "num":5}, {"id":4, "num":4}, {"id":3, "num":3}, {"id":2, "num":2}, {"id":1, "num":1}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 6, "num": 6}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 1, "num": 1}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 6, "num": 6}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 1, "num": 1}}
 		/* odd.order_by(r.desc("num")).union(even.order_by(r.desc("num")), interleave= [r.desc(lambda x: x["num"])]) */
 
 		suite.T().Log("About to run line #50: odd.OrderBy(r.Desc('num')).Union(even.OrderBy(r.Desc('num'))).OptArgs(r.UnionOpts{Interleave: []interface{}{r.Desc(func(x r.Term) interface{} { return x.AtIndex('num')})}, })")
@@ -251,7 +251,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #54
 		/* [{"id":1, "num":1}, {"id":7, "num":1}, {"id":2, "num":2}, {"id":9, "num":2}, {"id":3, "num":3}, {"id":8, "num":3}, {"id":4, "num":4}, {"id":5, "num":5}, {"id":6, "num":6}, ] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 7, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 9, "num": 2}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 8, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 6, "num": 6}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"id": 1, "num": 1}, map[interface{}]interface{}{"id": 7, "num": 1}, map[interface{}]interface{}{"id": 2, "num": 2}, map[interface{}]interface{}{"id": 9, "num": 2}, map[interface{}]interface{}{"id": 3, "num": 3}, map[interface{}]interface{}{"id": 8, "num": 3}, map[interface{}]interface{}{"id": 4, "num": 4}, map[interface{}]interface{}{"id": 5, "num": 5}, map[interface{}]interface{}{"id": 6, "num": 6}}
 		/* odd.order_by("num", "id").union(even.order_by("num", "id"), odd2.order_by("num", "id"), interleave= ["num", "id"]) */
 
 		suite.T().Log("About to run line #54: odd.OrderBy('num', 'id').Union(even.OrderBy('num', 'id'), odd2.OrderBy('num', 'id')).OptArgs(r.UnionOpts{Interleave: []interface{}{'num', 'id'}, })")
@@ -266,7 +266,7 @@ func (suite *TransformUnorderedMapSuite) TestCases() {
 	{
 		// transform/unordered_map.yaml line #58
 		/* err("ReqlQueryLogicError","The streams given as arguments are not ordered by given ordering.") */
-		var expected_ Err = err("ReqlQueryLogicError", "The streams given as arguments are not ordered by given ordering.")
+		var expected_ = err("ReqlQueryLogicError", "The streams given as arguments are not ordered by given ordering.")
 		/* odd.order_by("num", "id").union(even.order_by("num", "id"), odd2.order_by(r.desc("num"), "id"), interleave= ["num", "id"]) */
 
 		suite.T().Log("About to run line #58: odd.OrderBy('num', 'id').Union(even.OrderBy('num', 'id'), odd2.OrderBy(r.Desc('num'), 'id')).OptArgs(r.UnionOpts{Interleave: []interface{}{'num', 'id'}, })")

--- a/internal/integration/reql_tests/reql_transformation_test.go
+++ b/internal/integration/reql_tests/reql_transformation_test.go
@@ -86,7 +86,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #6
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl.insert([{'id':i, 'a':i%4} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #6: tbl.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, 'a': r.Mod(i, 4), })\n    }\n    return res\n}()))")
@@ -108,7 +108,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #18
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('a') */
 
 		suite.T().Log("About to run line #18: tbl.IndexCreate('a')")
@@ -123,7 +123,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #21
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('truncated_a', lambda x: ['a' * 300, x['a']]) */
 
 		suite.T().Log("About to run line #21: tbl.IndexCreateFunc('truncated_a', func(x r.Term) interface{} { return []interface{}{'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', x.AtIndex('a')}})")
@@ -140,7 +140,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #24
 		/* {'created':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"created": 1}
+		var expected_ = map[interface{}]interface{}{"created": 1}
 		/* tbl.index_create('error_prone', lambda x: 1/x['a']) */
 
 		suite.T().Log("About to run line #24: tbl.IndexCreateFunc('error_prone', func(x r.Term) interface{} { return r.Div(1, x.AtIndex('a'))})")
@@ -155,7 +155,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #27
 		/* AnythingIsFine */
-		var expected_ string = compare.AnythingIsFine
+		var expected_ = compare.AnythingIsFine
 		/* tbl.index_wait().pluck('index', 'ready') */
 
 		suite.T().Log("About to run line #27: tbl.IndexWait().Pluck('index', 'ready')")
@@ -170,7 +170,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #29
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl2.insert([{'id':i, 'b':i%4} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #29: tbl2.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, 'b': r.Mod(i, 4), })\n    }\n    return res\n}()))")
@@ -192,7 +192,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #41
 		/* {'deleted':0.0,'replaced':0.0,'unchanged':0.0,'errors':0.0,'skipped':0.0,'inserted':100} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
+		var expected_ = map[interface{}]interface{}{"deleted": 0.0, "replaced": 0.0, "unchanged": 0.0, "errors": 0.0, "skipped": 0.0, "inserted": 100}
 		/* tbl3.insert([{'id':i, 'a':i%4, 'b':{'c':i%5}} for i in xrange(100)]) */
 
 		suite.T().Log("About to run line #41: tbl3.Insert((func() []interface{} {\n    res := []interface{}{}\n    for iterator_ := 0; iterator_ < 100; iterator_++ {\n        i := iterator_\n        res = append(res, map[interface{}]interface{}{'id': i, 'a': r.Mod(i, 4), 'b': map[interface{}]interface{}{'c': r.Mod(i, 5), }, })\n    }\n    return res\n}()))")
@@ -214,7 +214,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #55
 		/* 4950 */
-		var expected_ int = 4950
+		var expected_ = 4950
 		/* tbl.map(lambda row:row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #55: tbl.Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -229,7 +229,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #56
 		/* 4950 */
-		var expected_ int = 4950
+		var expected_ = 4950
 		/* tbl.map(r.row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #56: tbl.Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -244,7 +244,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #65
 		/* 9900 */
-		var expected_ int = 9900
+		var expected_ = 9900
 		/* tbl.union(tbl).map(lambda row:row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #65: tbl.Union(tbl).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -259,7 +259,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #66
 		/* 9900 */
-		var expected_ int = 9900
+		var expected_ = 9900
 		/* tbl.union(tbl).map(r.row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #66: tbl.Union(tbl).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -274,7 +274,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #75
 		/* 9900 */
-		var expected_ int = 9900
+		var expected_ = 9900
 		/* tbl.coerce_to("array").union(tbl).map(lambda row:row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #75: tbl.CoerceTo('array').Union(tbl).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -289,7 +289,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #76
 		/* 9900 */
-		var expected_ int = 9900
+		var expected_ = 9900
 		/* tbl.coerce_to("array").union(tbl).map(r.row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #76: tbl.CoerceTo('array').Union(tbl).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -304,7 +304,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #85
 		/* 9900 */
-		var expected_ int = 9900
+		var expected_ = 9900
 		/* tbl.union(tbl.coerce_to("array")).map(lambda row:row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #85: tbl.Union(tbl.CoerceTo('array')).Map(func(row r.Term) interface{} { return row.AtIndex('id')}).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -319,7 +319,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #86
 		/* 9900 */
-		var expected_ int = 9900
+		var expected_ = 9900
 		/* tbl.union(tbl.coerce_to("array")).map(r.row['id']).reduce(lambda a,b:a+b) */
 
 		suite.T().Log("About to run line #86: tbl.Union(tbl.CoerceTo('array')).Map(r.Row.AtIndex('id')).Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b)})")
@@ -334,7 +334,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #94
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.get_all().fold(0, lambda acc, _: acc.add(1), emit=lambda old,row,acc: [acc]) */
 
 		suite.T().Log("About to run line #94: tbl.GetAll().Fold(0, func(acc r.Term, _ r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return []interface{}{acc}}, })")
@@ -349,7 +349,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #97
 		/* err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.") */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type ARRAY but found NUMBER.")
 		/* r.range(0, 10).fold(0, lambda acc, _: acc.add(1), emit=lambda old,row,acc: acc) */
 
 		suite.T().Log("About to run line #97: r.Range(0, 10).Fold(0, func(acc r.Term, _ r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return acc}, })")
@@ -364,7 +364,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #100
 		/* err("ReqlQueryLogicError", "Expected type DATUM but found SEQUENCE:") */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type DATUM but found SEQUENCE:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type DATUM but found SEQUENCE:")
 		/* r.range(0, 10).fold(0, lambda acc, _: acc.add(1), emit=lambda old,row,acc: r.range()) */
 
 		suite.T().Log("About to run line #100: r.Range(0, 10).Fold(0, func(acc r.Term, _ r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return r.Range()}, })")
@@ -379,7 +379,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #103
 		/* err("ReqlQueryLogicError", "Cannot call `changes` on an eager stream.") */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot call `changes` on an eager stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot call `changes` on an eager stream.")
 		/* r.range(0, 10).fold(0, lambda acc, _: acc.add(1), emit=lambda old,row,acc: [acc]).changes() */
 
 		suite.T().Log("About to run line #103: r.Range(0, 10).Fold(0, func(acc r.Term, _ r.Term) interface{} { return acc.Add(1)}).OptArgs(r.FoldOpts{Emit: func(old r.Term, row r.Term, acc r.Term) interface{} { return []interface{}{acc}}, }).Changes()")
@@ -394,7 +394,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #111
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl.concat_map(lambda row:[]) */
 
 		suite.T().Log("About to run line #111: tbl.ConcatMap(func(row r.Term) interface{} { return []interface{}{}})")
@@ -416,7 +416,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #119
 		/* 200 */
-		var expected_ int = 200
+		var expected_ = 200
 		/* ccm.count() */
 
 		suite.T().Log("About to run line #119: ccm.Count()")
@@ -431,7 +431,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #121
 		/* 0 */
-		var expected_ int = 0
+		var expected_ = 0
 		/* ccm.reduce(lambda a,b:(a+b) % 4) */
 
 		suite.T().Log("About to run line #121: ccm.Reduce(func(a r.Term, b r.Term) interface{} { return r.Add(a, b).Mod(4)})")
@@ -446,7 +446,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #127
 		/* {'id':0, 'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by('id')[0] */
 
 		suite.T().Log("About to run line #127: tbl.OrderBy('id').AtIndex(0)")
@@ -461,7 +461,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #132
 		/* err('ReqlQueryLogicError', 'Expected type STRING but found ARRAY.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type STRING but found ARRAY.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type STRING but found ARRAY.")
 		/* tbl.order_by([1,2,3]) */
 
 		suite.T().Log("About to run line #132: tbl.OrderBy([]interface{}{1, 2, 3})")
@@ -476,7 +476,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #137
 		/* {'id':0, 'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by(index='id')[0] */
 
 		suite.T().Log("About to run line #137: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).AtIndex(0)")
@@ -491,7 +491,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #142
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.order_by(index='id')[0].update({'a':0})['unchanged'] */
 
 		suite.T().Log("About to run line #142: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).AtIndex(0).Update(map[interface{}]interface{}{'a': 0, }).AtIndex('unchanged')")
@@ -506,7 +506,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #147
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.get_all(0).update({'a':0})['unchanged'] */
 
 		suite.T().Log("About to run line #147: tbl.GetAll(0).Update(map[interface{}]interface{}{'a': 0, }).AtIndex('unchanged')")
@@ -521,7 +521,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #152
 		/* err('ReqlQueryLogicError', 'Cannot perform multiple indexed ORDER_BYs on the same table.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform multiple indexed ORDER_BYs on the same table.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform multiple indexed ORDER_BYs on the same table.")
 		/* tbl.order_by(index='id').order_by(index='id')[0] */
 
 		suite.T().Log("About to run line #152: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).AtIndex(0)")
@@ -536,7 +536,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #158
 		/* err('ReqlQueryLogicError', 'Cannot perform multiple indexed ORDER_BYs on the same table.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform multiple indexed ORDER_BYs on the same table.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform multiple indexed ORDER_BYs on the same table.")
 		/* tbl.order_by(index='id').order_by(index='id')[0] */
 
 		suite.T().Log("About to run line #158: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).AtIndex(0)")
@@ -551,7 +551,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #163
 		/* err('ReqlQueryLogicError', 'Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
+		var expected_ = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
 		/* tbl.order_by('id').order_by(index='id')[0] */
 
 		suite.T().Log("About to run line #163: tbl.OrderBy('id').OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).AtIndex(0)")
@@ -566,7 +566,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #168
 		/* err('ReqlQueryLogicError', 'Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
+		var expected_ = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
 		/* tbl.order_by('id').order_by(index='a')[0] */
 
 		suite.T().Log("About to run line #168: tbl.OrderBy('id').OrderBy().OptArgs(r.OrderByOpts{Index: 'a', }).AtIndex(0)")
@@ -581,7 +581,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #173
 		/* {'id':5, 'a':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 5, "a": 1}
+		var expected_ = map[interface{}]interface{}{"id": 5, "a": 1}
 		/* tbl.between(5, r.maxval, index='id').order_by(index='id')[0] */
 
 		suite.T().Log("About to run line #173: tbl.Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', }).OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).AtIndex(0)")
@@ -596,7 +596,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #178
 		/* err('ReqlQueryLogicError', 'Expected type TABLE_SLICE but found SELECTION:', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type TABLE_SLICE but found SELECTION:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type TABLE_SLICE but found SELECTION:")
 		/* tbl.order_by('a', index='id').between(5, r.maxval, index='id')[0] */
 
 		suite.T().Log("About to run line #178: tbl.OrderBy('a').OptArgs(r.OrderByOpts{Index: 'id', }).Between(5, r.MaxVal).OptArgs(r.BetweenOpts{Index: 'id', }).AtIndex(0)")
@@ -611,7 +611,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #183
 		/* {'id':0, 'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by(lambda x: x['id'])[0] */
 
 		suite.T().Log("About to run line #183: tbl.OrderBy(func(x r.Term) interface{} { return x.AtIndex('id')}).AtIndex(0)")
@@ -626,7 +626,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #188
 		/* {'id':0,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by('a', 'id').nth(0) */
 
 		suite.T().Log("About to run line #188: tbl.OrderBy('a', 'id').Nth(0)")
@@ -641,7 +641,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #191
 		/* {'id':0,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by('id', index='a').nth(0) */
 
 		suite.T().Log("About to run line #191: tbl.OrderBy('id').OptArgs(r.OrderByOpts{Index: 'a', }).Nth(0)")
@@ -656,7 +656,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #196
 		/* {'id':0,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by('id', index='truncated_a').nth(0) */
 
 		suite.T().Log("About to run line #196: tbl.OrderBy('id').OptArgs(r.OrderByOpts{Index: 'truncated_a', }).Nth(0)")
@@ -671,7 +671,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #199
 		/* {'id':3,'a':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 3, "a": 3}
+		var expected_ = map[interface{}]interface{}{"id": 3, "a": 3}
 		/* tbl.order_by('id', index='error_prone').nth(0) */
 
 		suite.T().Log("About to run line #199: tbl.OrderBy('id').OptArgs(r.OrderByOpts{Index: 'error_prone', }).Nth(0)")
@@ -686,7 +686,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #202
 		/* {'id':0, 'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by(lambda x: [x['a'], x['id']])[0] */
 
 		suite.T().Log("About to run line #202: tbl.OrderBy(func(x r.Term) interface{} { return []interface{}{x.AtIndex('a'), x.AtIndex('id')}}).AtIndex(0)")
@@ -701,7 +701,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #207
 		/* {'id':3,'a':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 3, "a": 3}
+		var expected_ = map[interface{}]interface{}{"id": 3, "a": 3}
 		/* tbl.order_by(r.desc('a'), r.asc('id')).nth(0) */
 
 		suite.T().Log("About to run line #207: tbl.OrderBy(r.Desc('a'), r.Asc('id')).Nth(0)")
@@ -716,7 +716,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #210
 		/* {'id':3,'a':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 3, "a": 3}
+		var expected_ = map[interface{}]interface{}{"id": 3, "a": 3}
 		/* tbl.order_by('id', index=r.desc('a')).nth(0) */
 
 		suite.T().Log("About to run line #210: tbl.OrderBy('id').OptArgs(r.OrderByOpts{Index: r.Desc('a'), }).Nth(0)")
@@ -731,7 +731,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #215
 		/* {'id':3, 'a':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 3, "a": 3}
+		var expected_ = map[interface{}]interface{}{"id": 3, "a": 3}
 		/* tbl.order_by(r.desc(lambda x: x['a']), lambda x: x['id'])[0] */
 
 		suite.T().Log("About to run line #215: tbl.OrderBy(r.Desc(func(x r.Term) interface{} { return x.AtIndex('a')}), func(x r.Term) interface{} { return x.AtIndex('id')}).AtIndex(0)")
@@ -746,7 +746,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #220
 		/* {'id':96,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 96, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 96, "a": 0}
 		/* tbl.order_by(r.asc('a'), r.desc('id')).nth(0) */
 
 		suite.T().Log("About to run line #220: tbl.OrderBy(r.Asc('a'), r.Desc('id')).Nth(0)")
@@ -761,7 +761,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #223
 		/* {'id':96,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 96, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 96, "a": 0}
 		/* tbl.order_by(r.desc('id'), index='a').nth(0) */
 
 		suite.T().Log("About to run line #223: tbl.OrderBy(r.Desc('id')).OptArgs(r.OrderByOpts{Index: 'a', }).Nth(0)")
@@ -776,7 +776,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #228
 		/* 'SELECTION<ARRAY>' */
-		var expected_ string = "SELECTION<ARRAY>"
+		var expected_ = "SELECTION<ARRAY>"
 		/* tbl.order_by('id').type_of() */
 
 		suite.T().Log("About to run line #228: tbl.OrderBy('id').TypeOf()")
@@ -791,7 +791,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #231
 		/* {'id':0, 'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by('missing').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #231: tbl.OrderBy('missing').OrderBy('id').Nth(0)")
@@ -806,7 +806,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #234
 		/* err('ReqlQueryLogicError', 'Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
+		var expected_ = err("ReqlQueryLogicError", "Indexed order_by can only be performed on a TABLE or TABLE_SLICE. Make sure order_by comes before any transformations (such as map) or filters.")
 		/* tbl.order_by('missing').order_by(index='id').nth(0) */
 
 		suite.T().Log("About to run line #234: tbl.OrderBy('missing').OrderBy().OptArgs(r.OrderByOpts{Index: 'id', }).Nth(0)")
@@ -821,7 +821,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #239
 		/* {'id':0, 'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by('id', 'missing').nth(0) */
 
 		suite.T().Log("About to run line #239: tbl.OrderBy('id', 'missing').Nth(0)")
@@ -836,7 +836,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #242
 		/* {'id':0, 'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.order_by('missing', index='id').nth(0) */
 
 		suite.T().Log("About to run line #242: tbl.OrderBy('missing').OptArgs(r.OrderByOpts{Index: 'id', }).Nth(0)")
@@ -851,7 +851,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #247
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* tbl.order_by(r.desc('id')).coerce_to('ARRAY') == tbl.order_by(lambda x: 0 - x['id']).coerce_to('ARRAY') */
 
 		suite.T().Log("About to run line #247: tbl.OrderBy(r.Desc('id')).CoerceTo('ARRAY').Eq(tbl.OrderBy(func(x r.Term) interface{} { return r.Sub(0, x.AtIndex('id'))}).CoerceTo('ARRAY'))")
@@ -866,7 +866,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #252
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* tbl.order_by(index=r.desc('id')).coerce_to('ARRAY') == tbl.order_by(lambda x: 0 - x['id']).coerce_to('ARRAY') */
 
 		suite.T().Log("About to run line #252: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: r.Desc('id'), }).CoerceTo('ARRAY').Eq(tbl.OrderBy(func(x r.Term) interface{} { return r.Sub(0, x.AtIndex('id'))}).CoerceTo('ARRAY'))")
@@ -881,7 +881,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #257
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* tbl.order_by(index=r.desc('id')).coerce_to('ARRAY') == tbl.order_by(r.desc('id')).coerce_to('ARRAY') */
 
 		suite.T().Log("About to run line #257: tbl.OrderBy().OptArgs(r.OrderByOpts{Index: r.Desc('id'), }).CoerceTo('ARRAY').Eq(tbl.OrderBy(r.Desc('id')).CoerceTo('ARRAY'))")
@@ -896,7 +896,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #263
 		/* 99 */
-		var expected_ int = 99
+		var expected_ = 99
 		/* tbl.skip(1).count() */
 
 		suite.T().Log("About to run line #263: tbl.Skip(1).Count()")
@@ -911,7 +911,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #265
 		/* err('ReqlQueryLogicError', 'Cannot use a negative left index on a stream.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
 		/* tbl.skip(-1).count() */
 
 		suite.T().Log("About to run line #265: tbl.Skip(-1).Count()")
@@ -926,7 +926,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #267
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* tbl.skip('foo').count() */
 
 		suite.T().Log("About to run line #267: tbl.Skip('foo').Count()")
@@ -941,7 +941,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #271
 		/* 1 */
-		var expected_ int = 1
+		var expected_ = 1
 		/* tbl.limit(1).count() */
 
 		suite.T().Log("About to run line #271: tbl.Limit(1).Count()")
@@ -956,7 +956,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #273
 		/* err('ReqlQueryLogicError', 'LIMIT takes a non-negative argument (got -1)', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "LIMIT takes a non-negative argument (got -1)")
+		var expected_ = err("ReqlQueryLogicError", "LIMIT takes a non-negative argument (got -1)")
 		/* tbl.limit(-1).count() */
 
 		suite.T().Log("About to run line #273: tbl.Limit(-1).Count()")
@@ -971,7 +971,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #275
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* tbl.limit('foo').count() */
 
 		suite.T().Log("About to run line #275: tbl.Limit('foo').Count()")
@@ -986,7 +986,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #279
 		/* 2 */
-		var expected_ int = 2
+		var expected_ = 2
 		/* tbl.slice(1, 3).count() */
 
 		suite.T().Log("About to run line #279: tbl.Slice(1, 3).Count()")
@@ -1001,7 +1001,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #281
 		/* 95 */
-		var expected_ int = 95
+		var expected_ = 95
 		/* tbl.slice(5).count() */
 
 		suite.T().Log("About to run line #281: tbl.Slice(5).Count()")
@@ -1016,7 +1016,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #283
 		/* err('ReqlQueryLogicError', 'Cannot use a negative left index on a stream.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
 		/* tbl.slice(-1, -3).count() */
 
 		suite.T().Log("About to run line #283: tbl.Slice(-1, -3).Count()")
@@ -1031,7 +1031,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #285
 		/* err('ReqlQueryLogicError', 'Cannot use a right index < -1 on a stream.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.")
 		/* tbl.slice(0, -3).count() */
 
 		suite.T().Log("About to run line #285: tbl.Slice(0, -3).Count()")
@@ -1046,7 +1046,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #287
 		/* err('ReqlQueryLogicError', 'Cannot slice to an open right index of -1 on a stream.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot slice to an open right index of -1 on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot slice to an open right index of -1 on a stream.")
 		/* tbl.slice(0, -1).count() */
 
 		suite.T().Log("About to run line #287: tbl.Slice(0, -1).Count()")
@@ -1061,7 +1061,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #289
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* tbl.slice('foo', 'bar').count() */
 
 		suite.T().Log("About to run line #289: tbl.Slice('foo', 'bar').Count()")
@@ -1076,7 +1076,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #291
 		/* err('ReqlNonExistenceError', 'Expected type NUMBER but found NULL.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* tbl.slice(1, null).count() */
 
 		suite.T().Log("About to run line #291: tbl.Slice(1, nil).Count()")
@@ -1091,7 +1091,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #293
 		/* err('ReqlNonExistenceError', 'Expected type NUMBER but found NULL.', [0]) */
-		var expected_ Err = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
+		var expected_ = err("ReqlNonExistenceError", "Expected type NUMBER but found NULL.")
 		/* tbl.slice(null, 1).count() */
 
 		suite.T().Log("About to run line #293: tbl.Slice(nil, 1).Count()")
@@ -1106,7 +1106,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #296
 		/* 8 */
-		var expected_ int = 8
+		var expected_ = 8
 		/* tbl.slice(12, 20).count() */
 
 		suite.T().Log("About to run line #296: tbl.Slice(12, 20).Count()")
@@ -1121,7 +1121,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #299
 		/* 9 */
-		var expected_ int = 9
+		var expected_ = 9
 		/* tbl.slice(12, 20, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #299: tbl.Slice(12, 20).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1136,7 +1136,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #303
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* tbl.slice(12, 20, left_bound='open').count() */
 
 		suite.T().Log("About to run line #303: tbl.Slice(12, 20).OptArgs(r.SliceOpts{LeftBound: 'open', }).Count()")
@@ -1151,7 +1151,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #307
 		/* 8 */
-		var expected_ int = 8
+		var expected_ = 8
 		/* tbl.slice(12, 20, left_bound='open', right_bound='closed').count() */
 
 		suite.T().Log("About to run line #307: tbl.Slice(12, 20).OptArgs(r.SliceOpts{LeftBound: 'open', RightBound: 'closed', }).Count()")
@@ -1166,7 +1166,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #311
 		/* err("ReqlQueryLogicError", "Cannot slice to an open right index of -1 on a stream.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot slice to an open right index of -1 on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot slice to an open right index of -1 on a stream.")
 		/* tbl.slice(12, -1).count() */
 
 		suite.T().Log("About to run line #311: tbl.Slice(12, -1).Count()")
@@ -1181,7 +1181,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #314
 		/* 88 */
-		var expected_ int = 88
+		var expected_ = 88
 		/* tbl.slice(12, -1, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #314: tbl.Slice(12, -1).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1196,7 +1196,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #318
 		/* err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.")
 		/* tbl.slice(12, -2).count() */
 
 		suite.T().Log("About to run line #318: tbl.Slice(12, -2).Count()")
@@ -1211,7 +1211,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #321
 		/* err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a right index < -1 on a stream.")
 		/* tbl.slice(12, -2, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #321: tbl.Slice(12, -2).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1226,7 +1226,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #325
 		/* err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
 		/* tbl.slice(-12, -2).count() */
 
 		suite.T().Log("About to run line #325: tbl.Slice(-12, -2).Count()")
@@ -1241,7 +1241,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #328
 		/* err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.", []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot use a negative left index on a stream.")
 		/* tbl.slice(-12, -2, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #328: tbl.Slice(-12, -2).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1256,7 +1256,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #332
 		/* 8 */
-		var expected_ int = 8
+		var expected_ = 8
 		/* tbl.coerce_to('array').slice(12, 20).count() */
 
 		suite.T().Log("About to run line #332: tbl.CoerceTo('array').Slice(12, 20).Count()")
@@ -1271,7 +1271,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #335
 		/* 9 */
-		var expected_ int = 9
+		var expected_ = 9
 		/* tbl.coerce_to('array').slice(12, 20, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #335: tbl.CoerceTo('array').Slice(12, 20).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1286,7 +1286,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #339
 		/* 7 */
-		var expected_ int = 7
+		var expected_ = 7
 		/* tbl.coerce_to('array').slice(12, 20, left_bound='open').count() */
 
 		suite.T().Log("About to run line #339: tbl.CoerceTo('array').Slice(12, 20).OptArgs(r.SliceOpts{LeftBound: 'open', }).Count()")
@@ -1301,7 +1301,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #343
 		/* 8 */
-		var expected_ int = 8
+		var expected_ = 8
 		/* tbl.coerce_to('array').slice(12, 20, left_bound='open', right_bound='closed').count() */
 
 		suite.T().Log("About to run line #343: tbl.CoerceTo('array').Slice(12, 20).OptArgs(r.SliceOpts{LeftBound: 'open', RightBound: 'closed', }).Count()")
@@ -1316,7 +1316,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #347
 		/* 87 */
-		var expected_ int = 87
+		var expected_ = 87
 		/* tbl.coerce_to('array').slice(12, -1).count() */
 
 		suite.T().Log("About to run line #347: tbl.CoerceTo('array').Slice(12, -1).Count()")
@@ -1331,7 +1331,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #350
 		/* 88 */
-		var expected_ int = 88
+		var expected_ = 88
 		/* tbl.coerce_to('array').slice(12, -1, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #350: tbl.CoerceTo('array').Slice(12, -1).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1346,7 +1346,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #354
 		/* 86 */
-		var expected_ int = 86
+		var expected_ = 86
 		/* tbl.coerce_to('array').slice(12, -2).count() */
 
 		suite.T().Log("About to run line #354: tbl.CoerceTo('array').Slice(12, -2).Count()")
@@ -1361,7 +1361,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #357
 		/* 87 */
-		var expected_ int = 87
+		var expected_ = 87
 		/* tbl.coerce_to('array').slice(12, -2, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #357: tbl.CoerceTo('array').Slice(12, -2).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1376,7 +1376,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #361
 		/* 10 */
-		var expected_ int = 10
+		var expected_ = 10
 		/* tbl.coerce_to('array').slice(-12, -2).count() */
 
 		suite.T().Log("About to run line #361: tbl.CoerceTo('array').Slice(-12, -2).Count()")
@@ -1391,7 +1391,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #364
 		/* 11 */
-		var expected_ int = 11
+		var expected_ = 11
 		/* tbl.coerce_to('array').slice(-12, -2, right_bound='closed').count() */
 
 		suite.T().Log("About to run line #364: tbl.CoerceTo('array').Slice(-12, -2).OptArgs(r.SliceOpts{RightBound: 'closed', }).Count()")
@@ -1413,7 +1413,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #372
 		/* [2, 3] */
-		var expected_ []interface{} = []interface{}{2, 3}
+		var expected_ = []interface{}{2, 3}
 		/* arr[1:3] */
 
 		suite.T().Log("About to run line #372: arr.Slice(1, 3)")
@@ -1428,7 +1428,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #377
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* arr[1:-3] */
 
 		suite.T().Log("About to run line #377: arr.Slice(1, -3)")
@@ -1443,7 +1443,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #380
 		/* [2,3,4,5] */
-		var expected_ []interface{} = []interface{}{2, 3, 4, 5}
+		var expected_ = []interface{}{2, 3, 4, 5}
 		/* arr[1:] */
 
 		suite.T().Log("About to run line #380: arr.Slice(1, -1, r.SliceOpts{RightBound: 'closed'})")
@@ -1458,7 +1458,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #383
 		/* [2,3,4] */
-		var expected_ []interface{} = []interface{}{2, 3, 4}
+		var expected_ = []interface{}{2, 3, 4}
 		/* arr[1:-1] */
 
 		suite.T().Log("About to run line #383: arr.Slice(1, -1)")
@@ -1473,7 +1473,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #387
 		/* {'id':1,'a':1} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 1, "a": 1}
+		var expected_ = map[interface{}]interface{}{"id": 1, "a": 1}
 		/* tbl.order_by('id').nth(1) */
 
 		suite.T().Log("About to run line #387: tbl.OrderBy('id').Nth(1)")
@@ -1488,7 +1488,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #389
 		/* {'id':99,'a':3} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 99, "a": 3}
+		var expected_ = map[interface{}]interface{}{"id": 99, "a": 3}
 		/* tbl.order_by('id').nth(-1) */
 
 		suite.T().Log("About to run line #389: tbl.OrderBy('id').Nth(-1)")
@@ -1503,7 +1503,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #391
 		/* err('ReqlQueryLogicError', 'Expected type NUMBER but found STRING.', [0]) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
+		var expected_ = err("ReqlQueryLogicError", "Expected type NUMBER but found STRING.")
 		/* tbl.order_by('id').nth('foo').count() */
 
 		suite.T().Log("About to run line #391: tbl.OrderBy('id').Nth('foo').Count()")
@@ -1518,7 +1518,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #395
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* tbl.is_empty() */
 
 		suite.T().Log("About to run line #395: tbl.IsEmpty()")
@@ -1533,7 +1533,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #397
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* tbl.limit(0).is_empty() */
 
 		suite.T().Log("About to run line #397: tbl.Limit(0).IsEmpty()")
@@ -1548,7 +1548,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #399
 		/* err('ReqlQueryLogicError', 'Cannot convert NUMBER to SEQUENCE', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert NUMBER to SEQUENCE")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert NUMBER to SEQUENCE")
 		/* r.expr(1).is_empty() */
 
 		suite.T().Log("About to run line #399: r.Expr(1).IsEmpty()")
@@ -1563,7 +1563,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #401
 		/* err('ReqlQueryLogicError', 'Cannot convert STRING to SEQUENCE', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot convert STRING to SEQUENCE")
+		var expected_ = err("ReqlQueryLogicError", "Cannot convert STRING to SEQUENCE")
 		/* r.expr("").is_empty() */
 
 		suite.T().Log("About to run line #401: r.Expr('').IsEmpty()")
@@ -1578,7 +1578,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #405
 		/* {} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{}
+		var expected_ = map[interface{}]interface{}{}
 		/* tbl3.pluck().nth(0) */
 
 		suite.T().Log("About to run line #405: tbl3.Pluck().Nth(0)")
@@ -1593,7 +1593,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #408
 		/* {} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{}
+		var expected_ = map[interface{}]interface{}{}
 		/* tbl3.pluck({}).nth(0) */
 
 		suite.T().Log("About to run line #408: tbl3.Pluck(map[interface{}]interface{}{}).Nth(0)")
@@ -1608,7 +1608,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #411
 		/* {} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{}
+		var expected_ = map[interface{}]interface{}{}
 		/* tbl3.pluck([]).nth(0) */
 
 		suite.T().Log("About to run line #411: tbl3.Pluck([]interface{}{}).Nth(0)")
@@ -1623,7 +1623,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #414
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.pluck('id').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #414: tbl3.Pluck('id').OrderBy('id').Nth(0)")
@@ -1638,7 +1638,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #417
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.pluck(['id']).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #417: tbl3.Pluck([]interface{}{'id'}).OrderBy('id').Nth(0)")
@@ -1653,7 +1653,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #420
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.pluck({'id':True}).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #420: tbl3.Pluck(map[interface{}]interface{}{'id': true, }).OrderBy('id').Nth(0)")
@@ -1668,7 +1668,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #425
 		/* {'id':0,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl3.pluck('id', 'a').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #425: tbl3.Pluck('id', 'a').OrderBy('id').Nth(0)")
@@ -1683,7 +1683,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #428
 		/* {'id':0,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl3.pluck(['id', 'a']).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #428: tbl3.Pluck([]interface{}{'id', 'a'}).OrderBy('id').Nth(0)")
@@ -1698,7 +1698,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #431
 		/* {'id':0,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl3.pluck({'id':True, 'a':True}).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #431: tbl3.Pluck(map[interface{}]interface{}{'id': true, 'a': true, }).OrderBy('id').Nth(0)")
@@ -1713,7 +1713,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #436
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.pluck('id', 'missing').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #436: tbl3.Pluck('id', 'missing').OrderBy('id').Nth(0)")
@@ -1728,7 +1728,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #439
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.pluck(['id', 'missing']).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #439: tbl3.Pluck([]interface{}{'id', 'missing'}).OrderBy('id').Nth(0)")
@@ -1743,7 +1743,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #442
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.pluck({'id':True, 'missing':True}).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #442: tbl3.Pluck(map[interface{}]interface{}{'id': true, 'missing': true, }).OrderBy('id').Nth(0)")
@@ -1758,7 +1758,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #447
 		/* {'id':0, 'b':{'c':0}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{"c": 0}}
+		var expected_ = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{"c": 0}}
 		/* tbl3.pluck('id', {'b':'c'}).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #447: tbl3.Pluck('id', map[interface{}]interface{}{'b': 'c', }).OrderBy('id').Nth(0)")
@@ -1773,7 +1773,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #450
 		/* {'id':0, 'b':{'c':0}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{"c": 0}}
+		var expected_ = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{"c": 0}}
 		/* tbl3.pluck(['id', {'b':'c'}]).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #450: tbl3.Pluck([]interface{}{'id', map[interface{}]interface{}{'b': 'c', }}).OrderBy('id').Nth(0)")
@@ -1788,7 +1788,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #453
 		/* err('ReqlQueryLogicError', 'Invalid path argument `1`.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Invalid path argument `1`.")
+		var expected_ = err("ReqlQueryLogicError", "Invalid path argument `1`.")
 		/* tbl3.pluck(1) */
 
 		suite.T().Log("About to run line #453: tbl3.Pluck(1)")
@@ -1803,7 +1803,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #456
 		/* err('ReqlQueryLogicError', 'Cannot perform pluck on a sequence of sequences.', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Cannot perform pluck on a sequence of sequences.")
+		var expected_ = err("ReqlQueryLogicError", "Cannot perform pluck on a sequence of sequences.")
 		/* r.expr([[{"foo":1}]]).pluck("foo") */
 
 		suite.T().Log("About to run line #456: r.Expr([]interface{}{[]interface{}{map[interface{}]interface{}{'foo': 1, }}}).Pluck('foo')")
@@ -1818,7 +1818,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #461
 		/* [{'a':1},{'b':2}] */
-		var expected_ []interface{} = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"b": 2}}
+		var expected_ = []interface{}{map[interface{}]interface{}{"a": 1}, map[interface{}]interface{}{"b": 2}}
 		/* r.expr(['a','b']).map(lambda x:r.expr({'a':1,'b':2}).pluck(x)) */
 
 		suite.T().Log("About to run line #461: r.Expr([]interface{}{'a', 'b'}).Map(func(x r.Term) interface{} { return r.Expr(map[interface{}]interface{}{'a': 1, 'b': 2, }).Pluck(x)})")
@@ -1833,7 +1833,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #466
 		/* {"foo":{}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"foo": map[interface{}]interface{}{}}
+		var expected_ = map[interface{}]interface{}{"foo": map[interface{}]interface{}{}}
 		/* r.expr({"foo":{"bar":1}}).pluck({"foo":{"bar":"buzz"}}) */
 
 		suite.T().Log("About to run line #466: r.Expr(map[interface{}]interface{}{'foo': map[interface{}]interface{}{'bar': 1, }, }).Pluck(map[interface{}]interface{}{'foo': map[interface{}]interface{}{'bar': 'buzz', }, })")
@@ -1848,7 +1848,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #470
 		/* {'id':0,'a':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "a": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0, "a": 0}
 		/* tbl.without().order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #470: tbl.Without().OrderBy('id').Nth(0)")
@@ -1863,7 +1863,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #473
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl.without('a').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #473: tbl.Without('a').OrderBy('id').Nth(0)")
@@ -1878,7 +1878,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #476
 		/* {} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{}
+		var expected_ = map[interface{}]interface{}{}
 		/* tbl.without('id', 'a').nth(0) */
 
 		suite.T().Log("About to run line #476: tbl.Without('id', 'a').Nth(0)")
@@ -1893,7 +1893,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #479
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl.without('a', 'missing').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #479: tbl.Without('a', 'missing').OrderBy('id').Nth(0)")
@@ -1908,7 +1908,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #482
 		/* {'id':0, 'b':{}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{}}
+		var expected_ = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{}}
 		/* tbl3.without('a', {'b':'c'}).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #482: tbl3.Without('a', map[interface{}]interface{}{'b': 'c', }).OrderBy('id').Nth(0)")
@@ -1923,7 +1923,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #485
 		/* {'id':0, 'b':{}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{}}
+		var expected_ = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{}}
 		/* tbl3.without(['a', {'b':'c'}]).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #485: tbl3.Without([]interface{}{'a', map[interface{}]interface{}{'b': 'c', }}).OrderBy('id').Nth(0)")
@@ -1938,7 +1938,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #488
 		/* {'id':0, 'b':{'c':0}} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{"c": 0}}
+		var expected_ = map[interface{}]interface{}{"id": 0, "b": map[interface{}]interface{}{"c": 0}}
 		/* tbl3.without(['a', {'b':'d'}]).order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #488: tbl3.Without([]interface{}{'a', map[interface{}]interface{}{'b': 'd', }}).OrderBy('id').Nth(0)")
@@ -1953,7 +1953,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #492
 		/* 200 */
-		var expected_ int = 200
+		var expected_ = 200
 		/* tbl.union(tbl2).count() */
 
 		suite.T().Log("About to run line #492: tbl.Union(tbl2).Count()")
@@ -1968,7 +1968,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #494
 		/* 103 */
-		var expected_ int = 103
+		var expected_ = 103
 		/* tbl.union([1,2,3]).count() */
 
 		suite.T().Log("About to run line #494: tbl.Union([]interface{}{1, 2, 3}).Count()")
@@ -1983,7 +1983,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #496
 		/* 103 */
-		var expected_ int = 103
+		var expected_ = 103
 		/* r.expr([1,2,3]).union(tbl2).count() */
 
 		suite.T().Log("About to run line #496: r.Expr([]interface{}{1, 2, 3}).Union(tbl2).Count()")
@@ -2005,7 +2005,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #502
 		/* [0,1] */
-		var expected_ []interface{} = []interface{}{0, 1}
+		var expected_ = []interface{}{0, 1}
 		/* ord.offsets_of(r.row['id'] < 2) */
 
 		suite.T().Log("About to run line #502: ord.OffsetsOf(r.Row.AtIndex('id').Lt(2))")
@@ -2020,7 +2020,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #506
 		/* [2] */
-		var expected_ []interface{} = []interface{}{2}
+		var expected_ = []interface{}{2}
 		/* r.expr([1,2,3,4]).offsets_of(3) */
 
 		suite.T().Log("About to run line #506: r.Expr([]interface{}{1, 2, 3, 4}).OffsetsOf(3)")
@@ -2035,7 +2035,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #509
 		/* err('ReqlQueryLogicError', 'Expected type DATUM but found TABLE:', []) */
-		var expected_ Err = err("ReqlQueryLogicError", "Expected type DATUM but found TABLE:")
+		var expected_ = err("ReqlQueryLogicError", "Expected type DATUM but found TABLE:")
 		/* r.expr([1]).offsets_of(tbl) */
 
 		suite.T().Log("About to run line #509: r.Expr([]interface{}{1}).OffsetsOf(tbl)")
@@ -2050,7 +2050,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #512
 		/* [1] */
-		var expected_ []interface{} = []interface{}{1}
+		var expected_ = []interface{}{1}
 		/* r.expr(1).do(lambda x: r.expr([2,1,0]).offsets_of(x)) */
 
 		suite.T().Log("About to run line #512: r.Expr(1).Do(func(x r.Term) interface{} { return r.Expr([]interface{}{2, 1, 0}).OffsetsOf(x)})")
@@ -2065,7 +2065,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #518
 		/* true */
-		var expected_ bool = true
+		var expected_ = true
 		/* tbl.contains(tbl[0]) */
 
 		suite.T().Log("About to run line #518: tbl.Contains(tbl.AtIndex(0))")
@@ -2080,7 +2080,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #521
 		/* false */
-		var expected_ bool = false
+		var expected_ = false
 		/* tbl.contains(tbl[0].pluck('id')) */
 
 		suite.T().Log("About to run line #521: tbl.Contains(tbl.AtIndex(0).Pluck('id'))")
@@ -2095,7 +2095,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #533
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.filter({'b':{'c':0}}).pluck('id').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #533: tbl3.Filter(map[interface{}]interface{}{'b': map[interface{}]interface{}{'c': 0, }, }).Pluck('id').OrderBy('id').Nth(0)")
@@ -2110,7 +2110,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #536
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl3.filter({'b':{'c':6}}) */
 
 		suite.T().Log("About to run line #536: tbl3.Filter(map[interface{}]interface{}{'b': map[interface{}]interface{}{'c': 6, }, })")
@@ -2125,7 +2125,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #539
 		/* [] */
-		var expected_ []interface{} = []interface{}{}
+		var expected_ = []interface{}{}
 		/* tbl3.filter(r.literal({'id':0})) */
 
 		suite.T().Log("About to run line #539: tbl3.Filter(r.Literal(map[interface{}]interface{}{'id': 0, }))")
@@ -2140,7 +2140,7 @@ func (suite *TransformationSuite) TestCases() {
 	{
 		// transformation.yaml line #542
 		/* {'id':0} */
-		var expected_ map[interface{}]interface{} = map[interface{}]interface{}{"id": 0}
+		var expected_ = map[interface{}]interface{}{"id": 0}
 		/* tbl3.filter({'b':r.literal({'c':0})}).pluck('id').order_by('id').nth(0) */
 
 		suite.T().Log("About to run line #542: tbl3.Filter(map[interface{}]interface{}{'b': r.Literal(map[interface{}]interface{}{'c': 0, }), }).Pluck('id').OrderBy('id').Nth(0)")


### PR DESCRIPTION
Hi @gabor-boros

me again, had some spare time and spent it to fix some obvious linter complains.
Please have a look if your time allows.

**Reason for the change**
golangci-lint staticcheck complains that in variable declarations, the lefthand side is not necessary, fix this.

**Description**
A clear and concise description of what did you changed and why.

**Code examples**
If applicable, add code examples to help explain your changes.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
Anything else related to the change e.g. documentations, RFCs, etc.
